### PR TITLE
Alphanumerical layer ordering

### DIFF
--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -351,10 +351,7 @@ public class KnownLayer implements Serializable {
     }
 
     public void setOrder(String order) {
-        if (order == null) {
-        	order = "";
-        }
-    	this.order = order;
+    	this.order = (order == null) ? "" : order;
         logger.info(String.format("setOrder - group: %s, name: %s, order: %s", getGroup(), getName(), getOrder()));
     }
 }

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -66,7 +66,7 @@ public class KnownLayer implements Serializable {
     private int feature_count;
 
     /** Set an order - defaults to name */
-    private int order;
+    private String order;
 
     /**
      * Creates a new KnownLayer
@@ -346,12 +346,15 @@ public class KnownLayer implements Serializable {
         this.feature_count = feature_count;
     }
 
-    public int getOrder() {
+    public String getOrder() {
         return order;
     }
 
-    public void setOrder(int order) {
-        this.order = order;
-        logger.info(String.format("setOrder - group: %s, name: %s, order: %d", getGroup(), getName(), getOrder()));
+    public void setOrder(String order) {
+        if (order == null) {
+        	order = "";
+        }
+    	this.order = order;
+        logger.info(String.format("setOrder - group: %s, name: %s, order: %s", getGroup(), getName(), getOrder()));
     }
 }

--- a/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
+++ b/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
@@ -31,7 +31,7 @@ Ext.define('portal.knownlayer.KnownLayer', {
         { name: 'layer', type: 'auto'}, // store the layer after it has been converted.        
         { name: 'active', type: 'boolean', defaultValue: false },//Whether this layer is current active on the map.
         { name: 'feature_count', type: 'string'}, //GetFeatureInfo feature_count attribute, 0 would be to default to whatever is set on the server.
-        { name: 'order', type: 'int'}	// Order of the layers within a group
+        { name: 'order', type: 'string'}	// Order of the layers within a group
     ],
 
     /**


### PR DESCRIPTION
The order of layers can now be specified in alphanumerical format, e.g - 
 <property name="order" value="1_Geological Survey of Western Australia_5"/>