### PR TITLE
Gpt 57   clicking on a layer causes javascript error which stops layers from working

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/InlineContextMenu.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/InlineContextMenu.js
@@ -68,7 +68,7 @@ Ext.define('portal.widgets.grid.plugin.InlineContextMenu', {
         this.callParent(arguments);
     },
 
-    generateToolbar : function(record, renderTo) {
+    generateToolbar : function(record, renderTo, grid) {
         var items = [];
         Ext.each(this.actions, function(action) {
             items.push(Ext.create('Ext.button.Button', action));

--- a/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
@@ -186,21 +186,23 @@ Ext.define('portal.widgets.grid.plugin.RowExpanderContainer', {
         }
     },
     
-    restoreRowContainer: function(record) {
+    restoreRowContainer: function(record) {        
+        var me = this;
+        
         //We don't want this function to be re-entrant
         //Which can occur if the generateContainer callback
         //makes any updates to record
-        if (this.generationRunning === true) {
+        if (me.generationRunning === true) {
             return;
         }
         
-        this.generationRunning = true;
-        if (this.restorationRequired(record)) {
+        me.generationRunning = true;
+        if (me.restorationRequired(record)) {
             var id = "rowexpandercontainer-" + record.id;
-            var container = this.generateContainer(record, id);
+            var container = me.generateContainer(record, id, me.grid);
             
-            this.recordStatus[record.id].container = container;
-            this.recordStatus[record.id].container.updateLayout({
+            me.recordStatus[record.id].container = container;
+            me.recordStatus[record.id].container.updateLayout({
                 defer:false,
                 isRoot:false
             });

--- a/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
@@ -5,7 +5,7 @@
  *
  * To use this plugin, assign the following field to the plugin constructor
  * {
- *  generateContainer : function(record, parentElId) - returns Ext.container.Container,
+ *  generateContainer : function(record, parentElId, grid) - returns Ext.container.Container,
  *  allowMultipleOpen : Boolean - whether multiple containers can be open simultaneously.
  *  toggleColIndexes : int[] - Optional - Which column indexes can toggle open/close on single click - Defaults to every column 
  * }
@@ -21,7 +21,7 @@
  *                renderTo: 'foo',
  *                plugins : [{
  *                  ptype : 'rowexpandercontainer',
- *                  generateContainer : function(record, parentElId) {
+ *                  generateContainer : function(record, parentElId, grid) {
  *                     return Ext.create('Ext.panel.Panel', {});
  *                  }
  *                }]

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -138,7 +138,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
               ptype : 'rowexpandercontainer',
               pluginId : 'maingrid_rowexpandercontainer',
               toggleColIndexes: [0, 2],
-              generateContainer : function(record, parentElId) {                  
+              generateContainer : function(record, parentElId, grid) {                  
                   //VT:if this is deserialized, we don't need to regenerate the layer
                   if(record.get('layer')) {                        
                       newLayer =  record.get('layer');                                    
@@ -150,7 +150,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                   record.set('layer',newLayer);
                   var filterForm = cfg.layerFactory.formFactory.getFilterForm(newLayer).form; //ALWAYS recreate filter form - see https://jira.csiro.au/browse/AUS-2588
                   filterForm.setLayer(newLayer);
-                  var filterPanel = me._getInlineLayerPanel(filterForm, parentElId, me);
+                  var filterPanel = me._getInlineLayerPanel(filterForm, parentElId, this);
                   
                   //Update the layer panel to use
                   if (filterForm) {
@@ -160,7 +160,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                           filterForm.getForm().setValues(existingParams);
                       }
                   }
-                  me.grid.updateLayout({
+                  grid.updateLayout({
                       defer:false,
                       isRoot:false
                   });                    


### PR DESCRIPTION
I changed some "this" to "me" for optimisation. Had an issue with closure scope of "this" not working as I expected, then instead of reverting that I decided to pass in the object that needed to be updated (grid) rather than relying on the closure scope to get the reference to the grid. It seems simpler and neater to me. We've tested in our CI environment and it appears to all work fine.  