### PR TITLE
Gpt 82 add service flag to csw record

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
@@ -71,6 +71,8 @@ public class CSWRecord {
 
     private boolean noCache;
 
+    private boolean service;
+    
     /**
      * Instantiates a new empty CSWRecord
      * 
@@ -584,7 +586,15 @@ public class CSWRecord {
         }
     }
 
-    /**
+    public boolean isService() {
+        return service;
+    }
+
+    public void setService(boolean service) {
+        this.service = service;
+    }
+
+	/**
      * Creates a hashcode based on this record's file identifier
      */
     @Override

--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecordTransformer.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecordTransformer.java
@@ -34,11 +34,20 @@ public class CSWRecordTransformer {
     protected Node mdMetadataNode;
 
     protected static final String DATEFORMATSTRING = "yyyy-MM-dd'T'HH:mm:ss";
-
+    
+    protected enum Scope {
+    	service, dataset
+    };
+    
     protected static final CSWNamespaceContext nc = new CSWNamespaceContext();
+    private static final String SERVICEIDENTIFICATIONPATH = "gmd:identificationInfo/srv:SV_ServiceIdentification";
+    private static final String DATAIDENTIFICATIONPATH = "gmd:identificationInfo/gmd:MD_DataIdentification";
+    private static final String TITLEEXPRESSION = "/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString";
+    
     private static final String DATESTAMPEXPRESSION = "gmd:dateStamp/gco:DateTime";
-    private static final String SERVICETITLEEXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString";
-    private static final String DATAIDENTIFICATIONABSTRACTEXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString";
+    private static final String SCOPEEXPRESSION = "gmd:hierarchyLevel/gmd:MD_ScopeCode/@codeListValue";    
+    private static final String ABSTRACTEXPRESSION = "/gmd:abstract/gco:CharacterString";
+
     private static final String CONTACTEXPRESSION = "gmd:contact/gmd:CI_ResponsibleParty";
     private static final String RESOURCEPROVIDEREXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:pointOfContact/gmd:CI_ResponsibleParty[./gmd:role[./gmd:CI_RoleCode[@codeListValue = 'resourceProvider']]]/gmd:organisationName/gco:CharacterString";
     private static final String FILEIDENTIFIEREXPRESSION = "gmd:fileIdentifier/gco:CharacterString";
@@ -531,8 +540,21 @@ public class CSWRecordTransformer {
         NodeList tempNodeList = null;
 
         //Parse our simple strings
-        record.setServiceName(evalXPathString(this.mdMetadataNode, SERVICETITLEEXPRESSION));
-        record.setDataIdentificationAbstract(evalXPathString(this.mdMetadataNode, DATAIDENTIFICATIONABSTRACTEXPRESSION));
+        Node scopeNode = evalXPathNode(this.mdMetadataNode, SCOPEEXPRESSION);
+        String recordType = scopeNode != null ? scopeNode.getNodeValue() : null;
+        
+        String identificationPath = null;
+        if (Scope.service.toString().equals(recordType)) {
+        	identificationPath = SERVICEIDENTIFICATIONPATH; 
+        	record.setService(true);
+        }
+        else {
+        	identificationPath = DATAIDENTIFICATIONPATH;
+        }
+      
+        record.setServiceName(evalXPathString(this.mdMetadataNode, identificationPath + TITLEEXPRESSION));  	
+        record.setDataIdentificationAbstract(evalXPathString(this.mdMetadataNode, identificationPath + ABSTRACTEXPRESSION));
+
         record.setFileIdentifier(evalXPathString(this.mdMetadataNode, FILEIDENTIFIEREXPRESSION));
         record.setParentIdentifier(evalXPathString(this.mdMetadataNode, PARENTIDENTIFIEREXPRESSION));
         record.setSupplementalInformation(evalXPathString(this.mdMetadataNode, SUPPLEMENTALINFOEXPRESSION));

--- a/src/main/java/org/auscope/portal/core/view/ViewCSWRecordFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewCSWRecordFactory.java
@@ -37,7 +37,8 @@ public class ViewCSWRecordFactory {
         obj.put("recordInfoUrl", record.getRecordInfoUrl());
         obj.put("description", record.getDataIdentificationAbstract());
         obj.put("noCache", record.getNoCache());
-
+        obj.put("service", record.isService());
+        
         CSWResponsibleParty rp = record.getContact();
         String adminArea = null;
         String contactOrg = "Unknown";

--- a/src/main/webapp/portal-core/js/portal/csw/CSWRecord.js
+++ b/src/main/webapp/portal-core/js/portal/csw/CSWRecord.js
@@ -35,7 +35,8 @@ Ext.define('portal.csw.CSWRecord', {
         { name: 'loading', type: 'boolean', defaultValue: false },//Whether this layer is currently loading data or not
         { name: 'layer', type: 'auto'}, // store the layer after it has been converted.        
         { name: 'active', type: 'boolean', defaultValue: false },//Whether this layer is current active on the map.
-        { name: 'customlayer', type: 'boolean', defaultValue: false } //If true, this layer is added from browse catalogue
+        { name: 'customlayer', type: 'boolean', defaultValue: false }, //If true, this layer is added from browse catalogue
+        { name: 'service', type: 'boolean', defaultValue: false } //If true, this layer is a service layer that may contain layers in the getCapabilities
     ],
 
     /**

--- a/src/main/webapp/portal-core/js/portal/layer/Layer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/Layer.js
@@ -123,7 +123,7 @@ Ext.define('portal.layer.Layer', {
         var results = [];
         var cswRecords=this.get('cswRecords');
         for(var i=0; i < cswRecords.length;i++){
-            if(cswRecords[i].containsOnlineResourceUrl(resourceURL)){
+            if(!cswRecords[i].containsOnlineResourceUrl || cswRecords[i].containsOnlineResourceUrl(resourceURL)){
                 results.push(cswRecords[i]);
             }            
         }

--- a/src/main/webapp/portal-core/js/portal/layer/Layer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/Layer.js
@@ -123,7 +123,7 @@ Ext.define('portal.layer.Layer', {
         var results = [];
         var cswRecords=this.get('cswRecords');
         for(var i=0; i < cswRecords.length;i++){
-            if(!cswRecords[i].containsOnlineResourceUrl || cswRecords[i].containsOnlineResourceUrl(resourceURL)){
+            if(cswRecords[i].containsOnlineResourceUrl(resourceURL)){
                 results.push(cswRecords[i]);
             }            
         }


### PR DESCRIPTION
This change allows the portals to differentiate between a service (ie a parent layer) and a dataset. 
For example, when displaying available layers from a getCapabilities request we use the service URL which returns all the layers, not just the layer of interest. getCapabilities does not allow a layername parameter like getMap does and I could not figure out any other way to interrogate the CSW record to learn whether it is a service. 