### PR TITLE
Gpt 80 display legend url for WMS

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/responses/wms/GetCapabilitiesWMSLayer_1_3_0.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wms/GetCapabilitiesWMSLayer_1_3_0.java
@@ -21,6 +21,8 @@ import org.w3c.dom.NodeList;
  */
 public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRecord {
 
+    private Node node;
+
     /** The log. */
     private final Log log = LogFactory.getLog(getClass());
 
@@ -34,16 +36,25 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
     private String description;
 
     /** The legendURL. */
-    private String legendURL;    
+    private String legendURL;
 
     /** The metadataURL. */
-    private String metadataURL;   
-    
+    private String metadataURL;
+
     /** The bbox. */
     private CSWGeographicBoundingBox bbox;
 
     /** The child layer srs. */
     private String[] childLayerSRS;
+
+    private XPath xPath;
+
+    private XPath getXPath() {
+        if (xPath == null) {
+            xPath = XPathFactory.newInstance().newXPath();
+        }
+        return xPath;
+    }
 
     /**
      * Instantiates a new gets the capabilities wms layer record.
@@ -54,60 +65,10 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      *             the xpath expression exception
      */
     public GetCapabilitiesWMSLayer_1_3_0(Node node) throws XPathExpressionException {
-        XPath xPath = XPathFactory.newInstance().newXPath();
-
-        String layerNameExpression = "Name";
-        Node tempNode = (Node) xPath.evaluate(layerNameExpression, node, XPathConstants.NODE);
-        name = tempNode != null ? tempNode.getTextContent() : "";
-
-        String layerTitleExpression = "Title";
-        tempNode = (Node) xPath.evaluate(layerTitleExpression, node, XPathConstants.NODE);
-        title = tempNode != null ? tempNode.getTextContent() : "";
-
-        String layerAbstractExpression = "Abstract";
-        tempNode = (Node) xPath.evaluate(layerAbstractExpression, node, XPathConstants.NODE);
-        description = tempNode != null ? tempNode.getTextContent() : "";
-
-        String layerLegendURLExpression = "Style/LegendURL/OnlineResource";
-        tempNode = (Node) xPath.evaluate(layerLegendURLExpression, node, XPathConstants.NODE);
-        legendURL = tempNode != null ? tempNode.getAttributes().getNamedItem("xlink:href").getNodeValue() : "";
-
-        String layerMetadataURLExpression = "MetadataURL";
-        tempNode = (Node) xPath.evaluate(layerMetadataURLExpression, node, XPathConstants.NODE);
-        metadataURL = tempNode != null ? tempNode.getTextContent() : "";
-        
-        String latLonBoundingBox = "EX_GeographicBoundingBox";
-        tempNode = (Node) xPath.evaluate(latLonBoundingBox, node, XPathConstants.NODE);
-        if (tempNode != null) {
-            String minx = (String) xPath.evaluate("westBoundLongitude", tempNode, XPathConstants.STRING);
-            String maxx = (String) xPath.evaluate("eastBoundLongitude", tempNode, XPathConstants.STRING);
-            String miny = (String) xPath.evaluate("southBoundLatitude", tempNode, XPathConstants.STRING);
-            String maxy = (String) xPath.evaluate("northBoundLatitude", tempNode, XPathConstants.STRING);
-
-            //Attempt to parse our bounding box
-            try {
-                bbox = new CSWGeographicBoundingBox(Double.parseDouble(minx),
-                        Double.parseDouble(maxx),
-                        Double.parseDouble(miny),
-                        Double.parseDouble(maxy));
-            } catch (NumberFormatException e) {
-                log.debug("Unable to parse the bounding box.");
-            }
-
-        }
-
-        String layerSRSExpression = "CRS";
-        NodeList nodes = (NodeList) xPath.evaluate(layerSRSExpression,
-                node,
-                XPathConstants.NODESET);
-        childLayerSRS = new String[nodes.getLength()];
-        for (int i = 0; i < nodes.getLength(); i++) {
-            Node childSRSNode = nodes.item(i);
-            childLayerSRS[i] = childSRSNode != null ? childSRSNode.getTextContent() : "";
-        }
+        this.node = node;
     }
 
-    // ------------------------------------------ Attribute Setters and Getters
+    // --- Attribute Setters and Getters - now modified to also be retrievers
 
     /**
      * Gets the name.
@@ -116,7 +77,12 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      * @throws XPathExpressionException
      *             the x path expression exception
      */
+    @Override
     public String getName() throws XPathExpressionException {
+        if (name == null) {
+            Node tempNode = (Node) getXPath().evaluate("Name", node, XPathConstants.NODE);
+            name = tempNode != null ? tempNode.getTextContent() : "";
+        }
         return name;
     }
 
@@ -127,7 +93,12 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      * @throws XPathExpressionException
      *             the x path expression exception
      */
+    @Override
     public String getTitle() throws XPathExpressionException {
+        if (title == null) {
+            Node tempNode = (Node) xPath.evaluate("Title", node, XPathConstants.NODE);
+            title = tempNode != null ? tempNode.getTextContent() : "";
+        }
         return title;
     }
 
@@ -138,7 +109,12 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      * @throws XPathExpressionException
      *             the x path expression exception
      */
+    @Override
     public String getLegendURL() throws XPathExpressionException {
+        if (legendURL == null) {
+            Node tempNode = (Node) xPath.evaluate("Style/LegendURL/OnlineResource", node, XPathConstants.NODE);
+            legendURL = tempNode != null ? tempNode.getAttributes().getNamedItem("xlink:href").getNodeValue() : "";
+        }
         return legendURL;
     }
 
@@ -149,10 +125,15 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      * @throws XPathExpressionException
      *             the x path expression exception
      */
+    @Override
     public String getAbstract() throws XPathExpressionException {
+        if (description == null) {
+            Node tempNode = (Node) xPath.evaluate("Abstract", node, XPathConstants.NODE);
+            description = tempNode != null ? tempNode.getTextContent() : "";
+        }
         return description;
     }
-    
+
     /**
      * Gets the metadataURL.
      *
@@ -160,16 +141,49 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      * @throws XPathExpressionException
      *             the x path expression exception
      */
+    @Override
     public String getMetadataURL() throws XPathExpressionException {
+        if (metadataURL == null) {
+            Node tempNode = (Node) xPath.evaluate("MetadataURL", node, XPathConstants.NODE);
+            metadataURL = tempNode != null ? tempNode.getTextContent() : "";
+        }
         return metadataURL;
     }
-    
+
     /**
      * Gets the bounding box.
      *
      * @return the bounding box
+     * @throws XPathExpressionException 
      */
+    @Override
     public CSWGeographicBoundingBox getBoundingBox() {
+        if (bbox == null) {
+            Node tempNode;
+            try {
+                tempNode = (Node) getXPath().evaluate("EX_GeographicBoundingBox", node, XPathConstants.NODE);
+                if (tempNode != null) {
+                    String minx = (String) getXPath().evaluate("westBoundLongitude", tempNode, XPathConstants.STRING);
+                    String maxx = (String) getXPath().evaluate("eastBoundLongitude", tempNode, XPathConstants.STRING);
+                    String miny = (String) getXPath().evaluate("southBoundLatitude", tempNode, XPathConstants.STRING);
+                    String maxy = (String) getXPath().evaluate("northBoundLatitude", tempNode, XPathConstants.STRING);
+                    
+                    // Attempt to parse our bounding box
+                    try {
+                        bbox = new CSWGeographicBoundingBox(Double.parseDouble(minx),
+                                Double.parseDouble(maxx),
+                                Double.parseDouble(miny),
+                                Double.parseDouble(maxy));
+                    } catch (NumberFormatException e) {
+                        log.debug("Unable to parse the bounding box.");
+                    }
+                    
+                }
+            } catch (XPathExpressionException ex) {
+                log.error("Format error", ex);
+                throw new RuntimeException(ex);
+            }
+        }
         return bbox;
     }
 
@@ -180,23 +194,38 @@ public class GetCapabilitiesWMSLayer_1_3_0 implements GetCapabilitiesWMSLayerRec
      * @throws XPathExpressionException
      *             the x path expression exception
      */
+    @Override
     public String[] getChildLayerSRS() throws XPathExpressionException {
+        if (childLayerSRS == null) {
+            NodeList nodes = (NodeList) xPath.evaluate("CRS", node, XPathConstants.NODESET);
+            childLayerSRS = new String[nodes.getLength()];
+            for (int i = 0; i < nodes.getLength(); i++) {
+                Node childSRSNode = nodes.item(i);
+                childLayerSRS[i] = childSRSNode != null ? childSRSNode.getTextContent() : "";
+            }
+        }
         return childLayerSRS;
     }
 
     /**
      * @see java.lang.Object#toString()
      */
+    @Override
     public String toString() {
         final String seperator = ",";
 
         StringBuffer buf = new StringBuffer();
-        buf.append(name);
-        buf.append(seperator);
-        buf.append(title);
-        buf.append(seperator);
-        buf.append(description);
-        buf.append(seperator);
+        try {
+            buf.append(getName());
+            buf.append(seperator);
+            buf.append(getTitle());
+            buf.append(seperator);
+            buf.append(getAbstract());
+            buf.append(seperator);
+        } catch (XPathExpressionException ex) {
+            log.error("Format error", ex);
+            throw new RuntimeException(ex);
+        }
         return buf.toString();
     }
 

--- a/src/main/webapp/portal-core/js/portal/events/AppEvents.js
+++ b/src/main/webapp/portal-core/js/portal/events/AppEvents.js
@@ -75,14 +75,14 @@ Ext.define('portal.events.AppEvents', {
   },
   broadcast : function (event, args) {
       var me = this;
-      console.log("AppEvents - broadcast - event: ", event, ", args: ", args);
+//      console.log("AppEvents - broadcast - event: ", event, ", args: ", args);
       Object.keys(this.listeners).forEach(function(id, index) {
           if (me.listeners[id]) {
               var listener=me.listeners[id].listener;
               var listenerArgs=me.listeners[id].args;
               var theArgs = me._combineArgs(args, listenerArgs);
-              console.log("   AppEvents - broadcast - listener: ", listener);
-              console.log("            args: ",theArgs);
+//              console.log("   AppEvents - broadcast - listener: ", listener);
+//              console.log("            args: ",theArgs);
               listener.fireEvent(event, theArgs);
           } else {
               // Seems to be a timing thing - even though a removed listener it hangs around for a bit 

--- a/src/main/webapp/portal-core/js/portal/layer/LayerStore.js
+++ b/src/main/webapp/portal-core/js/portal/layer/LayerStore.js
@@ -16,12 +16,12 @@ Ext.define('portal.layer.LayerStore', {
     }, 
     listeners : {
         add : function(store, records, index, eOpts) {
-            console.log("LayerStore - Records added to layerstore: ", records);
+//            console.log("LayerStore - Records added to layerstore: ", records);
             // Let the listeners know about the new active layer
             AppEvents.broadcast('addactivelayer', {layer:records});
         },
         remove : function( store, records, index, isMove, eOpts ) {
-            console.log("LayerStore - Records removed from layerstore: ", records);
+//            console.log("LayerStore - Records removed from layerstore: ", records);
             // Let the listeners know about the removed active layer
             AppEvents.broadcast('removeactivelayer', {layer:records});
         }

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegend.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegend.js
@@ -2,7 +2,7 @@
  * An implementation of portal.layer.legend.Legend for providing
  * simple GUI details on a WFS layer added to the map
  */
-Ext.define('portal.layer.legend.wfs.WMSLegend', {
+Ext.define('portal.layer.legend.wms.WMSLegend', {
     extend: 'portal.layer.legend.Legend',
 
     iconUrl : '',
@@ -21,8 +21,11 @@ Ext.define('portal.layer.legend.wfs.WMSLegend', {
      * Implemented function, see parent class
      */
     getLegendComponent : function(resources, filterer,sld_body, callback) {
+        // GPT-80 - Legend - This is called from BARP / _getLegendAction().  I think I want to change WMSLegendForm ... (see there)
         var form = Ext.create('portal.layer.legend.wms.WMSLegendForm',{resources : resources,filterer : filterer,sld_body:sld_body});
         callback(this, resources, filterer, true, form); //this layer cannot generate a GUI popup
+        // GPT-80 - the Legend data now comes from async service calls and needs to added separately (prev. was done in constructor)
+        form.addLegends({resources : resources, form : form});
     },
 
     /**
@@ -48,7 +51,7 @@ Ext.define('portal.layer.legend.wfs.WMSLegend', {
 
     statics : {
 
-        generateImageUrl : function(wmsURL,wmsName,wmsVersion,sld_body,styles) {
+        generateImageUrl : function(wmsURL,wmsName,wmsVersion,width,sld_body,styles) {
             var url = wmsURL;
             var last_char = url.charAt(url.length - 1);
             if ((last_char !== "?") && (last_char !== "&")) {
@@ -65,7 +68,8 @@ Ext.define('portal.layer.legend.wfs.WMSLegend', {
             url += '&BGCOLOR=0xFFFFFF';
             url += '&LAYER=' + escape(wmsName);
             url += '&LAYERS=' + escape(wmsName);
-            url += '&legend_options=forceLabels:on';
+            url += '&WIDTH=' + width;
+//            url += '&legend_options=forceLabels:on';
             //vt: The sld for legend does not require any filter therefore it should be
             // able to accomadate all sld length.
             if(sld_body && sld_body.length< 2000){
@@ -76,6 +80,34 @@ Ext.define('portal.layer.legend.wfs.WMSLegend', {
             }
 
             return url;
+        },
+    
+        // WMS Can specify a <legendUrl> image - retrieve from the service
+        generateLegendUrl : function(wmsURL,wmsName,wmsVersion,width,sld_body,styles, callback) {
+            Ext.Ajax.request({
+                url: "getLegendURL.do",
+                timeout : 30000,    // Yes this seems a long time but was necessary  
+                params : {
+                    serviceUrl : wmsURL ,
+                    wmsVersion : wmsVersion,
+                    layerName : wmsName
+                },
+                scope : this,
+                success: function(response, options){
+                    var text = response.responseText;
+                    
+                    console.log("getLegendURL.do call success - response text: ",text, "options: ", options);
+                    callback(JSON.parse(response.responseText)["data"]);
+                },
+                failure: function(response, opts) {
+                    var status = response.status;
+                    var statusMsg = response.statusText;
+                    
+                    console.log("getLegendURL.do call failure - layerName: ", opts.params.layerName, ", url: ", wmsURL, ", status: ", status, ", status text: ",statusMsg, ".  Try alternate method.");
+                    var url = portal.layer.legend.wms.WMSLegend.generateImageUrl(wmsURL,wmsName,wmsVersion,width,sld_body,styles);
+                    callback(url);
+                }
+            });
         }
-    }
+    }    
 });

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
@@ -44,7 +44,6 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
                             });
                             config.form.setData(html);
                             me._setFormHeight(config.form, url, dimensions);
-//                            config.form.setHeight(40);
                         }
                     });
             if(config.sld_body && config.sld_body.length > 0 && config.sld_body.length < 2000){

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
@@ -17,7 +17,7 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
         var wmsOnlineResources = portal.csw.OnlineResource.getFilteredFromArray(config.resources, portal.csw.OnlineResource.WMS);
         var urlsFound=wmsOnlineResources.length;
         var urls={};
-        var dimensions = {maxWidth:0,height:0}; // Of all graphics so can resize window - accumulative height, max width
+        var dimensions = {maxWidth:300,height:0}; // Of all graphics so can resize window - accumulative height, max width (allow for title)
         var me = this;
 
         for (var j = 0; j < wmsOnlineResources.length; j++) {

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
@@ -17,6 +17,8 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
         var wmsOnlineResources = portal.csw.OnlineResource.getFilteredFromArray(config.resources, portal.csw.OnlineResource.WMS);
         var urlsFound=wmsOnlineResources.length;
         var urls={};
+        var dimensions = {maxWidth:0,height:0}; // Of all graphics so can resize window - accumulative height, max width
+        var me = this;
 
         for (var j = 0; j < wmsOnlineResources.length; j++) {
             portal.layer.legend.wms.WMSLegend.generateLegendUrl(
@@ -41,6 +43,8 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
                                 html += '<br/>\n';
                             });
                             config.form.setData(html);
+                            me._setFormHeight(config.form, url, dimensions);
+//                            config.form.setHeight(40);
                         }
                     });
             if(config.sld_body && config.sld_body.length > 0 && config.sld_body.length < 2000){
@@ -50,6 +54,21 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
             }
         }
 
+    },
+    
+    _setFormHeight : function(form, url, dimensions) {
+        var image = new Image(); 
+        image.onload = function(){
+            dimensions.height += image.height;
+            // Add extra to allow for spacing
+            dimensions.height += (dimensions.height * 0.02);
+            dimensions.maxWidth = Math.max(dimensions.maxWidth,image.width);
+            console.log("Image height x width: ", image.height, image.width, ", acc height x max Width: ", dimensions.height, dimensions.maxWidth);
+            form.setHeight(dimensions.height);
+            form.setWidth(dimensions.maxWidth);
+        };
+        image.src=url;
+//        "https://shijitht.files.wordpress.com/2010/08/github.png"
     }
 
 });

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
@@ -6,19 +6,43 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
     extend: 'portal.layer.legend.BaseComponent',
 
     constructor : function(config) {
-        var html='';
+ 
+        Ext.apply(config, {
+            html    : '<p> Waiting for Legend data ...</p>'
+        });
+        this.callParent(arguments);
+    },
+    
+    addLegends : function(config) {
         var wmsOnlineResources = portal.csw.OnlineResource.getFilteredFromArray(config.resources, portal.csw.OnlineResource.WMS);
+        var urlsFound=wmsOnlineResources.length;
+        var urls={};
 
         for (var j = 0; j < wmsOnlineResources.length; j++) {
-            var url = portal.layer.legend.wfs.WMSLegend.generateImageUrl(
+            portal.layer.legend.wms.WMSLegend.generateLegendUrl(
                     wmsOnlineResources[j].get('url'), 
                     wmsOnlineResources[j].get('name'),
                     wmsOnlineResources[j].get('version'),
-                    config.sld_body);
-            html += '<a target="_blank" href="' + url + '">';
-            html += '<img onerror="this.alt=\'There was an error loading this legend. Click here to try again in a new window or contact the data supplier.\'" alt="Loading legend..." src="' + url + '"/>';
-            html += '</a>';
-            html += '<br/>';
+                    this.getWidth(), // 100,    // getWidth() ? - Won't work as don't know width until this constructor is finished
+                    config.sld_body, undefined, function(url) {
+                        if (! urls.hasOwnProperty(url)) {
+                            // Add a WIDTH attribute to ?requests (but not to normal resource GETs ie. that don't contain a '?')
+                            if (url.match(/width/i) === null && url.match(/\?/) !== null) {
+                                // Force a width or else the gis server seems to return it truncated
+                                url += "&WIDTH=100";
+                            }
+                            var html='';
+                            
+                            urls[url] = 1;
+                            Object.getOwnPropertyNames(urls).sort().forEach(function (url, index, array) {
+                                html += '<a target="_blank" href="' + url + '">';
+                                html += '<img onerror="this.alt=\'There was an error loading this legend. Click here to try again in a new window or contact the data supplier.\'" alt="Loading legend..." src="' + url + '"/>';
+                                html += '</a>';
+                                html += '<br/>\n';
+                            });
+                            config.form.setData(html);
+                        }
+                    });
             if(config.sld_body && config.sld_body.length > 0 && config.sld_body.length < 2000){
                 //VT: if we are supplying the SLD, we are controlling the legends. Therefore we only need to
                 // loop once
@@ -26,10 +50,6 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
             }
         }
 
-        Ext.apply(config, {
-            html    : html
-        });
-        this.callParent(arguments);
     }
 
 });

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
@@ -63,12 +63,10 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
             // Add extra to allow for spacing
             dimensions.height += (dimensions.height * 0.02);
             dimensions.maxWidth = Math.max(dimensions.maxWidth,image.width);
-            console.log("Image height x width: ", image.height, image.width, ", acc height x max Width: ", dimensions.height, dimensions.maxWidth);
             form.setHeight(dimensions.height);
             form.setWidth(dimensions.maxWidth);
         };
         image.src=url;
-//        "https://shijitht.files.wordpress.com/2010/08/github.png"
     }
 
 });

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
@@ -24,7 +24,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
         // give it a wms legend.
 
         if(config.icon.getIsDefault()===true){
-            this.legend = Ext.create('portal.layer.legend.wfs.WMSLegend', {
+            this.legend = Ext.create('portal.layer.legend.wms.WMSLegend', {
                 iconUrl : config.iconCfg ? config.iconCfg.url : 'portal-core/img/key.png'
             });
         }else{
@@ -308,7 +308,6 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
                  if (this.currentRequestCount === 0) {                     
                      this.fireEvent('renderfinished', this);
                  }
-                           
             }
         });
         

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/DisjunctionLayerRenderer.js
@@ -7,7 +7,7 @@ Ext.define('portal.layer.renderer.wms.DisjunctionLayerRenderer', {
     extend : 'portal.layer.renderer.Renderer',
 
     constructor : function(config) {
-        this.legend = Ext.create('portal.layer.legend.wfs.WMSLegend', {
+        this.legend = Ext.create('portal.layer.legend.wms.WMSLegend', {
             iconUrl : config.iconCfg ? config.iconCfg.url : 'portal-core/img/key.png'
         });
         this.callParent(arguments);

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
@@ -6,7 +6,7 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
     extend: 'portal.layer.renderer.Renderer',
 
     constructor: function(config) {
-        this.legend = Ext.create('portal.layer.legend.wfs.WMSLegend', {
+        this.legend = Ext.create('portal.layer.legend.wms.WMSLegend', {
             iconUrl : config.iconCfg ? config.iconCfg.url : 'portal-core/img/key.png'
         });
         this.callParent(arguments);

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -190,7 +190,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                     me.activelayerstore.suspendEvents(true);
                     me.activelayerstore.insert(0,layer); //this adds the layer to our store
                     me.activelayerstore.resumeEvents();
-                    console.log("Added layer: ", layer);
+//                    console.log("Added layer: ", layer);
                 },
                 removelayer : function(layer){
                     me.activelayerstore.remove(layer);

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/LayerPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/LayerPanel.js
@@ -309,8 +309,9 @@ Ext.define('portal.widgets.panel.LayerPanel', {
                 var win = Ext.create('Ext.window.Window', {
                     title       : 'Legend: '+ layer.get('name'),
                     layout      : 'fit',
-                    width       : 200,
-                    height      : 300,
+                    // this will be resized dynamically as legend content is added
+                    //                    width       : 200,
+                    //                    height      : 300,
                     items: form
                 });
                 return win.show();

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/LayerPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/LayerPanel.js
@@ -304,14 +304,12 @@ Ext.define('portal.widgets.panel.LayerPanel', {
      */
     _legendClickHandler : function(column, layer, rowIndex, colIndex) {
         //The callback takes our generated component and displays it in a popup window
+        // this will be resized dynamically as legend content is added
         var legendCallback = function(legend, resources, filterer, success, form, layer){
             if (success && form) {
                 var win = Ext.create('Ext.window.Window', {
                     title       : 'Legend: '+ layer.get('name'),
                     layout      : 'fit',
-                    // this will be resized dynamically as legend content is added
-                    //                    width       : 200,
-                    //                    height      : 300,
                     items: form
                 });
                 return win.show();


### PR DESCRIPTION
* Previously portal-core was generating a hard-coded URL to getLegendGraphic.  However sometimes the LegendUrl in the getCapabilities was different.  So now LegendUrl is hit in the first place
* The code behind GetCapabilities was updated.  Previously GetCapabilitiesWMSLayer_1_3_0 was building the XML node structure for EVERY node for every layer.  I changed it to only build the node for the element that was request (eg. 'Legend').  This took the time to render the LegendUrl from 70 secs to 13 for the example I was looking at (Populated Places).
* For some reason (and perhaps something to investigate separately), the gis server at GA is returning truncated (width) legend graphics.  So if the graphic is being returned with a .../...?REQUEST=GetLegendGraphic then a WIDTH=100 is being sent with the request
* The Legend Panel renders dynamically as data comes in.  However the width is forced to some minimum to allow for the title

To see the change go to http://portal-dev.geoscience.gov.au/gmap.html and add any WMS layers.  For example Populated Places and Coastlines under Topography and Infrastructure.  To see the legend use the original AuScope method under the KnownLayers Options menu or the Key icon on the Active Layers panel.