### PR TITLE
AUS-2608 Fixed a JS error that can occur with orphaned tooltips

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js
@@ -214,7 +214,13 @@ Ext.define('portal.widgets.grid.plugin.RowExpanderContainer', {
             // GPT-73 - If a container already existed it needs to be destroyed.  Since Singleton AppEvents holds a ref to it
             // it is never removed from memory (and worse, AppEvents keeps trying to broadcast to it).
             if (me.recordStatus[record.id].container) {
-                me.recordStatus[record.id].container.destroy();
+                //AUS-2608 - Wrapped this in a try-catch due to some tooltips getting orphaned and throwing a JS error when
+                //           trying to reference their dead parent.
+                try {
+                    me.recordStatus[record.id].container.destroy();
+                } catch(err) {
+                    console.log("Error destroying parent container:", err);
+                }
             }
             me.recordStatus[record.id].container = container;
             me.recordStatus[record.id].container.updateLayout({


### PR DESCRIPTION
There is a rare JS error that can occur with the RowExpanderContainer that is related to the regeneration of the internal containers.

Basically if there is a tooltip open and the panel is regenerated (you can trigger this on rare occasions by expanding a group/row with an open tooltip) you'll get a nasty JS error during component destruction.

There's not a whole lot we can do to stop it, we can however recover somewhat gracefully...

See: https://jira.csiro.au/browse/AUS-2608