### PR TITLE
AUS-2613 Fixed img references to old openlayers

### DIFF
--- a/src/main/webapp/portal-core/jsimports-openlayers.htm
+++ b/src/main/webapp/portal-core/jsimports-openlayers.htm
@@ -39,7 +39,7 @@
 
 
     .olControlPanel .olControlDrawFeatureItemActive span:first-child {
-      background-image: url("portal-core/js/OpenLayers-2.12/theme/default/img/draw_polygon_off.png");
+      background-image: url("portal-core/js/OpenLayers-2.13.1/theme/default/img/draw_polygon_off.png");
       height: 22px;
       width: 24px;
       top: 5px;
@@ -50,7 +50,7 @@
     }
 
     .olControlPanel .olControlDrawFeatureItemInactive span:first-child {
-      background-image: url("portal-core/js/OpenLayers-2.12/theme/default/img/draw_polygon_off.png");
+      background-image: url("portal-core/js/OpenLayers-2.13.1/theme/default/img/draw_polygon_off.png");
       height: 22px;
       width: 24px;
       top: 5px;


### PR DESCRIPTION
Previous OpenLayers upgrade to 2.13.1 missed a few img references.