### PR TITLE
Include deployment config for nexus

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,13 @@
         <developerConnection>scm:git:https://github.com/AuScope/portal-core.git</developerConnection>
         <url>https://github.com/AuScope/portal-core</url>
     </scm>
+    <distributionManagement>
+        <repository>
+            <id>deployment</id>
+            <name>Internal nexus</name>
+            <url>https://cgsrv8.arrc.csiro.au/nexus/content/repositories/PortalRelease/</url>
+        </repository>
+    </distributionManagement>
     <!-- Build Configuration -->
     <organization>
         <name>AuScope</name>


### PR DESCRIPTION
Adding this element allows for manual deployment of artifacts to the nexus repository (using "mvn deploy"). We used it recently to manually deploy a modified version of the core for VHIRL to depend on.

Is the release repo a sensible default? It can also have a snapshots repository element added alongside the release one to allow for manual snapshot deployments as well.
