### PR TITLE
AUS-2609 Downloader to better support variable file extensions

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/http/download/DownloadTracker.java
+++ b/src/main/java/org/auscope/portal/core/server/http/download/DownloadTracker.java
@@ -52,7 +52,7 @@ public class DownloadTracker {
 
     /**
      * To get a reference to an instance of the tracker. Each email address acts as a token and is only allowed 1 instance of a tracker
-     * 
+     *
      * @param email
      *            : unique token to identify the tracker and its user
      * @return a reference to a DownloadTracker instance
@@ -74,7 +74,7 @@ public class DownloadTracker {
 
     /**
      * This method cleans up the downloadTracker map object and frees up memory
-     * 
+     *
      * @param timeAllowance
      *            : how much time do we allow the object to sit in memory.
      */
@@ -99,13 +99,25 @@ public class DownloadTracker {
 
     /**
      * Creates a background thread to commence the download
-     * 
+     *
      * @param smd
      *            - ServiceDownloadManager {@link ServiceDownloadManager}
      * @throws InCompleteDownloadException
      *             {@link InCompleteDownloadException}
      */
     public synchronized void startTrack(ServiceDownloadManager sdm) throws InCompleteDownloadException {
+        startTrack(sdm, null);
+    }
+
+    /**
+     * Creates a background thread to commence the download
+     *
+     * @param smd
+     *            - ServiceDownloadManager {@link ServiceDownloadManager}
+     * @throws InCompleteDownloadException
+     *             {@link InCompleteDownloadException}
+     */
+    public synchronized void startTrack(ServiceDownloadManager sdm, String extensionOverride) throws InCompleteDownloadException {
 
         if (this.downloadProgress == Progression.INPROGRESS) {
             throw new InCompleteDownloadException(
@@ -115,7 +127,7 @@ public class DownloadTracker {
                 this.downloadProgress = Progression.INPROGRESS;
             }
         }
-        Process p = new Process(sdm);
+        Process p = new Process(sdm, extensionOverride);
         ExecutorService pool = Executors.newSingleThreadExecutor();
         pool.execute(p);
         pool.shutdown();
@@ -124,7 +136,7 @@ public class DownloadTracker {
 
     /**
      * Retrieve the file after download as stream
-     * 
+     *
      * @return
      * @throws InCompleteDownloadException
      *             {@link InCompleteDownloadException}
@@ -141,7 +153,7 @@ public class DownloadTracker {
 
     /**
      * Retrieve the file after download as a file handle
-     * 
+     *
      * @return
      * @throws InCompleteDownloadException
      * @throws FileNotFoundException
@@ -157,7 +169,7 @@ public class DownloadTracker {
 
     /**
      * return the time of last completion
-     * 
+     *
      * @return time of last completion
      */
     public long getLastCompletedTime() {
@@ -174,7 +186,7 @@ public class DownloadTracker {
 
     /**
      * get current progress of download
-     * 
+     *
      * @return download progress
      */
     public Progression getProgress() {
@@ -183,17 +195,19 @@ public class DownloadTracker {
 
     /**
      * A runnable thread to executed in the background to perform download
-     * 
+     *
      * @author tey006
      *
      */
     public class Process implements Runnable {
         ServiceDownloadManager sdm;
+        String extensionOverride;
 
         // File file;
 
-        public Process(ServiceDownloadManager sdm) {
+        public Process(ServiceDownloadManager sdm, String extensionOverride) {
             this.sdm = sdm;
+            this.extensionOverride = extensionOverride;
             // this.file=file;
         }
 
@@ -215,7 +229,7 @@ public class DownloadTracker {
                 fos = new FileOutputStream(file);
                 zout = new ZipOutputStream(fos);
                 ArrayList<DownloadResponse> gmlDownloads = sdm.downloadAll();
-                FileIOUtil.writeResponseToZip(gmlDownloads, zout);
+                FileIOUtil.writeResponseToZip(gmlDownloads, zout, this.extensionOverride);
                 zout.finish();
                 zout.flush();
                 zout.close();

--- a/src/main/java/org/auscope/portal/core/util/FileIOUtil.java
+++ b/src/main/java/org/auscope/portal/core/util/FileIOUtil.java
@@ -438,7 +438,7 @@ public class FileIOUtil {
 
                     zout.putNextEntry(new ZipEntry(new SimpleDateFormat(
                             (i + 1) + "_yyyyMMdd_HHmmss").format(new Date())
-                            + extension));
+                            + (extension == null ? ".xml" : extension)));
                     zout.write(gmlBytes);
                     zout.closeEntry();
                 }

--- a/src/main/java/org/auscope/portal/core/util/MimeUtil.java
+++ b/src/main/java/org/auscope/portal/core/util/MimeUtil.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 /**
  * Utilities for MIME types
- * 
+ *
  * @author Josh Vote
  */
 public class MimeUtil {
@@ -64,6 +64,8 @@ public class MimeUtil {
             return "kmz";
         } else if (mime.contains("xml")) {
             return "xml";
+        } else if (mime.contains("csv")) {
+            return "csv";
         }
 
         return "";

--- a/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/KLWFSDownloader.js
+++ b/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/KLWFSDownloader.js
@@ -438,10 +438,10 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
         var sUrl = '<iframe id="nav1" style="overflow:auto;width:100%;height:100%;" frameborder="0" src="';
 
         sUrl += 'downloadGMLAsZip.do?';
-        sUrl += "email=";
-        sUrl += email;
-
-
+        sUrl += "outputFormat=";
+        sUrl += escape(outputFormat);
+        sUrl += "&email=";
+        sUrl += escape(email);
 
 
         //Iterate our WFS records and generate the array of PORTAL BACKEND requests that will be


### PR DESCRIPTION
The Download code in AuScope essentially makes a series of HTTP requests and bundles the results into a ZIP file, appending an arbitrary XML file extension.

This obviously doesn't work well with CSV downloads (supported by some WFS) so this PR attempts to add an override where the file extension can be forced at the controller level.