### PR TITLE
constrained wms layers to getcaps ranges

### DIFF
--- a/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
@@ -23,12 +23,10 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
 
         var wmsLayer = null;
 
-        var bbox = Ext.JSON.decode(cfg.layer.data.filterer.getMercatorCompatibleParameters()[portal.layer.filterer.Filterer.BBOX_FIELD]);
+        //var bbox = Ext.JSON.decode(cfg.layer.data.filterer.getMercatorCompatibleParameters()[portal.layer.filterer.Filterer.BBOX_FIELD]);
 
-        // bounds
-        var bounds = bbox ? new OpenLayers.Bounds(bbox.westBoundLongitude, bbox.southBoundLatitude, bbox.eastBoundLongitude, bbox.northBoundLatitude) : null;
-
-        var srs = bbox ? bbox.crs : null;
+        // bounds must be in EPSG:3857
+        var bounds = this.getBbox() ? this.getBbox().transform(this.getBbox_crs(),"EPSG:3857") : null;
 
         if(this.getSld_body() && this.getSld_body().length > 0){
              wmsLayer = new OpenLayers.Layer.WMS( this.getWmsLayer(),
@@ -43,7 +41,7 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
                     },{
                          tileOptions: {maxGetUrlLength: 1500},
                          isBaseLayer : false,
-                         projection: srs,
+                         projection: 'EPSG:3857',
                          maxExtent: bounds,
                          tileOrigin: new OpenLayers.LonLat(-20037508.34, -20037508.34)
                     });
@@ -59,7 +57,7 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
                     },{
                         tileOptions: {maxGetUrlLength: 1500},
                         isBaseLayer : false,
-                        projection: srs,
+                        projection: 'EPSG:3857',
                         maxExtent: bounds,
                         tileOrigin: new OpenLayers.LonLat(-20037508.34, -20037508.34)
                     });

--- a/src/main/webapp/portal-core/js/portal/map/primitives/BaseWMSPrimitive.js
+++ b/src/main/webapp/portal-core/js/portal/map/primitives/BaseWMSPrimitive.js
@@ -103,7 +103,11 @@ Ext.define('portal.map.primitives.BaseWMSPrimitive', {
 
         version : '',
 
-        sld_body : ''
+        sld_body : '',
+
+        bbox : '',
+
+        bbox_crs : ''
 
     },
 
@@ -123,6 +127,13 @@ Ext.define('portal.map.primitives.BaseWMSPrimitive', {
         this.setSld_body(cfg.sld_body);
         if(cfg.layer.get('cswRecords')[0]){
             this.setVersion(cfg.layer.get('cswRecords')[0].get('version'));
+            var index;
+            for (index = 0; index < cfg.layer.get('cswRecords').length; ++index) {
+                if (cfg.layer.get('cswRecords')[index].get('onlineResources').indexOf(cfg.onlineResource) >= 0) {
+                    this.setBbox(new OpenLayers.Bounds(cfg.layer.get('cswRecords')[index].get('geographicElements')[0].westBoundLongitude,cfg.layer.get('cswRecords')[index].get('geographicElements')[0].southBoundLatitude,cfg.layer.get('cswRecords')[index].get('geographicElements')[0].eastBoundLongitude,cfg.layer.get('cswRecords')[index].get('geographicElements')[0].northBoundLatitude));
+                    this.setBbox_crs(cfg.layer.get('cswRecords')[index].get('geographicElements')[0].crs);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Changed wms layer bounding box filtering to be per service instead of
per layer.  This forces the portal to only query services where their
getcapabilities documents say data exists.
