### PR TITLE
Gpt 40 - AND/OR layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .project
 .settings/
 target/
+.buildpath

--- a/src/main/java/org/auscope/portal/core/services/KnownLayerService.java
+++ b/src/main/java/org/auscope/portal/core/services/KnownLayerService.java
@@ -5,6 +5,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
 import org.auscope.portal.core.view.knownlayer.KnownLayer;
 import org.auscope.portal.core.view.knownlayer.KnownLayerAndRecords;
@@ -18,6 +20,8 @@ import org.auscope.portal.core.view.knownlayer.KnownLayerSelector;
  *
  */
 public class KnownLayerService {
+    private final Log logger = LogFactory.getLog(getClass().getName());
+
     private List<KnownLayer> knownLayers;
     private CSWCacheService cswCacheService;
 
@@ -75,6 +79,7 @@ public class KnownLayerService {
 
         //Figure out what records belong to which known layers (could be multiple)
         for (KnownLayer knownLayer : knownLayers) {
+            logger.debug("groupKnownLayerRecords - knownLayer: " + knownLayer);
             // We have to do this part regardless of the classFilters because
             // if not, the results for unmappedRecords will be incorrect.
             // (I.e.: they'll include related features from things that have
@@ -96,6 +101,11 @@ public class KnownLayerService {
                     belongingRecords.add(record);
                     mappedRecordIDs.put(record.getFileIdentifier(), null);
                     break;
+                case NotRelated:
+                    break;
+                default:
+                    throw new RuntimeException(
+                            "This must be a new isRelatedRecord: " + selector.isRelatedRecord(record));
                 }
             }
 
@@ -131,7 +141,7 @@ public class KnownLayerService {
                 unmappedRecords.add(record);
             }
         }
-
-        return new KnownLayerGrouping(knownLayerAndRecords, unmappedRecords, originalRecordList);
+        KnownLayerGrouping knownLayerGrouping = new KnownLayerGrouping(knownLayerAndRecords, unmappedRecords, originalRecordList);
+        return knownLayerGrouping;
     }
 }

--- a/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
@@ -4,6 +4,9 @@ import java.awt.Dimension;
 import java.awt.Point;
 
 import org.auscope.portal.core.view.knownlayer.KnownLayer;
+import org.auscope.portal.core.view.knownlayer.KnownLayerSelector;
+import org.auscope.portal.core.view.knownlayer.SelectorsMode;
+import org.auscope.portal.core.view.knownlayer.WMSSelectors;
 import org.springframework.ui.ModelMap;
 
 /**
@@ -51,6 +54,19 @@ public class ViewKnownLayerFactory {
             group = k.getGroup();
         }
         obj.put("group", group);
+        
+        // LayersMode is from GA GPT-41 where Layers can have Layers and they can be 'OR'd or 'AND'd.
+        if (k.getKnownLayerSelector() != null) {
+            KnownLayerSelector knownLayerSelector = k.getKnownLayerSelector();
+            if (knownLayerSelector instanceof WMSSelectors) {
+                WMSSelectors wmsSelectors = (WMSSelectors) knownLayerSelector;
+                obj.put("layerMode", wmsSelectors.getLayersMode());
+            } else {
+                obj.put("layerMode", SelectorsMode.NA);
+            }
+        } else {
+            obj.put("layerMode", SelectorsMode.NA);
+        }
 
         return obj;
     }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -354,4 +354,19 @@ public class KnownLayer implements Serializable {
         this.order = order;
         logger.info(String.format("setOrder - group: %s, name: %s, order: %d", getGroup(), getName(), getOrder()));
     }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "KnownLayer [name=" + name + ", id=" + id + ", description=" + description + ", hidden=" + hidden
+                + ", group=" + group + ", proxyUrl=" + proxyUrl + ", proxyCountUrl=" + proxyCountUrl
+                + ", proxyStyleUrl=" + proxyStyleUrl + ", proxyDownloadUrl=" + proxyDownloadUrl
+                + ", knownLayerSelector=" + knownLayerSelector + ", iconUrl=" + iconUrl + ", polygonColor="
+                + polygonColor + ", iconAnchor=" + iconAnchor + ", iconSize=" + iconSize + ", feature_count="
+                + feature_count + ", order=" + order + "]";
+    }
+    
+    
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerAndRecords.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerAndRecords.java
@@ -61,4 +61,12 @@ public class KnownLayerAndRecords {
         return relatedRecords;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "KnownLayerAndRecords [knownLayer=" + knownLayer + ", belongingRecords=" + belongingRecords
+                + ", relatedRecords=" + relatedRecords + "]";
+    }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerGrouping.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayerGrouping.java
@@ -52,4 +52,12 @@ public class KnownLayerGrouping {
         return originalRecordSet;
     }
 
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "KnownLayerGrouping [knownLayers=" + knownLayers + ", unmappedRecords=" + unmappedRecords
+                + ", originalRecordSet=" + originalRecordSet + "]";
+    }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/SelectorsMode.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/SelectorsMode.java
@@ -1,0 +1,12 @@
+/**
+ * 
+ */
+package org.auscope.portal.core.view.knownlayer;
+
+/**
+ * @author u86990
+ *
+ */
+public enum SelectorsMode {
+    NA,OR,AND
+}

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelector.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelector.java
@@ -1,5 +1,7 @@
 package org.auscope.portal.core.view.knownlayer;
 
+import java.util.Arrays;
+
 import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
 import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource.OnlineResourceType;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
@@ -136,5 +138,15 @@ public class WMSSelector implements KnownLayerSelector {
 
     public boolean includeEndpoints() {
         return includeEndpoints;
+    }
+
+    /* (non-Javadoc)
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        return "WMSSelector [layerName=" + layerName + ", relatedLayerNames=" + Arrays.toString(relatedLayerNames)
+                + ", serviceEndpoints=" + Arrays.toString(serviceEndpoints) + ", includeEndpoints=" + includeEndpoints
+                + "]";
     }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelectors.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/WMSSelectors.java
@@ -1,0 +1,77 @@
+/**
+ * 
+ */
+package org.auscope.portal.core.view.knownlayer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+
+/**
+ * This class is for handling multiple layers to group them together in some way. Either they are 'AND'ed and all layers show together effectively on-top of
+ * each other. This is most relevant where there are complementary layers that show the same features but at different scales - one might show at scales less
+ * than 1:x and another might show at scales greater (equal) 1:x. Written as part of GPT-41 for Geoscience Surface Geology layer group.
+ * 
+ * @author Brooke Smith
+ * 
+ */
+public class WMSSelectors implements KnownLayerSelector {
+
+    private List<WMSSelector> wmsSelectors;
+    private SelectorsMode layersMode;
+
+    private WMSSelectors() {
+        super();
+    }
+
+    public WMSSelectors(SelectorsMode layersMode, List<String> layerNames) {
+        this();
+        this.layersMode = layersMode;
+        wmsSelectors = new ArrayList<WMSSelector>();
+        for (String layerName : layerNames) {
+            WMSSelector wmsSelector = new WMSSelector(layerName);
+            wmsSelectors.add(wmsSelector);
+            // Now set the other layers as related
+            Set<String> otherLayerNames = new HashSet<>(layerNames);
+            otherLayerNames.remove(layerName);
+            wmsSelector.setRelatedLayerNames(otherLayerNames.toArray(new String[0]));
+        }
+    }
+
+    /**
+     * @return the layersMode
+     */
+    public SelectorsMode getLayersMode() {
+        return layersMode;
+    }
+
+    /**
+     * @param layersMode
+     *            the layersMode to set
+     */
+    public void setLayersMode(SelectorsMode layersMode) {
+        this.layersMode = layersMode;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see org.auscope.portal.core.view.knownlayer.KnownLayerSelector#isRelatedRecord(org.auscope.portal.core.services.responses.csw.CSWRecord)
+     * 
+     * We need to get the RelationType for all wmsSelectors and return the 'greatest' one (Belongs, Related, Not Related is strongest to weakest). And we only
+     * want to return one of each type or else we'll get multiply defined records - subsequent ones are 'Not Related'
+     */
+    @Override
+    public RelationType isRelatedRecord(CSWRecord record) {
+        RelationType greatestRelationship = RelationType.NotRelated;
+        for (WMSSelector selector : wmsSelectors) {
+            if (selector.isRelatedRecord(record).ordinal() > greatestRelationship.ordinal()) {
+                greatestRelationship = selector.isRelatedRecord(record);
+            }
+        }
+        return greatestRelationship;
+    }
+}

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js
@@ -1,0 +1,111 @@
+/**
+ * An implementation of a portal.layer.Renderer for rendering WMS Layers that belong to a set of portal.csw.CSWRecord
+ * objects. This extension is for Disjuncted ("OR") Layers of Layers defined through a WFSSelectors KnownLayerSelector
+ * (in auscope-known-layers.xml) and was developed by GA in GPT-40.
+ */
+Ext.define('portal.layer.renderer.wms.DisjunctionLayerRenderer', {
+    extend : 'portal.layer.renderer.Renderer',
+
+    constructor : function(config) {
+        this.legend = Ext.create('portal.layer.legend.wfs.WMSLegend', {
+            iconUrl : config.iconCfg ? config.iconCfg.url : 'portal-core/img/key.png'
+        });
+        this.callParent(arguments);
+    },
+
+    /**
+     * A function for displaying layered data from a variety of data sources. This function will raise the renderstarted
+     * and renderfinished events as appropriate. The effect of multiple calls to this function (ie calling displayData
+     * again before renderfinished is raised) is undefined.
+     * 
+     * This function will re-render itself entirely and thus may call removeData() during the normal operation of this
+     * function
+     * 
+     * function(portal.csw.OnlineResource[] resources, portal.layer.filterer.Filterer filterer,
+     * function(portal.layer.renderer.Renderer this, portal.csw.OnlineResource[] resources,
+     * portal.layer.filterer.Filterer filterer, bool success) callback
+     * 
+     * returns - void
+     * 
+     * resources - an array of data sources which should be used to render data filterer - A custom filter that can be
+     * applied to the specified data sources callback - Will be called when the rendering process is completed and
+     * passed an instance of this renderer and the parameters used to call this function
+     */
+    displayData : function(resources, filterer, callback) {
+        this.removeData();
+        var wmsResources = portal.csw.OnlineResource.getFilteredFromArray(resources, portal.csw.OnlineResource.WMS);
+
+        var urls = [];
+        for (var i = 0; i < wmsResources.length; i++) {
+            urls.push(wmsResources[i].get('url'));
+        }
+        this.renderStatus.initialiseResponses(urls, 'Loading...');
+
+
+        var primitives = [];
+        for (var i = 0; i < wmsResources.length; i++) {
+            // Find the layer.name that is the same as the selected one
+            var wmsLayer = wmsResources[i].get('name');
+            if (wmsLayer === filterer.getParameter('serviceFilter')) {
+                var wmsUrl = wmsResources[i].get('url');
+                var wmsOpacity = filterer.getParameter('opacity');
+
+                var layer = this.map.makeWms(undefined, undefined, wmsResources[i], this.parentLayer, wmsUrl, wmsLayer,
+                        wmsOpacity);
+
+                layer.getWmsLayer().events.register("loadstart", this, function() {
+                    this.currentRequestCount++;
+                    var listOfStatus = this.renderStatus.getParameters();
+                    this.fireEvent('renderstarted', this, wmsResources, filterer);
+                    this.renderStatus.updateResponse(layer.getWmsUrl(), "Loading WMS");
+                });
+
+                // VT: Handle the after wms load clean up event.
+                layer.getWmsLayer().events.register("loadend", this, function(evt) {
+                    this.currentRequestCount--;
+                    var listOfStatus = this.renderStatus.getParameters();
+                    this.renderStatus.updateResponse(layer.getWmsUrl(), "WMS Loaded");
+                    this.fireEvent('renderfinished', this);
+                });
+
+                primitives.push(layer);
+            }
+        }
+
+        this.primitiveManager.addPrimitives(primitives);
+        this.hasData = true;
+
+    },
+
+    /**
+     * A function for creating a legend that can describe the displayed data. If no such thing exists for this renderer
+     * then null should be returned.
+     * 
+     * function(portal.csw.OnlineResource[] resources, portal.layer.filterer.Filterer filterer)
+     * 
+     * returns - portal.layer.legend.Legend or null
+     * 
+     * resources - (same as displayData) an array of data sources which should be used to render data filterer - (same
+     * as displayData) A custom filter that can be applied to the specified data sources
+     */
+    getLegend : function(resources, filterer) {
+        return this.legend;
+    },
+
+    /**
+     * A function that is called when this layer needs to be permanently removed from the map. In response to this
+     * function all rendered information should be removed
+     * 
+     * function()
+     * 
+     * returns - void
+     */
+    removeData : function() {
+        this.primitiveManager.clearPrimitives();
+    },
+
+    /**
+     * You can't abort a WMS layer from rendering as it does so via img tags
+     */
+    abortDisplay : Ext.emptyFn
+});

--- a/src/main/webapp/portal-core/jsimports.htm
+++ b/src/main/webapp/portal-core/jsimports.htm
@@ -115,6 +115,7 @@
 <script src="portal-core/js/portal/layer/renderer/kml/KMLRenderer.js" type="text/javascript"></script>
 
 <script src="portal-core/js/portal/layer/renderer/wms/LayerRenderer.js" type="text/javascript"></script>
+<script src="portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/Layer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/LayerFactory.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/LayerStore.js" type="text/javascript"></script>

--- a/src/test/java/org/auscope/portal/core/view/knownlayer/RelationTypeTest.java
+++ b/src/test/java/org/auscope/portal/core/view/knownlayer/RelationTypeTest.java
@@ -1,0 +1,39 @@
+/**
+ * 
+ */
+package org.auscope.portal.core.view.knownlayer;
+
+import org.auscope.portal.core.view.knownlayer.KnownLayerSelector.RelationType;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author u86990
+ *
+ */
+public class RelationTypeTest {
+
+    @Test
+    public void testRelationTypeRelationships01() {
+        RelationType left = RelationType.Belongs;
+        RelationType right = RelationType.Related;
+        
+        Assert.assertTrue(left.ordinal() > right.ordinal());
+    }
+
+    @Test
+    public void testRelationTypeRelationships02() {
+        RelationType left = RelationType.Belongs;
+        RelationType right = RelationType.NotRelated;
+        
+        Assert.assertTrue(left.ordinal() > right.ordinal());
+    }
+    
+    @Test
+    public void testRelationTypeRelationships03() {
+        RelationType left = RelationType.Related;
+        RelationType right = RelationType.NotRelated;
+        
+        Assert.assertTrue(left.ordinal() > right.ordinal());
+    }
+}


### PR DESCRIPTION
Hi AuScope, here is the pull request for work we discussed during the telecon Wed 14/10/15.  This pull request is for the portal-core mods.  Work was required on the (geoscience-) portal side and I've got a link below to the commit for that.  There is the mod to the `auscope-known-layers.xml` as is expected (see code below) and there are code changes. Do you think we should try and get these into the portal-core?  Or perhaps you'd like to adopt them into the auscope-portal.  I'll create a pull request if you'd like to do the latter.

Here is some doco I'd written for this:

----

Allow a single layer to be a conjunction of several related layers (AND), or a disjunction of several related layers but which would conflict if drawn atop of each other.

![image](https://cloud.githubusercontent.com/assets/2556595/10502782/3baeb2fa-733b-11e5-89a4-1f06456b9ea6.png)

The AND layers are all WFS and are seen simply as a single layer with an Opacity slider.
The OR layers are also WFS and the specific desired one has to be chosen from a drop-down before being added to the Map.

The code is in Portal-Core (GitHub commit https://github.com/GeoscienceAustralia/portal-core/commit/0db72831b2d04450be861107f783ba7222e7cf9b) and Geoscience-Portal (GitHub commit - https://github.com/GeoscienceAustralia/geoscience-portal/commit/6170f92129fc8d5413defa2644dd1cc64d3816c6).  

Layer definitions
---------------------
From the code found in the Geoscience-Portal commit are these on src/main/webapp/WEB-INF/auscope-known-layers.xml.  Note that these definitions may not be the final ones that Geoscience decides to use):

    <!-- SurfaceGeology__1to1M_ContactsFaultsMakerBeds (Define Disjunction of
        multiple layers into one (OR)) -->
    <bean
        id="knownTypeGeologicalMaps_SurfaceGeology__1to1M_GeologicalUnits__ALL"
        class="org.auscope.portal.core.view.knownlayer.KnownLayer">
        <constructor-arg name="id" value="layers-disjunction1m" />
        <constructor-arg name="knownLayerSelector">
            <bean class="org.auscope.portal.core.view.knownlayer.WMSSelectors">
                <constructor-arg name="layersMode" value="OR" />
                <constructor-arg name="layerNames">
                    <list>
                        <value>AUS_GA_1M_GUPoly_Lithostratigraphy</value>
                        <value>AUS_GA_1M_GUPoly_Age</value>
                        <value>AUS_GA_1M_GUPoly_Lithology</value>
                    </list>
                </constructor-arg>
            </bean>
        </constructor-arg>
        <property name="name" value="1:1M Surface Geology - Geological Units" />
        <property name="description"
            value="Combined (OR) AUS_GA_1M_GUPoly_Lithostratigraph (Surface geological units (outcrop or near-outcrop bedrock and surficial regolith units) symbolised by lithostratigraphic classification, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS_GA_1M_GUPoly_Age (Surface geological units (outcrop or near-outcrop bedrock and surficial regolith units) symbolised by age, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS_GA_1M_GUPoly_Lithology (Surface geological units (outcrop or near-outcrop bedrock and surficial regolith units) symbolised by lithology, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000)." />
        <property name="group" value="1:1 Surface Geology Layers OR" />
        <property name="proxyUrl" value="" />
        <property name="proxyCountUrl" value="" />
        <property name="order" value="372" />
    </bean>
    <!-- SurfaceGeology__1to1M_ContactsFaultsMakerBeds (Define Conjunction of
        multiple layers into one (AND) -->
    <bean
        id="knownTypeGeologicalMaps_SurfaceGeology__1to1M_ContactsFaultsMakerBeds__ALL"
        class="org.auscope.portal.core.view.knownlayer.KnownLayer">
        <constructor-arg name="id" value="layers-conjunction" />
        <constructor-arg name="knownLayerSelector">
            <bean class="org.auscope.portal.core.view.knownlayer.WMSSelectors">
                <constructor-arg name="layersMode" value="AND" />
                <constructor-arg name="layerNames">
                    <list>
                        <value>AUS_GA_1M_MiscLines</value>
                        <value>AUS_GA_1M_Faults</value>
                        <value>AUS_GA_1M_Contacts</value>
                        <value>AUS_GA_1M_GULine</value>
                    </list>
                </constructor-arg>
            </bean>
        </constructor-arg>
        <property name="name"
            value="1:1 Surface Geo contacts, faults, marker beds" />
        <property name="description"
            value="Combined (AND) - AUS GA 1:1M Miscellaneous Lines (This layer contains lines that complement the geology data, but are not classified as geological features (eg, coastline and other water boundaries, limits of mapping or available data), compiled at 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS GA 1:1M Faults and Shears (Fault and shear structures, represented as lines, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS GA 1:1M Contacts (Lines that represent contacts between geological units (eg, depositional, intrusive and faulted contacts), compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS GA 1:1M Geological Unit Lines (Surface geological units (outcrop or near-outcrop) that are too narrow to be represented by polygons, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000)." />
        <property name="group" value="1:1 Surface Geology Layers AND" />
        <property name="proxyUrl" value="" />
        <property name="proxyCountUrl" value="" />
        <property name="order" value="371" />
    </bean>
    <!-- SurfaceGeology__1to25M_ContactsFaultsMakerBeds (Define Disjunction
        of multiple layers into one (OR)) -->
    <bean
        id="knownTypeGeologicalMaps_SurfaceGeology__1to25M_GeologicalUnits__ALL"
        class="org.auscope.portal.core.view.knownlayer.KnownLayer">
        <constructor-arg name="id" value="layers-disjunction2500k" />
        <constructor-arg name="knownLayerSelector">
            <bean class="org.auscope.portal.core.view.knownlayer.WMSSelectors">
                <constructor-arg name="layersMode" value="OR" />
                <constructor-arg name="layerNames">
                    <list>
                        <value>AUS_GA_2500k_GUPoly_Lithostratigraphy</value>
                        <value>AUS_GA_2500k_GUPoly_Age</value>
                        <value>AUS_GA_2500k_GUPoly_Lithology</value>
                    </list>
                </constructor-arg>
            </bean>
        </constructor-arg>
        <property name="name" value="1:2.5M Surface Geology - Geological Units" />
        <property name="description"
            value="Combined (OR) AUS_GA_1M_GUPoly_Lithostratigraph (Surface geological units (outcrop or near-outcrop bedrock and surficial regolith units) symbolised by lithostratigraphic classification, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS_GA_1M_GUPoly_Age (Surface geological units (outcrop or near-outcrop bedrock and surficial regolith units) symbolised by age, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS_GA_1M_GUPoly_Lithology (Surface geological units (outcrop or near-outcrop bedrock and surficial regolith units) symbolised by lithology, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000)." />
        <property name="group" value="1:25 Surface Geology Layers OR" />
        <property name="proxyUrl" value="" />
        <property name="proxyCountUrl" value="" />
        <property name="order" value="382" />
    </bean>
    <!-- SurfaceGeology__1to25M_ContactsFaultsMakerBeds (Define Conjunction
        of multiple layers into one (AND) -->
    <bean
        id="knownTypeGeologicalMaps_SurfaceGeology__1to25M_ContactsFaultsMakerBeds__ALL"
        class="org.auscope.portal.core.view.knownlayer.KnownLayer">
        <constructor-arg name="id" value="layers-conjunction2" />
        <constructor-arg name="knownLayerSelector">
            <bean class="org.auscope.portal.core.view.knownlayer.WMSSelectors">
                <constructor-arg name="layersMode" value="AND" />
                <constructor-arg name="layerNames">
                    <list>
                        <value>AUS_GA_2500k_MiscLines</value>
                        <value>AUS_GA_2500k_Faults</value>
                        <value>AUS_GA_2500k_Contacts</value>
                    </list>
                </constructor-arg>
            </bean>
        </constructor-arg>
        <property name="name"
            value="1:2.5 Surface Geo contacts, faults, marker beds" />
        <property name="description"
            value="Combined (AND) - AUS GA 1:1M Miscellaneous Lines (This layer contains lines that complement the geology data, but are not classified as geological features (eg, coastline and other water boundaries, limits of mapping or available data), compiled at 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS GA 1:1M Faults and Shears (Fault and shear structures, represented as lines, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS GA 1:1M Contacts (Lines that represent contacts between geological units (eg, depositional, intrusive and faulted contacts), compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000), AUS GA 1:1M Geological Unit Lines (Surface geological units (outcrop or near-outcrop) that are too narrow to be represented by polygons, compiled for use around 1:1M scale. This layer is limited to display only at scales greater than 1:1,500,000)." />
        <property name="group" value="1:25 Surface Geology Layers AND" />
    </bean>