### PR TITLE
Gpt 73 active layers stop reordering for auscope

### DIFF
--- a/src/main/webapp/portal-core/js/portal/events/AppEvents.js
+++ b/src/main/webapp/portal-core/js/portal/events/AppEvents.js
@@ -62,15 +62,15 @@ Ext.define('portal.events.AppEvents', {
       var id = listener.uniqueId; // Defined in js/admin/global.js
       var entry = {listener:listener,args:args};
       this.listeners[id]=entry;
-      console.log("AppEvents - addListner - id: "+id+", args: ", args, ", listener: ", listener, " # listeners: ", Object.getOwnPropertyNames(this.listeners).length);
+//      console.log("AppEvents - addListner - id: "+id+", args: ", args, ", listener: ", listener, " # listeners: ", Object.getOwnPropertyNames(this.listeners).length);
   },
   removeListener : function (listener) {
       var id = listener.uniqueId; // Defined in js/admin/global.js
       if (this.listeners[id]) {
           delete this.listeners[id];
-          console.log("AppEvents - removeListener - id: ", id, " # listeners: ", Object.getOwnPropertyNames(this.listeners).length);
+//          console.log("AppEvents - removeListener - id: ", id, " # listeners: ", Object.getOwnPropertyNames(this.listeners).length);
       } else {
-          console.log("AppEvents - NOT removeListener as doesnt exist - id: ", id)
+//          console.log("AppEvents - NOT removeListener as doesnt exist - id: ", id)
       }
   },
   broadcast : function (event, args) {
@@ -86,7 +86,7 @@ Ext.define('portal.events.AppEvents', {
               listener.fireEvent(event, theArgs);
           } else {
               // Seems to be a timing thing - even though a removed listener it hangs around for a bit 
-              console.log("  WARNING - trying to broadcast to object without listener - id: ", id);
+//              console.log("  WARNING - trying to broadcast to object without listener - id: ", id);
           }
       },this.listeners);
   },

--- a/src/main/webapp/portal-core/js/portal/events/AppEvents.js
+++ b/src/main/webapp/portal-core/js/portal/events/AppEvents.js
@@ -62,13 +62,13 @@ Ext.define('portal.events.AppEvents', {
       var id = listener.uniqueId; // Defined in js/admin/global.js
       var entry = {listener:listener,args:args};
       this.listeners[id]=entry;
-      console.log("AppEvents - addListner - id: "+id+", args: ", args, ", listener: ", listener)
+      console.log("AppEvents - addListner - id: "+id+", args: ", args, ", listener: ", listener, " # listeners: ", Object.getOwnPropertyNames(this.listeners).length);
   },
   removeListener : function (listener) {
       var id = listener.uniqueId; // Defined in js/admin/global.js
       if (this.listeners[id]) {
           delete this.listeners[id];
-          console.log("AppEvents - removeListener - id: ", id)
+          console.log("AppEvents - removeListener - id: ", id, " # listeners: ", Object.getOwnPropertyNames(this.listeners).length);
       } else {
           console.log("AppEvents - NOT removeListener as doesnt exist - id: ", id)
       }
@@ -76,17 +76,18 @@ Ext.define('portal.events.AppEvents', {
   broadcast : function (event, args) {
       var me = this;
       console.log("AppEvents - broadcast - event: ", event, ", args: ", args);
-      //for (var listener in this.listeners) {
       Object.keys(this.listeners).forEach(function(id, index) {
-          var listener=me.listeners[id].listener;
-          var listenerArgs=me.listeners[id].args;
-          var theArgs = me._combineArgs(args, listenerArgs);
-          
-//          var theseArgs = (Array.isArray(args) || ! args) ? args : [args];
-//          var allArgs = listenerArgs ? (theseArgs ? listenerArgs.concat(theseArgs) : listenerArgs) : theseArgs ? theseArgs : [];
-          console.log("   AppEvents - broadcast - listener: ", listener);
-          console.log("            args: ",theArgs);
-          listener.fireEvent(event, theArgs);
+          if (me.listeners[id]) {
+              var listener=me.listeners[id].listener;
+              var listenerArgs=me.listeners[id].args;
+              var theArgs = me._combineArgs(args, listenerArgs);
+              console.log("   AppEvents - broadcast - listener: ", listener);
+              console.log("            args: ",theArgs);
+              listener.fireEvent(event, theArgs);
+          } else {
+              // Seems to be a timing thing - even though a removed listener it hangs around for a bit 
+              console.log("  WARNING - trying to broadcast to object without listener - id: ", id);
+          }
       },this.listeners);
   },
   /**

--- a/src/main/webapp/portal-core/js/portal/layer/filterer/BaseFilterForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/filterer/BaseFilterForm.js
@@ -51,6 +51,11 @@ Ext.define('portal.layer.filterer.BaseFilterForm', {
         }
     },
     
+    onDestroy : function() {
+        AppEvents.removeListener(this);
+        this.callParent();
+    },
+    
     setLayer : function(layer){
         this.layer = layer;
     },

--- a/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
@@ -208,12 +208,16 @@ Ext.define('portal.widgets.grid.plugin.RowExpanderContainer', {
             var id = me.baseId + '-' + record.id;   // "rowexpandercontainer-"
             var container = me.generateContainer(record, id, me.grid);
             
+            // GPT-73 - If a container already existed it needs to be destroyed.  Since Singleton AppEvents holds a ref to it
+            // it is never removed from memory (and worse, AppEvents keeps trying to broadcast to it).
+            if (me.recordStatus[record.id].container) {
+                me.recordStatus[record.id].container.destroy();
+            }
             me.recordStatus[record.id].container = container;
             me.recordStatus[record.id].container.updateLayout({
                 defer:false,
                 isRoot:false
             });
-            
         }
 
         this.generationRunning = false;

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -172,6 +172,11 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
         AppEvents.addListener(me);
     },
     
+    onDestroy : function() {
+        AppEvents.removeListener(me);
+        me.callParent();
+    },
+
     _getInlineLayerPanel : function(filterForm, parentElId){                             
         var me = this;   
         var panel = Ext.create('portal.widgets.panel.FilterPanel', {    

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CommonBaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CommonBaseRecordPanel.js
@@ -45,6 +45,11 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
         AppEvents.addListener(me);
     },
     
+    onDestroy : function() {
+        AppEvents.removeListener(me);
+        me.callParent();
+    },
+    
     //-------- Abstract methods requiring implementation ---------
 
     /**


### PR DESCRIPTION
Fixed a memory leak that I'm 90% sure caused the bug at Geoscience where dragging and dropping to reorder the layers in the Active Layers panel would eventually stop working. Although this was reported in GA portal, its in core code and needed to be fixed.

I've left debug in AppEvents.js since this bug could crop up in other places (though couldn't find on first look). I'm planning to add a debug library so can set the logging level and will be sending another PR soonish.

UPDATE - that debug library was looking like too much work (uses require.js) so have just commented out the console.logs.