### PR TITLE
ANVGL-3 AWS EC2 Support for CloudComputeService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -511,12 +511,6 @@
             <artifactId>jclouds-all</artifactId>
             <version>${jclouds.version}</version>
         </dependency>
-        <!-- We need AWS to cover the gaps in JCloud's client -->
-        <dependency>
-            <groupId>com.amazonaws</groupId>
-            <artifactId>aws-java-sdk-ec2</artifactId>
-            <version>1.9.0</version>
-        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -552,16 +546,6 @@
 		  <groupId>org.pacesys</groupId>
 		  <artifactId>openstack4j-core</artifactId>
 		  <version>2.0.3</version>
-          <exclusions>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.core</groupId>
-                    <artifactId>jackson-databind</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>com.fasterxml.jackson.dataformat</groupId>
-                    <artifactId>jackson-dataformat-yaml</artifactId>
-                </exclusion>
-          </exclusions>
 		</dependency>
 		<dependency>
 		  <groupId>org.pacesys.openstack4j.connectors</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -511,6 +511,12 @@
             <artifactId>jclouds-all</artifactId>
             <version>${jclouds.version}</version>
         </dependency>
+        <!-- We need AWS to cover the gaps in JCloud's client -->
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-ec2</artifactId>
+            <version>1.9.0</version>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
@@ -546,6 +552,16 @@
 		  <groupId>org.pacesys</groupId>
 		  <artifactId>openstack4j-core</artifactId>
 		  <version>2.0.3</version>
+          <exclusions>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.dataformat</groupId>
+                    <artifactId>jackson-dataformat-yaml</artifactId>
+                </exclusion>
+          </exclusions>
 		</dependency>
 		<dependency>
 		  <groupId>org.pacesys.openstack4j.connectors</groupId>

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
@@ -18,7 +18,9 @@ import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.cloud.CloudJob;
 import org.auscope.portal.core.cloud.ComputeType;
 import org.auscope.portal.core.cloud.MachineImage;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.cloud.SimpleEC2Client.InstanceInitiatedShutdownBehaviour;
 import org.jclouds.ContextBuilder;
 import org.jclouds.aws.AWSResponseException;
 import org.jclouds.aws.ec2.compute.AWSEC2TemplateOptions;
@@ -39,15 +41,6 @@ import org.jclouds.openstack.nova.v2_0.extensions.AvailabilityZoneApi;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.openstack.OSFactory;
 
-import com.amazonaws.AmazonClientException;
-import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
-import com.amazonaws.services.ec2.AmazonEC2Client;
-import com.amazonaws.services.ec2.model.GetConsoleOutputRequest;
-import com.amazonaws.services.ec2.model.GetConsoleOutputResult;
-import com.amazonaws.services.ec2.model.InstanceAttributeName;
-import com.amazonaws.services.ec2.model.ModifyInstanceAttributeRequest;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
@@ -71,7 +64,7 @@ public class CloudComputeService {
     private ComputeService computeService;
     private ComputeServiceContext context;
     private NovaApi novaApi; //will be null for non nova API's
-    private AmazonEC2Client ec2Api; //will be null for non ec2 API's
+    private SimpleEC2Client ec2Api; //will be null for non ec2 API's
     private Set<String> skippedZones = new HashSet<String>();
     private String zone; //can be null
 
@@ -142,9 +135,28 @@ public class CloudComputeService {
      *            The Compute Secret key (password)
      * @param apiVersion
      *            The API version
+     * @param httpServiceCaller - required for EC2, can be null for Nova
      */
     public CloudComputeService(ProviderType provider, String endpoint, String accessKey, String secretKey,
             String apiVersion) {
+        this(provider, endpoint, accessKey, secretKey, apiVersion, null);
+    }
+
+    /**
+     * Creates a new instance with the specified credentials
+     *
+     * @param endpoint
+     *            (URL) The location of the Compute (Nova) service
+     * @param accessKey
+     *            The Compute Access key (user name)
+     * @param secretKey
+     *            The Compute Secret key (password)
+     * @param apiVersion
+     *            The API version
+     * @param httpServiceCaller - required for EC2, can be null for Nova
+     */
+    public CloudComputeService(ProviderType provider, String endpoint, String accessKey, String secretKey,
+            String apiVersion, HttpServiceCaller httpServiceCaller) {
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         this.endpoint = endpoint;
@@ -182,7 +194,7 @@ public class CloudComputeService {
             this.novaApi = b.buildApi(NovaApi.class);
             break;
         case AWSEc2:
-            this.ec2Api = new AmazonEC2Client(new BasicAWSCredentials(accessKey, secretKey));
+            this.ec2Api = new SimpleEC2Client(httpServiceCaller, accessKey, secretKey, zone);
             break;
         }
 
@@ -191,6 +203,15 @@ public class CloudComputeService {
 
         this.terminateFilter = Predicates.and(not(TERMINATED), not(RUNNING), inGroup(groupName));
 
+    }
+
+
+    /**
+     * This is overridable for test mocking
+     * @param ec2Api
+     */
+    protected void setEc2Api(SimpleEC2Client ec2Api) {
+        this.ec2Api = ec2Api;
     }
 
     public CloudComputeService(ProviderType provider, ComputeService computeService, NovaApi novaApi,
@@ -249,7 +270,7 @@ public class CloudComputeService {
     public void setZone(String zone) {
         this.zone = zone;
         if (this.ec2Api != null) {
-            this.ec2Api.setRegion(Region.getRegion(Regions.fromName(zone)));
+            this.ec2Api.setRegion(zone);
         }
     }
 
@@ -353,10 +374,8 @@ public class CloudComputeService {
 
             //Configure the instance to terminate on shutdown:
             try {
-                ModifyInstanceAttributeRequest miar = new ModifyInstanceAttributeRequest(result.getId(), InstanceAttributeName.InstanceInitiatedShutdownBehavior);
-                miar.setValue("terminate");
-                ec2Api.modifyInstanceAttribute(miar);
-            } catch (AmazonClientException ex) {
+                ec2Api.setInstanceInitiatedShutdownBehaviour(result.getId().split("/")[1], InstanceInitiatedShutdownBehaviour.Terminate);
+            } catch (Exception ex) {
                 //if we fail here - kill the instance, we don't want a floating VM sitting around
                 logger.error(String.format("Instance ID '%1$s' could NOT be set to terminate on shutdown: %2$s", result.getId(), ex.getMessage()));
                 logger.debug("Exception:", ex);
@@ -576,12 +595,9 @@ public class CloudComputeService {
      * @throws PortalServiceException
      */
     private String getConsoleLogAws(String computeInstanceId, CloudJob job, int numLines) throws PortalServiceException {
-        GetConsoleOutputRequest getConsoleOutputRequest = new GetConsoleOutputRequest(computeInstanceId);
-
         try {
-            GetConsoleOutputResult result = ec2Api.getConsoleOutput(getConsoleOutputRequest);
-            return result.getDecodedOutput();
-        } catch (AmazonClientException ex) {
+            return ec2Api.getConsoleOutput(computeInstanceId);
+        } catch (Exception ex) {
             logger.error("Unable to retrieve console logs for " + computeInstanceId, ex);
             throw new PortalServiceException("Unable to retrieve console logs for " + computeInstanceId, ex);
         }

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
@@ -374,7 +374,7 @@ public class CloudComputeService {
 
             //Configure the instance to terminate on shutdown:
             try {
-                ec2Api.setInstanceInitiatedShutdownBehaviour(result.getId().split("/")[1], InstanceInitiatedShutdownBehaviour.Terminate);
+                ec2Api.setInstanceInitiatedShutdownBehaviour(result.getId(), InstanceInitiatedShutdownBehaviour.Terminate);
             } catch (Exception ex) {
                 //if we fail here - kill the instance, we don't want a floating VM sitting around
                 logger.error(String.format("Instance ID '%1$s' could NOT be set to terminate on shutdown: %2$s", result.getId(), ex.getMessage()));

--- a/src/main/java/org/auscope/portal/core/services/cloud/SimpleEC2Client.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/SimpleEC2Client.java
@@ -254,14 +254,13 @@ public class SimpleEC2Client {
      */
     public void setInstanceInitiatedShutdownBehaviour(String instanceId, InstanceInitiatedShutdownBehaviour behaviour) throws PortalServiceException {
         HashMap<String, String> params = new HashMap<String, String>();
-        params.put("Attribute", "instanceInitiatedShutdownBehavior");
         params.put("InstanceId", instanceId);
         switch(behaviour) {
         case Stop:
-            params.put("Value", "stop");
+            params.put("InstanceInitiatedShutdownBehavior.Value", "stop");
             break;
         case Terminate:
-            params.put("Value", "terminate");
+            params.put("InstanceInitiatedShutdownBehavior.Value", "terminate");
             break;
         }
 

--- a/src/main/java/org/auscope/portal/core/services/cloud/SimpleEC2Client.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/SimpleEC2Client.java
@@ -1,0 +1,296 @@
+package org.auscope.portal.core.services.cloud;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.services.PortalServiceException;
+
+/**
+ * This class was created due to our inability to use the AWS Java SDK due to a number of dependency clashes.
+ *
+ * it implements a tiny subset of the EC2 API that JClouds doesn't
+ *
+ * @see https://jira.csiro.au/browse/ANVGL-3
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public class SimpleEC2Client {
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private static final String CONTENT_TYPE = "application/x-www-form-urlencoded; charset=utf-8";
+    private static final String SIGNED_HEADERS = "content-type;host;x-amz-date";
+
+    private HttpServiceCaller httpService;
+    private String region;
+    private String accessKey;
+    private String secretKey;
+    private String service = "ec2";
+
+    public SimpleEC2Client(HttpServiceCaller httpService, String accessKey, String secretKey, String region) {
+        super();
+        this.httpService = httpService;
+        this.region = region;
+        this.accessKey = accessKey;
+        this.secretKey = secretKey;
+    }
+
+    protected String getService() {
+        return service;
+    }
+
+    protected void setService(String service) {
+        this.service = service;
+    }
+
+    protected String getRegion() {
+        return region;
+    }
+
+    protected void setRegion(String region) {
+        this.region = region;
+    }
+
+    private String sha256Hash(String data) {
+        MessageDigest crypt;
+        try {
+            crypt = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            logger.error("sha256 Algorithm not available. Unable to hash EC2 requests.", e);
+            throw new RuntimeException("sha256 Algorithm not available. Unable to hash EC2 requests");
+        }
+        byte[] dataBytes = data.getBytes(StandardCharsets.UTF_8);
+
+        crypt.update(dataBytes);
+
+        return new String(Hex.encodeHex(crypt.digest(), true));
+    }
+
+    private byte[] HmacSHA256(String data, byte[] key) throws NoSuchAlgorithmException, InvalidKeyException, IllegalStateException, UnsupportedEncodingException {
+        String algorithm = "HmacSHA256";
+        Mac mac = Mac.getInstance(algorithm);
+        mac.init(new SecretKeySpec(key, algorithm));
+        return mac.doFinal(data.getBytes("UTF8"));
+    }
+
+    private byte[] getSignatureKey(String key, String dateStamp, String regionName, String serviceName) throws InvalidKeyException, NoSuchAlgorithmException, IllegalStateException, UnsupportedEncodingException {
+        byte[] kSecret = ("AWS4" + key).getBytes("UTF8");
+        byte[] kDate = HmacSHA256(dateStamp, kSecret);
+        byte[] kRegion = HmacSHA256(regionName, kDate);
+        byte[] kService = HmacSHA256(serviceName, kRegion);
+        byte[] kSigning = HmacSHA256("aws4_request", kService);
+        return kSigning;
+    }
+
+    private String getISO8601DateString(Date date) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(date);
+    }
+
+    private String getSimpleDateString(Date date) {
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd");
+        sdf.setTimeZone(TimeZone.getTimeZone("UTC"));
+        return sdf.format(date);
+    }
+
+    private String generateEndpoint() {
+        if (region == null) {
+            return  "http://" + service + ".amazonaws.com/";
+        } else {
+            return "http://" + service + "." + region + ".amazonaws.com/";
+        }
+    }
+
+    /**
+     * Generates a canonical request as per: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
+     * @param uri
+     * @param date
+     * @param payload
+     * @return
+     */
+    protected String generateCanonicalRequest(URI uri, Date date, String payload) {
+        StringBuilder canonicalRequest = new StringBuilder();
+        canonicalRequest.append("GET\n"); //HTTPRequestMethod
+        canonicalRequest.append("/\n"); //CanonicalURI
+        canonicalRequest.append(uri.getQuery()); //CanonicalQueryString
+        canonicalRequest.append("\n");
+        canonicalRequest.append("content-type:");
+        canonicalRequest.append(CONTENT_TYPE);
+        canonicalRequest.append("\n");
+        canonicalRequest.append("host:");
+        canonicalRequest.append(uri.getHost());
+        canonicalRequest.append("\n");
+        canonicalRequest.append("x-amz-date:");
+        canonicalRequest.append(getISO8601DateString(date));
+        canonicalRequest.append("\n");
+        canonicalRequest.append(payload); //Payload
+        canonicalRequest.append("\n");
+        canonicalRequest.append(SIGNED_HEADERS);
+        canonicalRequest.append("\n");
+        canonicalRequest.append(sha256Hash(payload)); //Hashed payload
+        return canonicalRequest.toString();
+    }
+
+    /**
+     * Generates a string to sign as per: http://docs.aws.amazon.com/general/latest/gr/sigv4-create-string-to-sign.html
+     * @param date
+     * @param hashedCanonicalRequest
+     * @return
+     */
+    protected String generateStringToSign(Date date, String hashedCanonicalRequest) {
+        StringBuilder stringToSign = new StringBuilder();
+        stringToSign.append("AWS4-HMAC-SHA256\n");
+        stringToSign.append(getISO8601DateString(date));
+        stringToSign.append("\n");
+        stringToSign.append(getSimpleDateString(date));
+        stringToSign.append("/");
+        stringToSign.append(region);
+        stringToSign.append("/");
+        stringToSign.append(service);
+        stringToSign.append("/aws4_request\n");
+        stringToSign.append(hashedCanonicalRequest);
+
+        return stringToSign.toString();
+    }
+
+    /**
+     * Generates an AWS signature as per: http://docs.aws.amazon.com/general/latest/gr/sigv4-calculate-signature.html
+     * @param stringToSign
+     * @param date
+     * @return
+     * @throws PortalServiceException
+     */
+    protected String generateSignature(String stringToSign, Date date) throws PortalServiceException {
+        try {
+            byte[] signingKeyBytes = getSignatureKey(secretKey, getSimpleDateString(date), region, service);
+            byte[] signatureBytes = HmacSHA256(stringToSign, signingKeyBytes);
+            return new String(Hex.encodeHex(signatureBytes, true));
+        } catch (Exception e) {
+            logger.error("Error creating EC2 signing key", e);
+            throw new PortalServiceException("Error creating EC2 signing key", e);
+        }
+    }
+
+    /**
+     * Generates an authorization header for an AWS request as per: http://docs.aws.amazon.com/general/latest/gr/sigv4-add-signature-to-request.html
+     * @param signature
+     * @param date
+     * @return
+     */
+    protected String generateAuthorizationHeader(String signature, Date date) {
+        StringBuilder authorization = new StringBuilder();
+        authorization.append("AWS4-HMAC-SHA256 Credential=");
+        authorization.append(accessKey);
+        authorization.append("/");
+        authorization.append(getSimpleDateString(date));
+        authorization.append("/");
+        authorization.append(region);
+        authorization.append("/");
+        authorization.append(service);
+        authorization.append("/aws4_request, SignedHeaders=");
+        authorization.append(SIGNED_HEADERS);
+        authorization.append(", Signature=");
+        authorization.append(signature);
+
+        return authorization.toString();
+    }
+
+    protected HttpGet makeRequest(String action, Date date, Map<String, String> params) throws URISyntaxException, PortalServiceException {
+        HttpGet method = new HttpGet();
+
+        URIBuilder builder = new URIBuilder(generateEndpoint());
+        builder.setParameter("action", action); //The access token I am getting after the Login
+        builder.setParameter("version", "2010-05-08");
+        for (String key : params.keySet()) {
+            builder.setParameter(key, params.get(key));
+        }
+
+
+        URI uri = builder.build();
+        String host = uri.getHost();
+        String contentType = "application/x-www-form-urlencoded; charset=utf-8";
+        String payload = ""; //(we are using GET - so empty string is the correct value)
+
+        String canonicalRequest = generateCanonicalRequest(uri, date, payload);
+        String hashedCanonicalRequest = sha256Hash(canonicalRequest);
+        String stringToSign = generateStringToSign(date, hashedCanonicalRequest);
+        String signature = generateSignature(stringToSign, date);
+        String authorization = generateAuthorizationHeader(signature, date);
+
+        method.setHeader("Host", host);
+        method.setHeader("Content-Type", contentType);
+        method.setHeader("X-Amz-Date", getISO8601DateString(date));
+        method.setHeader("Authorization", authorization.toString());
+        method.setURI(uri);
+        return method;
+    }
+
+    /**
+     * Sets the instanceInitiatedShutdownBehavior attribute for a given running instance
+     * @param instanceId
+     * @param behaviour
+     */
+    public void setInstanceInitiatedShutdownBehaviour(String instanceId, InstanceInitiatedShutdownBehaviour behaviour) throws PortalServiceException {
+        HashMap<String, String> params = new HashMap<String, String>();
+        params.put("Attribute", "instanceInitiatedShutdownBehavior");
+        params.put("InstanceId", instanceId);
+        switch(behaviour) {
+        case Stop:
+            params.put("Value", "stop");
+            break;
+        case Terminate:
+            params.put("Value", "terminate");
+            break;
+        }
+
+        try {
+            HttpGet request = makeRequest("ModifyInstanceAttribute", new Date(), params);
+            String response = httpService.getMethodResponseAsString(request);
+            if (!response.contains("<return>true</return>")) { //This could be so much more robust...
+                logger.debug("Error response from AWS: " + response);
+                throw new IOException("AWS has returned an error");
+            }
+
+        } catch (Exception ex) {
+            logger.error("Error setting instanceInitiatedShutdownBehavior for " + instanceId);
+            logger.debug("Exception: ", ex);
+            throw new PortalServiceException("Error setting instanceInitiatedShutdownBehavior for " + instanceId, ex);
+        }
+    }
+
+    /**
+     * Gets the console logs as reported by AWS for the specified instance.
+     * @param instanceId
+     * @throws PortalServiceException
+     */
+    public String getConsoleOutput(String instanceId) throws PortalServiceException {
+        throw new NotImplementedException();
+    }
+
+    public enum InstanceInitiatedShutdownBehaviour {
+        Terminate,
+        Stop
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/namespaces/AWSEC2NamespaceContext.java
+++ b/src/main/java/org/auscope/portal/core/services/namespaces/AWSEC2NamespaceContext.java
@@ -1,0 +1,16 @@
+package org.auscope.portal.core.services.namespaces;
+
+/**
+ * A simple implementation of <a href="http://java.sun.com/javase/6/docs/api/javax/xml/namespace/NamespaceContext.html"> NamespaceContext </a>. Instances are
+ * immutable.
+ *
+ * This is suitable for reading AWS EC2 response XML
+ *
+ * @version $Id$
+ */
+public class AWSEC2NamespaceContext extends IterableNamespace {
+
+    public AWSEC2NamespaceContext() {
+        map.put("aws", "http://ec2.amazonaws.com/doc/2015-10-01/");
+    };
+}

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestSimpleEC2Client.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestSimpleEC2Client.java
@@ -1,0 +1,86 @@
+package org.auscope.portal.core.services.cloud;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+import junit.framework.Assert;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the Simple EC2 client
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public class TestSimpleEC2Client extends PortalTestClass {
+    private SimpleEC2Client client;
+    private HttpServiceCaller httpService = context.mock(HttpServiceCaller.class);
+    private static final String ACCESS_KEY_EXAMPLE = "AKIDEXAMPLE";
+    private static final String SECRET_KEY_EXAMPLE = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY";
+    private static final String REGION = "us-east-1";
+    private Date date;
+
+    @Before
+    public void setup() throws ParseException {
+        client = new SimpleEC2Client(httpService, ACCESS_KEY_EXAMPLE, SECRET_KEY_EXAMPLE, REGION);
+        client.setService("iam"); //All of Amazon's examples are based around IAM so this is what we validate against
+
+        SimpleDateFormat df = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
+        df.setTimeZone(TimeZone.getTimeZone("UTC"));
+        date = df.parse("20150830T123600Z");
+    }
+
+    @Test
+    public void testCanonicalRequest() throws Exception {
+        URIBuilder builder = new URIBuilder("http://iam.amazonaws.com/?Action=ListUsers&Version=2010-05-08");
+        String actualCanonicalRequest = client.generateCanonicalRequest(builder.build(), date, "");
+        String expectedCanoncialRequest =
+                "GET\n" +
+                "/\n" +
+                "Action=ListUsers&Version=2010-05-08\n" +
+                "content-type:application/x-www-form-urlencoded; charset=utf-8\n" +
+                "host:iam.amazonaws.com\n" +
+                "x-amz-date:20150830T123600Z\n" +
+                "\n" +
+                "content-type;host;x-amz-date\n" +
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+        Assert.assertEquals(expectedCanoncialRequest, actualCanonicalRequest);
+    }
+
+    @Test
+    public void testStringToSign() throws Exception {
+        String stringToSign = client.generateStringToSign(date, "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59");
+        String expectedString =
+                "AWS4-HMAC-SHA256\n" +
+                "20150830T123600Z\n" +
+                "20150830/us-east-1/iam/aws4_request\n" +
+                "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59";
+        Assert.assertEquals(expectedString, stringToSign);
+    }
+
+    @Test
+    public void testGenerateSignature() throws Exception {
+        String stringToSign =
+                "AWS4-HMAC-SHA256\n" +
+                "20150830T123600Z\n" +
+                "20150830/us-east-1/iam/aws4_request\n" +
+                "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59";
+        String signature = client.generateSignature(stringToSign, date);
+        String expectedSignature = "5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7";
+        Assert.assertEquals(expectedSignature, signature);
+    }
+
+    @Test
+    public void testGenerateAuthHeader() throws Exception {
+        String signature = client.generateAuthorizationHeader("5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7", date);
+        String expectedSignature = "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7";
+        Assert.assertEquals(expectedSignature, signature);
+    }
+}

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestSimpleEC2Client.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestSimpleEC2Client.java
@@ -55,6 +55,24 @@ public class TestSimpleEC2Client extends PortalTestClass {
     }
 
     @Test
+    public void testCanonicalRequestOrderedParams() throws Exception {
+        URIBuilder builder = new URIBuilder("http://iam.amazonaws.com/?Version=2010-05-08&Action=ListUsers&Foo=bar%2Fbaz");
+        String actualCanonicalRequest = client.generateCanonicalRequest(builder.build(), date, "");
+        String expectedCanoncialRequest =
+                "GET\n" +
+                "/\n" +
+                "Action=ListUsers&Foo=bar%2Fbaz&Version=2010-05-08\n" +
+                "content-type:application/x-www-form-urlencoded; charset=utf-8\n" +
+                "host:iam.amazonaws.com\n" +
+                "x-amz-date:20150830T123600Z\n" +
+                "\n" +
+                "content-type;host;x-amz-date\n" +
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+        Assert.assertEquals(expectedCanoncialRequest, actualCanonicalRequest);
+    }
+
+    @Test
     public void testStringToSign() throws Exception {
         String stringToSign = client.generateStringToSign(date, "f536975d06c0309214f805bb90ccff089219ecd68b2577efef23edd43b7e1a59");
         String expectedString =

--- a/src/test/resources/org/auscope/portal/core/aws/getconsoleoutput-response-success.xml
+++ b/src/test/resources/org/auscope/portal/core/aws/getconsoleoutput-response-success.xml
@@ -1,0 +1,13 @@
+<GetConsoleOutputResponse xmlns="http://ec2.amazonaws.com/doc/2015-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <instanceId>i-28a64341</instanceId>
+  <timestamp>2010-10-14T01:12:41.000Z</timestamp>
+  <output>TGludXggdmVyc2lvbiAyLjYuMTYteGVuVSAoYnVpbGRlckBwYXRjaGJhdC5hbWF6b25zYSkgKGdj
+YyB2ZXJzaW9uIDQuMC4xIDIwMDUwNzI3IChSZWQgSGF0IDQuMC4xLTUpKSAjMSBTTVAgVGh1IE9j
+dCAyNiAwODo0MToyNiBTQVNUIDIwMDYKQklPUy1wcm92aWRlZCBwaHlzaWNhbCBSQU0gbWFwOgpY
+ZW46IDAwMDAwMDAwMDAwMDAwMDAgLSAwMDAwMDAwMDZhNDAwMDAwICh1c2FibGUpCjk4ME1CIEhJ
+R0hNRU0gYXZhaWxhYmxlLgo3MjdNQiBMT1dNRU0gYXZhaWxhYmxlLgpOWCAoRXhlY3V0ZSBEaXNh
+YmxlKSBwcm90ZWN0aW9uOiBhY3RpdmUKSVJRIGxvY2t1cCBkZXRlY3Rpb24gZGlzYWJsZWQKQnVp
+bHQgMSB6b25lbGlzdHMKS2VybmVsIGNvbW1hbmQgbGluZTogcm9vdD0vZGV2L3NkYTEgcm8gNApF
+bmFibGluZyBmYXN0IEZQVSBzYXZlIGFuZCByZXN0b3JlLi4uIGRvbmUuCg==</output>
+</GetConsoleOutputResponse>

--- a/src/test/resources/org/auscope/portal/core/aws/modifyinstanceattribute-response-failure.xml
+++ b/src/test/resources/org/auscope/portal/core/aws/modifyinstanceattribute-response-failure.xml
@@ -1,0 +1,4 @@
+<ModifyInstanceAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2015-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <return>false</return>
+</ModifyInstanceAttributeResponse>

--- a/src/test/resources/org/auscope/portal/core/aws/modifyinstanceattribute-response-success.xml
+++ b/src/test/resources/org/auscope/portal/core/aws/modifyinstanceattribute-response-success.xml
@@ -1,0 +1,4 @@
+<ModifyInstanceAttributeResponse xmlns="http://ec2.amazonaws.com/doc/2015-10-01/">
+  <requestId>59dbff89-35bd-4eac-99ed-be587EXAMPLE</requestId>
+  <return>true</return>
+</ModifyInstanceAttributeResponse>


### PR DESCRIPTION
Added EC2 support to the cloud compute service. There was a need to handroll our own EC2 client due to an inability to reconcile various jackson dependencies between our spring-oauth2-security-client (+ others) and the official AWS Java EC2 SDK. We were also unable to use the JClouds API for some functionality in AWS which basically left us with implementing our own SimpleEC2Client.

Any portals using CloudComputeService can continue to operate without changing any constructor arguments.

See https://jira.csiro.au/browse/ANVGL-3 for the full notes