### PR TITLE
Allow GoogleOAuth2UserDetailsLoader subclasses access to members

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/security/oauth2/GoogleOAuth2UserDetailsLoader.java
+++ b/src/main/java/org/auscope/portal/core/server/security/oauth2/GoogleOAuth2UserDetailsLoader.java
@@ -27,8 +27,8 @@ import com.racquettrack.security.oauth.OAuth2UserDetailsLoader;
 public class GoogleOAuth2UserDetailsLoader implements
         OAuth2UserDetailsLoader<PortalUser> {
 
-    private String defaultRole;
-    private Map<String, List<SimpleGrantedAuthority>> rolesByUser;
+    protected String defaultRole;
+    protected Map<String, List<SimpleGrantedAuthority>> rolesByUser;
 
     /**
      * Creates a new GoogleOAuth2UserDetailsLoader that will assign defaultRole to every user


### PR DESCRIPTION
Subclasses require access to members so that they can be used when overriding methods. See for example VGML, which overrides createUser:
https://github.com/bencaradocdavies/vgml/blob/master/src/main/java/org/auscope/portal/server/web/security/EmailGoogleOAuth2UserDetailsLoader.java
