### PR TITLE
AUS-2607 Fixed compileXPathExpr using undefined provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -388,6 +388,11 @@
             <optional>false</optional>
         </dependency>
         <dependency>
+            <groupId>xmlunit</groupId>
+            <artifactId>xmlunit</artifactId>
+            <version>1.6</version>
+        </dependency>
+        <dependency>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
             <exclusions>

--- a/src/main/java/org/auscope/portal/core/test/PortalTestClass.java
+++ b/src/main/java/org/auscope/portal/core/test/PortalTestClass.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import javax.xml.parsers.ParserConfigurationException;
+
 import junit.framework.Assert;
 
 import org.auscope.portal.core.test.jmock.DelayedReturnValueAction;
@@ -21,6 +23,9 @@ import org.auscope.portal.core.test.jmock.HttpMethodBaseMatcher;
 import org.auscope.portal.core.test.jmock.HttpMethodBaseMatcher.HttpMethodType;
 import org.auscope.portal.core.test.jmock.MapMatcher;
 import org.auscope.portal.core.test.jmock.PropertiesMatcher;
+import org.auscope.portal.core.util.DOMUtil;
+import org.custommonkey.xmlunit.Diff;
+import org.custommonkey.xmlunit.XMLUnit;
 import org.jmock.Mockery;
 import org.jmock.api.Action;
 import org.jmock.api.ExpectationError;
@@ -29,6 +34,8 @@ import org.jmock.lib.legacy.ClassImposteriser;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.runner.RunWith;
+import org.w3c.dom.Document;
+import org.xml.sax.SAXException;
 
 /**
  * Base class for all unit test classes to inherit from
@@ -89,7 +96,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
      * A JMock action similar to returnValue but that only returns AFTER a specified delay
      *
      * It can provide a neat workaround for testing multiple competing threads
-     * 
+     *
      * @param msDelay
      *            The delay in milli seconds to wait
      * @param returnValue
@@ -119,7 +126,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock Matcher for testing for a HttpMethodBase matching a few simplified terms
-     * 
+     *
      * @param type
      *            If not null, the type of method to match for
      * @param url
@@ -134,7 +141,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock Matcher for testing for a HttpMethodBase matching a few simplified terms
-     * 
+     *
      * @param type
      *            If not null, the type of method to match for
      * @param urlPattern
@@ -149,7 +156,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock Matcher for testing for a java.util.Properties object with a single matching property
-     * 
+     *
      * @param property
      *            The property name
      * @param value
@@ -162,7 +169,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock Matcher for testing for a java.util.Properties object with a matching property
-     * 
+     *
      * @param property
      *            The property name
      * @param value
@@ -179,7 +186,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock Matcher for testing a Map has every specified value
-     * 
+     *
      * @param map
      *            The values to test for
      * @return
@@ -190,7 +197,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock Matcher for testing a Map has every specified value
-     * 
+     *
      * @param keys
      *            The Keys to match for (must correspond 1:1 with values
      * @param values
@@ -218,7 +225,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * Gets the elapsed time since startTimer() was called (in milli seconds).
-     * 
+     *
      * @return
      */
     protected long endTimer() {
@@ -232,7 +239,7 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
      * Utility function for opening a system resource and parsing it into a string.
      *
      * Returns null if the resource cannot be opened
-     * 
+     *
      * @param resource
      */
     protected String getSystemResourceAsString(String resource) {
@@ -284,12 +291,29 @@ public abstract class PortalTestClass implements Thread.UncaughtExceptionHandler
 
     /**
      * A JMock matcher for matching a File with a specific name
-     * 
+     *
      * @param fileName
      *            The name of the file to match
      * @return
      */
     protected FileWithNameMatcher aFileWithName(String fileName) {
         return new FileWithNameMatcher(fileName);
+    }
+
+    /**
+     * Compares two strings by parsing them into XML and ensuring all elements/attributes match.
+     * @param xml1
+     * @param xml2
+     * @return
+     * @throws SAXException
+     * @throws IOException
+     * @throws ParserConfigurationException
+     */
+    protected boolean xmlStringEquals(String xml1, String xml2, boolean namespaceAware) throws ParserConfigurationException, IOException, SAXException {
+        Document d1 = DOMUtil.buildDomFromString(xml1, namespaceAware);
+        Document d2 = DOMUtil.buildDomFromString(xml2, namespaceAware);
+
+        Diff diff = XMLUnit.compareXML(d1, d2);
+        return diff.identical();
     }
 }

--- a/src/main/java/org/auscope/portal/core/util/DOMUtil.java
+++ b/src/main/java/org/auscope/portal/core/util/DOMUtil.java
@@ -21,8 +21,6 @@ import javax.xml.xpath.XPathExpression;
 import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
-import net.sf.saxon.xpath.XPathFactoryImpl;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.xml.sax.InputSource;
@@ -38,7 +36,7 @@ public class DOMUtil {
 
     /**
      * Utility for accessing a consistent DocumentBuilderFactory (irregardless of what is on the classpath)
-     * 
+     *
      * @return
      */
     private static DocumentBuilderFactory getDocumentBuilderFactory() {
@@ -48,8 +46,17 @@ public class DOMUtil {
     }
 
     /**
+     * Utility for accessing a consistent XPathFactory (irregardless of what is on the classpath)
+     *
+     * @return
+     */
+    private static XPathFactory getXPathFactory() {
+        return new net.sf.saxon.xpath.XPathFactoryImpl();
+    }
+
+    /**
      * Given a String containing XML, parse it and return a DOM object representation (that is namespace aware).
-     * 
+     *
      * @param xmlString
      *            A string containing valid XML
      * @return
@@ -61,7 +68,7 @@ public class DOMUtil {
 
     /**
      * Given a String containing XML, parse it and return a DOM object representation
-     * 
+     *
      * @param xmlString
      *            A string containing valid XML
      * @param isNamespaceAware
@@ -81,7 +88,7 @@ public class DOMUtil {
 
     /**
      * Given a Stream containing XML, parse it and return a DOM object representation (that is namespace aware).
-     * 
+     *
      * @param xmlString
      *            A string containing valid XML
      * @return
@@ -93,7 +100,7 @@ public class DOMUtil {
 
     /**
      * Given a Stream containing XML, parse it and return a DOM object representation (that is namespace aware).
-     * 
+     *
      * @param xmlString
      *            A string containing valid XML
      * @return
@@ -110,7 +117,7 @@ public class DOMUtil {
 
     /**
      * Given a DOM (sub)tree generate a string representation with no formatting
-     * 
+     *
      * @param node
      *            The node to generate the XML for
      * @param omitXmlDeclaration
@@ -140,7 +147,7 @@ public class DOMUtil {
 
     /**
      * Compiles the specified XPath (as a string) into an XPathExpression.
-     * 
+     *
      * @param xPathStr
      *            A string representing a valid XPath expression
      * @param nc
@@ -150,8 +157,7 @@ public class DOMUtil {
      */
     public static XPathExpression compileXPathExpr(String xPathStr, NamespaceContext nc)
             throws XPathExpressionException {
-        //Force the usage of the Saxon XPath library
-        XPathFactory factory = new XPathFactoryImpl();
+        XPathFactory factory = getXPathFactory();
         XPath xPath = factory.newXPath();
         xPath.setNamespaceContext(nc);
         return xPath.compile(xPathStr);
@@ -159,15 +165,14 @@ public class DOMUtil {
 
     /**
      * Compiles the specified XPath (as a string) into an XPathExpression.
-     * 
+     *
      * @param xPathStr
      *            A string representing a valid XPath expression
      * @return
      * @throws XPathExpressionException
      */
     public static XPathExpression compileXPathExpr(String xPathStr) throws XPathExpressionException {
-        //Force the usage of the Saxon XPath library
-        XPathFactory factory = XPathFactory.newInstance();
+        XPathFactory factory = getXPathFactory();
         XPath xPath = factory.newXPath();
         return xPath.compile(xPathStr);
     }

--- a/src/main/java/org/auscope/portal/core/util/DOMUtil.java
+++ b/src/main/java/org/auscope/portal/core/util/DOMUtil.java
@@ -46,15 +46,6 @@ public class DOMUtil {
     }
 
     /**
-     * Utility for accessing a consistent XPathFactory (irregardless of what is on the classpath)
-     *
-     * @return
-     */
-    private static XPathFactory getXPathFactory() {
-        return new net.sf.saxon.xpath.XPathFactoryImpl();
-    }
-
-    /**
      * Given a String containing XML, parse it and return a DOM object representation (that is namespace aware).
      *
      * @param xmlString
@@ -157,7 +148,8 @@ public class DOMUtil {
      */
     public static XPathExpression compileXPathExpr(String xPathStr, NamespaceContext nc)
             throws XPathExpressionException {
-        XPathFactory factory = getXPathFactory();
+        //Use saxon explicitly for namespace aware XPath - it's much more performant
+        XPathFactory factory = new net.sf.saxon.xpath.XPathFactoryImpl();
         XPath xPath = factory.newXPath();
         xPath.setNamespaceContext(nc);
         return xPath.compile(xPathStr);
@@ -172,7 +164,9 @@ public class DOMUtil {
      * @throws XPathExpressionException
      */
     public static XPathExpression compileXPathExpr(String xPathStr) throws XPathExpressionException {
-        XPathFactory factory = getXPathFactory();
+        //Use JAXP for namespace unaware xpath - saxon doesnt handle this sort of behaviour
+        //http://stackoverflow.com/questions/21118051/namespace-unaware-xpath-expression-fails-if-saxon-is-on-the-classpath
+        XPathFactory factory = new org.apache.xpath.jaxp.XPathFactoryImpl();
         XPath xPath = factory.newXPath();
         return xPath.compile(xPathStr);
     }


### PR DESCRIPTION
compileXPathExpr (when not namespace aware) will offload to any given XPath provider. The whole point of this class is to make for a consistent provider.

We fix this by making the XPathFactory instantiating consistent with the namespace aware method.