### PR TITLE
Gpt 61 Active layers z order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings/
 target/
 .buildpath
+*.swp

--- a/src/main/webapp/portal-core/js/portal/layer/Layer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/Layer.js
@@ -70,6 +70,10 @@ Ext.define('portal.layer.Layer', {
      * Whenever our filter changes, update the rendered page
      */
     onFilterChanged : function(filterer, keys) {
+        this.reRenderLayerDisplay(filterer, keys);
+    },
+    
+    reRenderLayerDisplay : function(filterer, keys) {
         var renderer = this.get('renderer');      
         this.removeDataFromMap();                  
         renderer.displayData(this.getAllOnlineResources(), this.get('filterer'), Ext.emptyFn);

--- a/src/main/webapp/portal-core/js/portal/layer/filterer/BaseFilterForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/filterer/BaseFilterForm.js
@@ -41,6 +41,8 @@ Ext.define('portal.layer.filterer.BaseFilterForm', {
             cls : 'filter-panel-color'
         })
 
+        AppEvents.addListener(this);
+
         this.callParent(arguments);        
         
         if (!this.delayedFormLoading) {
@@ -84,5 +86,12 @@ Ext.define('portal.layer.filterer.BaseFilterForm', {
     readFromFilterer : function(filterer) {
         var parameters = filterer.getParameters();
         this.getForm().setValues(parameters);
+    },
+    
+    listeners : {
+        layerindexchanged : function() {
+            this.layer.reRenderLayerDisplay();
+        }
     }
+
 });

--- a/src/main/webapp/portal-core/js/portal/map/BaseMap.js
+++ b/src/main/webapp/portal-core/js/portal/map/BaseMap.js
@@ -250,7 +250,12 @@ Ext.define('portal.map.BaseMap', {
      *
      */
     closeInfoWindow : Ext.util.UnimplementedFunction,
-
+    
+    /**
+     * The layerStore has been updated and want to force a re-indexing of the LayerIndex (z-order of the layers).
+     */
+    updateLayerIndex : Ext.util.UnimplementedFunction,
+    
     ////////////////// Base functionality
 
     /**

--- a/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
@@ -11,7 +11,6 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
     layerSwitcher : null,           // Keep as a global so can check if has been created
 
     constructor : function(cfg) {
-        var me = this;
         this.callParent(arguments);
         
 

--- a/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
@@ -11,6 +11,7 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
     layerSwitcher : null,           // Keep as a global so can check if has been created
 
     constructor : function(cfg) {
+        var me = this;
         this.callParent(arguments);
         
 
@@ -985,6 +986,14 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
         for(var i = 0; i < controlList.length; i++){
             controlList[i].deactivate();
         }
-    }
+    },
     
+    /**
+     * The layerStore has been updated and want to force a re-indexing of the LayerIndex (z-order of the layers).
+     */
+    updateLayerIndex : function() {
+        for(position=0;position < this.layerStore.length; position++){
+            this.map.setLayerIndex(layer,position);
+        }
+    }
 });

--- a/src/main/webapp/portal-core/js/portal/map/openlayers/PrimitiveManager.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/PrimitiveManager.js
@@ -75,20 +75,19 @@ Ext.define('portal.map.openlayers.PrimitiveManager', {
                 var layerStore = this.baseMap.layerStore.data.items;
                 var position = 0;
                 //layerStore provides the ordering
-               for(position=0;position < layerStore.length; position++){
-                   if(layerId==layerStore[position].data.id){
-                       break;
-                   }
-               }
+                for(position=0;position < layerStore.length; position++){
+                    if(layerId==layerStore[position].data.id){
+                        break;
+                    }
+                }
 
                 var layer = prim.getWmsLayer();
                 this.layers.push(layer);
                 this.baseMap.map.addLayer(layer);
 
-              //VT: this will give us the order where we should be slotting into the map layer
+                //VT: this will give us the order where we should be slotting into the map layer
                 position = this.baseMap.map.layers.length - 1 - position;
                 this.baseMap.map.setLayerIndex(layer,position);
-
             }
         }
 


### PR DESCRIPTION
The GPT-61 branch adds Z-ordering to the active-layers box and controlled through drag and drop.

This may have a bug where the content from the other Known Layer tabs is missing and I have a PR in for GPT-75.  I say 'may' as it might be GPT-65 that caused this bug (I can't remember).

Please merge this PR before GPT-65 and GPT-75 (they are coming).