### PR TITLE
Improved assertion errors when failing unit tests

### DIFF
--- a/src/main/java/org/auscope/portal/core/test/AssertViewUtility.java
+++ b/src/main/java/org/auscope/portal/core/test/AssertViewUtility.java
@@ -7,55 +7,54 @@ import org.springframework.ui.ModelMap;
 
 /**
  * Utility classes for testing views and modelmaps
- * 
+ *
  * @author vot002
  *
  */
 public class AssertViewUtility {
 
-    private static void assertEqual(Object expected, Object actual) {
+    private static void assertEqual(String message, Object expected, Object actual) {
         if (expected instanceof ModelMap) {
-            Assert.assertTrue(expected instanceof ModelMap);
+            Assert.assertTrue(message, expected instanceof ModelMap);
 
             assertModelMapsEqual((ModelMap) expected, (ModelMap) actual);
         } else if (expected instanceof List) {
-            Assert.assertTrue(actual instanceof List);
+            Assert.assertTrue(message, actual instanceof List);
 
             assertListsEqual((List) expected, (List) actual);
         } else {
-            Assert.assertEquals(expected, actual);
+            Assert.assertEquals(message, expected, actual);
         }
     }
 
     /**
      * Runs a number of assertions on the list (does a deep comparison)
-     * 
+     *
      * @param expected
      * @param actual
      */
     public static void assertListsEqual(List expected, List actual) {
-        Assert.assertEquals(expected.size(), actual.size());
+        Assert.assertEquals(String.format("Sizes vary. Expected %1$s, got %2$s", expected, actual), expected.size(), actual.size());
 
         for (int i = 0; i < expected.size(); i++) {
-            assertEqual(expected.get(i), actual.get(i));
+            assertEqual(String.format("Mismatch at index: %1$s. Expected %2$s but got %3$s", i, expected.get(i), actual.get(i)), expected.get(i), actual.get(i));
         }
     }
 
     /**
      * Runs a number of assertions on the specified model maps (does a deep comparison)
-     * 
+     *
      * @param expected
      * @param actual
      */
     public static void assertModelMapsEqual(ModelMap expected, ModelMap actual) {
-
-        Assert.assertEquals(expected.size(), actual.size());
+        Assert.assertEquals(String.format("Sizes vary. Expected %1$s, got %2$s", expected.keySet(), actual.keySet()), expected.size(), actual.size());
 
         for (String key : expected.keySet()) {
             Object expectedChild = expected.get(key);
             Object actualChild = actual.get(key);
 
-            assertEqual(expectedChild, actualChild);
+            assertEqual(String.format("Mismatch at key: %1$s. Expected %2$s but got %3$s", key, expectedChild, actualChild), expectedChild, actualChild);
         }
     }
 }


### PR DESCRIPTION
The unit test utility class for comparing ModelMaps is pretty bad at telling you WHERE in the model maps the difference lies. This is a minor improvement to make it a bit easier to figure out what's going wrong.