### PR TITLE
AUS-2614 Offloaded WCS XPath creation to DOMUtil

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/AxisDescriptionImpl.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/AxisDescriptionImpl.java
@@ -1,14 +1,15 @@
 package org.auscope.portal.core.services.responses.wcs;
 
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 
+import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
+import org.auscope.portal.core.util.DOMUtil;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
  * A simple (partial) implementation of the entire AxisDescription (Doesn't parse attributes)
- * 
+ *
  * @author vot002
  *
  */
@@ -20,24 +21,24 @@ public class AxisDescriptionImpl implements AxisDescription {
     private String label;
     private ValueEnumType[] values;
 
-    public AxisDescriptionImpl(Node node, XPath xPath) throws Exception {
+    public AxisDescriptionImpl(Node node, WCSNamespaceContext nc) throws Exception {
         Node tempNode;
 
         //optional
-        tempNode = (Node) xPath.evaluate("wcs:description", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:description", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null)
             description = tempNode.getTextContent();
 
-        tempNode = (Node) xPath.evaluate("wcs:name", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:name", nc).evaluate(node, XPathConstants.NODE);
         name = tempNode.getTextContent();
 
-        tempNode = (Node) xPath.evaluate("wcs:label", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:label", nc).evaluate(node, XPathConstants.NODE);
         label = tempNode.getTextContent();
 
-        NodeList tempNodeList = (NodeList) xPath.evaluate("wcs:values/wcs:*", node, XPathConstants.NODESET);
+        NodeList tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:values/wcs:*", nc).evaluate(node, XPathConstants.NODESET);
         values = new ValueEnumType[tempNodeList.getLength()];
         for (int i = 0; i < tempNodeList.getLength(); i++) {
-            values[i] = ValueEnumTypeFactory.parseFromNode(tempNodeList.item(i));
+            values[i] = ValueEnumTypeFactory.parseFromNode(tempNodeList.item(i), nc);
         }
     }
 

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/DescribeCoverageRecord.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/DescribeCoverageRecord.java
@@ -2,14 +2,14 @@ package org.auscope.portal.core.services.responses.wcs;
 
 import java.io.Serializable;
 
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
+import javax.xml.xpath.XPathExpression;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
 import org.auscope.portal.core.services.responses.ows.OWSExceptionParser;
+import org.auscope.portal.core.util.DOMUtil;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -108,24 +108,23 @@ public class DescribeCoverageRecord implements Serializable {
      * @throws Exception
      *             the exception
      */
-    private DescribeCoverageRecord(Node node, XPath xPath) throws Exception {
+    private DescribeCoverageRecord(Node node, WCSNamespaceContext nc) throws Exception {
         Node tempNode = null;
         NodeList tempNodeList = null;
 
-        tempNode = (Node) xPath.evaluate("wcs:description", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:description", nc).evaluate(node, XPathConstants.NODE);
         description = getTextContentOrEmptyString(tempNode);
 
-        tempNode = (Node) xPath.evaluate("wcs:name", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:name", nc).evaluate(node, XPathConstants.NODE);
         name = getTextContentOrEmptyString(tempNode);
 
-        tempNode = (Node) xPath.evaluate("wcs:label", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:label", nc).evaluate(node, XPathConstants.NODE);
         label = getTextContentOrEmptyString(tempNode);
 
         //We will get a list of <requestResponseCRSs> OR a list
         //of <requestCRSs> and <responseCRSs>
         //Lets parse one or the other
-        tempNodeList = (NodeList) xPath.evaluate("wcs:supportedCRSs/wcs:requestResponseCRSs", node,
-                XPathConstants.NODESET);
+        tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:supportedCRSs/wcs:requestResponseCRSs", nc).evaluate(node, XPathConstants.NODESET);
         if (tempNodeList.getLength() > 0) {
             supportedRequestCRSs = new String[tempNodeList.getLength()];
             supportedResponseCRSs = new String[tempNodeList.getLength()];
@@ -134,57 +133,55 @@ public class DescribeCoverageRecord implements Serializable {
                 supportedResponseCRSs[i] = getTextContentOrEmptyString(tempNodeList.item(i));
             }
         } else {
-            tempNodeList = (NodeList) xPath.evaluate("wcs:supportedCRSs/wcs:requestCRSs", node, XPathConstants.NODESET);
+            tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:supportedCRSs/wcs:requestCRSs", nc).evaluate(node, XPathConstants.NODESET);
             supportedRequestCRSs = new String[tempNodeList.getLength()];
             for (int i = 0; i < tempNodeList.getLength(); i++) {
                 supportedRequestCRSs[i] = getTextContentOrEmptyString(tempNodeList.item(i));
             }
 
-            tempNodeList = (NodeList) xPath
-                    .evaluate("wcs:supportedCRSs/wcs:responseCRSs", node, XPathConstants.NODESET);
+            tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:supportedCRSs/wcs:responseCRSs", nc).evaluate(node, XPathConstants.NODESET);
             supportedResponseCRSs = new String[tempNodeList.getLength()];
             for (int i = 0; i < tempNodeList.getLength(); i++) {
                 supportedResponseCRSs[i] = getTextContentOrEmptyString(tempNodeList.item(i));
             }
         }
 
-        tempNodeList = (NodeList) xPath.evaluate("wcs:supportedFormats/wcs:formats", node, XPathConstants.NODESET);
+        tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:supportedFormats/wcs:formats", nc).evaluate(node, XPathConstants.NODESET);
         supportedFormats = new String[tempNodeList.getLength()];
         for (int i = 0; i < tempNodeList.getLength(); i++) {
             supportedFormats[i] = getTextContentOrEmptyString(tempNodeList.item(i));
         }
 
-        tempNodeList = (NodeList) xPath.evaluate("wcs:supportedInterpolations/wcs:interpolationMethod", node,
-                XPathConstants.NODESET);
+        tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:supportedInterpolations/wcs:interpolationMethod", nc).evaluate(node, XPathConstants.NODESET);
         supportedInterpolations = new String[tempNodeList.getLength()];
         for (int i = 0; i < tempNodeList.getLength(); i++) {
             supportedInterpolations[i] = getTextContentOrEmptyString(tempNodeList.item(i));
         }
 
-        tempNodeList = (NodeList) xPath.evaluate("wcs:supportedCRSs/wcs:nativeCRSs", node, XPathConstants.NODESET);
+        tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:supportedCRSs/wcs:nativeCRSs", nc).evaluate(node, XPathConstants.NODESET);
         nativeCRSs = new String[tempNodeList.getLength()];
         for (int i = 0; i < tempNodeList.getLength(); i++) {
             nativeCRSs[i] = getTextContentOrEmptyString(tempNodeList.item(i));
         }
 
         //Parse our spatial domain (only grab gml:Envelopes and wcs:EnvelopeWithTimePeriod
-        tempNode = (Node) xPath.evaluate("wcs:domainSet/wcs:spatialDomain", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:domainSet/wcs:spatialDomain", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null) {
-            spatialDomain = new SpatialDomain(tempNode, xPath);
+            spatialDomain = new SpatialDomain(tempNode, nc);
         }
 
         //Get the temporal range (which is optional)
-        tempNode = (Node) xPath.evaluate("wcs:domainSet/wcs:temporalDomain", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:domainSet/wcs:temporalDomain", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null) {
-            tempNodeList = (NodeList) xPath.evaluate(XPATHALLCHILDREN, tempNode, XPathConstants.NODESET);
+            tempNodeList = (NodeList) DOMUtil.compileXPathExpr(XPATHALLCHILDREN, nc).evaluate(tempNode, XPathConstants.NODESET);
             temporalDomain = new TemporalDomain[tempNodeList.getLength()];
             for (int i = 0; i < tempNodeList.getLength(); i++) {
                 temporalDomain[i] = TemporalDomainFactory.parseFromNode(tempNodeList.item(i));
             }
         }
 
-        tempNode = (Node) xPath.evaluate("wcs:rangeSet/wcs:RangeSet", node, XPathConstants.NODE);
-        rangeSet = new RangeSetImpl(tempNode, xPath);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:rangeSet/wcs:RangeSet", nc).evaluate(node, XPathConstants.NODE);
+        rangeSet = new RangeSetImpl(tempNode, nc);
     }
 
     /**
@@ -314,16 +311,13 @@ public class DescribeCoverageRecord implements Serializable {
         //This is to make sure we actually receive a valid response
         OWSExceptionParser.checkForExceptionResponse(doc);
 
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        xPath.setNamespaceContext(new WCSNamespaceContext());
-
-        String serviceTitleExpression = "/wcs:CoverageDescription/wcs:CoverageOffering";
-
-        NodeList nodes = (NodeList) xPath.evaluate(serviceTitleExpression, doc, XPathConstants.NODESET);
+        WCSNamespaceContext nc = new WCSNamespaceContext();
+        XPathExpression xPath = DOMUtil.compileXPathExpr("/wcs:CoverageDescription/wcs:CoverageOffering", nc);
+        NodeList nodes = (NodeList) xPath.evaluate(doc, XPathConstants.NODESET);
 
         DescribeCoverageRecord[] records = new DescribeCoverageRecord[nodes.getLength()];
         for (int i = 0; i < nodes.getLength(); i++) {
-            records[i] = new DescribeCoverageRecord(nodes.item(i), xPath);
+            records[i] = new DescribeCoverageRecord(nodes.item(i), nc);
         }
 
         return records;

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/Interval.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/Interval.java
@@ -1,13 +1,14 @@
 package org.auscope.portal.core.services.responses.wcs;
 
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 
+import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
+import org.auscope.portal.core.util.DOMUtil;
 import org.w3c.dom.Node;
 
 /**
  * Represents a <wcs:interval> element from a WCS DescribeCoverage response
- * 
+ *
  * @author vot002
  */
 public class Interval implements ValueEnumType {
@@ -23,18 +24,18 @@ public class Interval implements ValueEnumType {
     private Double max;
     private Double resolution;
 
-    public Interval(Node node, XPath xPath) throws Exception {
+    public Interval(Node node, WCSNamespaceContext nc) throws Exception {
         type = node.getLocalName();
 
-        Node tempNode = (Node) xPath.evaluate("wcs:min", node, XPathConstants.NODE);
+        Node tempNode = (Node) DOMUtil.compileXPathExpr("wcs:min", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null)
             min = new Double(tempNode.getTextContent());
 
-        tempNode = (Node) xPath.evaluate("wcs:max", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:max", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null)
             max = new Double(tempNode.getTextContent());
 
-        tempNode = (Node) xPath.evaluate("wcs:resolution", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:resolution", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null)
             resolution = new Double(tempNode.getTextContent());
     }
@@ -45,7 +46,7 @@ public class Interval implements ValueEnumType {
 
     /**
      * Represents the minimum value on this interval (can be null)
-     * 
+     *
      * @return
      */
     public Double getMin() {
@@ -54,7 +55,7 @@ public class Interval implements ValueEnumType {
 
     /**
      * Represents the maximum value on this interval (can be null)
-     * 
+     *
      * @return
      */
     public Double getMax() {
@@ -63,7 +64,7 @@ public class Interval implements ValueEnumType {
 
     /**
      * Represents the resolution of this interval (can be null)
-     * 
+     *
      * @return
      */
     public Double getResolution() {

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/RangeSetImpl.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/RangeSetImpl.java
@@ -1,8 +1,9 @@
 package org.auscope.portal.core.services.responses.wcs;
 
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 
+import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
+import org.auscope.portal.core.util.DOMUtil;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
@@ -15,29 +16,27 @@ public class RangeSetImpl implements RangeSet {
     private ValueEnumType[] nullValues;
     private AxisDescription[] axisDescriptions;
 
-    public RangeSetImpl(Node node, XPath xPath) throws Exception {
-
-        Node tempNode = (Node) xPath.evaluate("wcs:description", node, XPathConstants.NODE);
+    public RangeSetImpl(Node node, WCSNamespaceContext nc) throws Exception {
+        Node tempNode = (Node) DOMUtil.compileXPathExpr("wcs:description", nc).evaluate(node, XPathConstants.NODE);
         if (tempNode != null)
             description = tempNode.getTextContent();
 
-        tempNode = (Node) xPath.evaluate("wcs:name", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:name", nc).evaluate(node, XPathConstants.NODE);
         name = tempNode.getTextContent();
 
-        tempNode = (Node) xPath.evaluate("wcs:label", node, XPathConstants.NODE);
+        tempNode = (Node) DOMUtil.compileXPathExpr("wcs:label", nc).evaluate(node, XPathConstants.NODE);
         label = tempNode.getTextContent();
 
-        NodeList tempNodeList = (NodeList) xPath.evaluate("wcs:axisDescription/wcs:AxisDescription", node,
-                XPathConstants.NODESET);
+        NodeList tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:axisDescription/wcs:AxisDescription", nc).evaluate(node, XPathConstants.NODESET);
         axisDescriptions = new AxisDescription[tempNodeList.getLength()];
         for (int i = 0; i < tempNodeList.getLength(); i++) {
-            axisDescriptions[i] = new AxisDescriptionImpl(tempNodeList.item(i), xPath);
+            axisDescriptions[i] = new AxisDescriptionImpl(tempNodeList.item(i), nc);
         }
 
-        tempNodeList = (NodeList) xPath.evaluate("wcs:nullValues/wcs:*", node, XPathConstants.NODESET);
+        tempNodeList = (NodeList) DOMUtil.compileXPathExpr("wcs:nullValues/wcs:*", nc).evaluate(node, XPathConstants.NODESET);
         nullValues = new ValueEnumType[tempNodeList.getLength()];
         for (int i = 0; i < tempNodeList.getLength(); i++) {
-            nullValues[i] = ValueEnumTypeFactory.parseFromNode(tempNodeList.item(i));
+            nullValues[i] = ValueEnumTypeFactory.parseFromNode(tempNodeList.item(i), nc);
         }
     }
 

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/SimpleEnvelope.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/SimpleEnvelope.java
@@ -2,16 +2,17 @@ package org.auscope.portal.core.services.responses.wcs;
 
 import java.io.Serializable;
 
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 
+import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
+import org.auscope.portal.core.util.DOMUtil;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 /**
  * This is a "stupid" representation of the spatial elements of a <gml:Envelope> from a WCS DescribeCoverage response
- * 
+ *
  * @author vot002
  *
  */
@@ -47,9 +48,9 @@ public class SimpleEnvelope implements Serializable {
         this.westBoundLongitude = westBoundLongitude;
     }
 
-    public SimpleEnvelope(Node node, XPath xPath) throws XPathExpressionException {
+    public SimpleEnvelope(Node node, WCSNamespaceContext nc) throws XPathExpressionException {
         //get our list of gml:Points and parse our spatial bounds
-        NodeList tempNodeList = (NodeList) xPath.evaluate("gml:pos", node, XPathConstants.NODESET);
+        NodeList tempNodeList = (NodeList) DOMUtil.compileXPathExpr("gml:pos", nc).evaluate(node, XPathConstants.NODESET);
         if (tempNodeList.getLength() != 2)
             throw new XPathExpressionException(String.format("%1$s:%2$s does not have 2 gml:pos nodes",
                     node.getNamespaceURI(), node.getLocalName()));
@@ -64,14 +65,14 @@ public class SimpleEnvelope implements Serializable {
         northBoundLatitude = Double.parseDouble(northEastPoints[1]);
 
         //Get our SRS name (can be null)
-        srsName = (String) xPath.evaluate("@srsName", node, XPathConstants.STRING);
+        srsName = (String) DOMUtil.compileXPathExpr("@srsName", new WCSNamespaceContext()).evaluate(node, XPathConstants.STRING);
 
         type = node.getLocalName();
     }
 
     /**
      * Gets the SRS Name of the ordinates this envelope is representing (Can be null/empty)
-     * 
+     *
      * @return
      */
     public String getSrsName() {
@@ -80,7 +81,7 @@ public class SimpleEnvelope implements Serializable {
 
     /**
      * Gets the southBoundLatitude of the bounding box
-     * 
+     *
      * @return
      */
     public double getSouthBoundLatitude() {
@@ -89,7 +90,7 @@ public class SimpleEnvelope implements Serializable {
 
     /**
      * Gets the northBoundLatitude of the bounding box
-     * 
+     *
      * @return
      */
     public double getNorthBoundLatitude() {
@@ -98,7 +99,7 @@ public class SimpleEnvelope implements Serializable {
 
     /**
      * Gets the eastBoundLongitude of the bounding box
-     * 
+     *
      * @return
      */
     public double getEastBoundLongitude() {
@@ -107,7 +108,7 @@ public class SimpleEnvelope implements Serializable {
 
     /**
      * Gets the westBoundLongitude of the bounding box
-     * 
+     *
      * @return
      */
     public double getWestBoundLongitude() {

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/SpatialDomain.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/SpatialDomain.java
@@ -2,7 +2,6 @@ package org.auscope.portal.core.services.responses.wcs;
 
 import java.io.Serializable;
 
-import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpressionException;
 
@@ -13,7 +12,7 @@ import org.w3c.dom.NodeList;
 
 /**
  * Represents any of the items that belong as children to a <wcs:spatialDomain> element in a DescribeCoverage response.
- * 
+ *
  * @author Josh Vote
  *
  */
@@ -36,18 +35,17 @@ public class SpatialDomain implements Serializable {
 
     /**
      * Creates a new spatial domain
-     * 
+     *
      * @param envelope
      * @param rectifiedGrid
      * @throws XPathExpressionException
      */
-    public SpatialDomain(Node node, XPath xPath) throws XPathExpressionException {
-        WCSNamespaceContext nc = new WCSNamespaceContext();
+    public SpatialDomain(Node node, WCSNamespaceContext nc) throws XPathExpressionException {
         NodeList envelopeNodes = (NodeList) DOMUtil.compileXPathExpr(
                 "wcs:Envelope | gml:Envelope | wcs:EnvelopeWithTimePeriod", nc).evaluate(node, XPathConstants.NODESET);
         this.envelopes = new SimpleEnvelope[envelopeNodes.getLength()];
         for (int i = 0; i < envelopeNodes.getLength(); i++) {
-            this.envelopes[i] = new SimpleEnvelope(envelopeNodes.item(i), xPath);
+            this.envelopes[i] = new SimpleEnvelope(envelopeNodes.item(i), nc);
         }
 
         Node gridNode = (Node) DOMUtil.compileXPathExpr("gml:RectifiedGrid", nc).evaluate(node, XPathConstants.NODE);
@@ -58,7 +56,7 @@ public class SpatialDomain implements Serializable {
 
     /**
      * The envelopes (if any) associated with this spatial domain). Can be null
-     * 
+     *
      * @return
      */
     public SimpleEnvelope[] getEnvelopes() {
@@ -67,7 +65,7 @@ public class SpatialDomain implements Serializable {
 
     /**
      * Returns the RectifiedGrid (if any) associated with this spatial domain. Can be null.
-     * 
+     *
      * @return
      */
     public RectifiedGrid getRectifiedGrid() {

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/ValueEnumTypeFactory.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/ValueEnumTypeFactory.java
@@ -1,27 +1,21 @@
 package org.auscope.portal.core.services.responses.wcs;
 
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathFactory;
-
 import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
 import org.w3c.dom.Node;
 
 public class ValueEnumTypeFactory {
     /**
      * Generates a SimpleTimePosition or SimpleTimePeriod instance from a child of a <wcs:temporalDomain> element
-     * 
+     *
      * @param node
      *            must be referencing a child from a <wcs:temporalDomain> node.
      * @return
      */
-    public static ValueEnumType parseFromNode(Node node) throws Exception {
-        XPath xPath = XPathFactory.newInstance().newXPath();
-        xPath.setNamespaceContext(new WCSNamespaceContext());
-
+    public static ValueEnumType parseFromNode(Node node, WCSNamespaceContext nc) throws Exception {
         if (node.getLocalName().equals("singleValue")) {
             return new SingleValue(node);
         } else if (node.getLocalName().equals("interval")) {
-            return new Interval(node, xPath);
+            return new Interval(node, nc);
         } else {
             throw new IllegalArgumentException("Unable to parse " + node.getLocalName());
         }


### PR DESCRIPTION
The WCS DescribeCoverageRecord currently manages all of its own XPath libraries which is a bit silly when we have DOMUtil to do that for us. Under certain environments this can cause all sorts of headaches.

The fix is to replace all the manual XPath generation with calls to DOMUtil