### PR TITLE
AUS-2615 Deprecated KMLParser for GMLParser

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/controllers/BasePortalController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/BasePortalController.java
@@ -70,7 +70,7 @@ public abstract class BasePortalController {
 
     /**
      * Utility method to generate a standard ModelAndView response for rendering JSON
-     * 
+     *
      * @param success
      *            The result of the operation
      * @return
@@ -81,7 +81,7 @@ public abstract class BasePortalController {
 
     /**
      * Utility method to generate a standard ModelAndView response for rendering JSON
-     * 
+     *
      * @param success
      *            The result of the operation
      * @param data
@@ -96,7 +96,7 @@ public abstract class BasePortalController {
 
     /**
      * Utility method to generate a standard ModelAndView response for rendering JSON
-     * 
+     *
      * @param success
      *            The result of the operation
      * @param data
@@ -113,7 +113,7 @@ public abstract class BasePortalController {
 
     /**
      * Utility method to generate a standard ModelAndView response for rendering JSON
-     * 
+     *
      * @param success
      *            The result of the operation
      * @param data
@@ -131,8 +131,8 @@ public abstract class BasePortalController {
     }
 
     /**
-     * Generates a JSON response containing WFS response info
-     * 
+     * Generates a JSON response containing WFS response info. The response data will be injected with a configurable name
+     *
      * @param success
      *            The result of the operation
      * @param gml
@@ -143,27 +143,16 @@ public abstract class BasePortalController {
      *            The method used to make the request (used for populating debug info)
      * @return
      */
-    protected ModelAndView generateJSONResponseMAV(boolean success, String gml, String kml, HttpRequestBase method) {
-
-        if (kml == null || kml.isEmpty()) {
-            log.error("Transform failed");
-            log.error("Input GML: "+gml);
-            return generateJSONResponseMAV(false, null, OPERATION_FAILED);
-        }
-
-        ModelMap data = new ModelMap();
-
-        data.put("gml", gml);
-        data.put("kml", kml);
-
+    protected ModelAndView generateNamedJSONResponseMAV(boolean success, String name, String data, HttpRequestBase method) {
+        ModelMap model = new ModelMap();
+        model.put(name, data);
         ModelMap debug = makeDebugInfoModel(method);
-
-        return generateJSONResponseMAV(success, data, "", debug);
+        return generateJSONResponseMAV(success, model, "", debug);
     }
 
     /**
      * Utility method to generate a standard ModelAndView response for rendering JSON
-     * 
+     *
      * @param success
      *            The result of the operation
      * @param data
@@ -187,7 +176,7 @@ public abstract class BasePortalController {
     /**
      * Utility method to generate a HTML MAV response. This will be identical in content to generateJSONResponseMAV but will be set to use a HTML content type.
      * Use this for overcoming weirdness with Ext JS and file uploads.
-     * 
+     *
      * @param success
      *            The result of the operation
      * @param data
@@ -203,7 +192,7 @@ public abstract class BasePortalController {
     /**
      * Utility method to generate a HTML MAV response. This will be identical in content to generateJSONResponseMAV but will be set to use a HTML content type.
      * Use this for overcoming weirdness with Ext JS and file uploads.
-     * 
+     *
      * @param success
      *            The result of the operation
      * @param data
@@ -224,7 +213,7 @@ public abstract class BasePortalController {
 
     /**
      * Turns a HttpRequest into a Map of url - the URI of request info - [Optional] The body of the request if relevant (for POST)
-     * 
+     *
      * @param request
      *            cannot be null
      * @return
@@ -257,7 +246,7 @@ public abstract class BasePortalController {
 
     /**
      * Exception resolver that maps exceptions to views presented to the user.
-     * 
+     *
      * @param e
      *            The exception
      * @param serviceUrl
@@ -270,7 +259,7 @@ public abstract class BasePortalController {
 
     /**
      * Exception resolver that maps exceptions to views presented to the user.
-     * 
+     *
      * @param e
      *            The exception
      * @param serviceUrl

--- a/src/main/java/org/auscope/portal/core/services/BaseWFSService.java
+++ b/src/main/java/org/auscope/portal/core/services/BaseWFSService.java
@@ -4,7 +4,6 @@ import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.xml.xpath.XPathConstants;
 import javax.xml.xpath.XPathExpression;
@@ -17,9 +16,8 @@ import org.auscope.portal.core.services.namespaces.WFSNamespaceContext;
 import org.auscope.portal.core.services.responses.ows.OWSExceptionParser;
 import org.auscope.portal.core.services.responses.wfs.WFSCountResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSGetCapabilitiesResponse;
-import org.auscope.portal.core.services.responses.wfs.WFSTransformedResponse;
+import org.auscope.portal.core.services.responses.wfs.WFSResponse;
 import org.auscope.portal.core.util.DOMUtil;
-import org.auscope.portal.core.xslt.PortalXSLTTransformer;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -40,15 +38,11 @@ public abstract class BaseWFSService {
 
     /**
      * Creates a new instance of this class with the specified dependencies
-     * 
+     *
      * @param httpServiceCaller
      *            Will be used for making requests
      * @param wfsMethodMaker
      *            Will be used for generating WFS methods
-     * @param gmlToKml
-     *            Will be used for transforming GML (WFS responses) into KML
-     * @param gmlToHtml
-     *            Will be used for transforming GML (WFS responses) into HTML
      */
     public BaseWFSService(HttpServiceCaller httpServiceCaller,
             WFSGetFeatureMethodMaker wfsMethodMaker) {
@@ -58,7 +52,7 @@ public abstract class BaseWFSService {
 
     /**
      * Utility method for choosing the correct WFS method to generate based on specified parameters
-     * 
+     *
      * @param wfsUrl
      *            [required] - the web feature service url
      * @param featureType
@@ -92,7 +86,7 @@ public abstract class BaseWFSService {
 
     /**
      * Utility method for choosing the correct WFS method to generate based on specified parameters
-     * 
+     *
      * @param wfsUrl
      *            [required] - the web feature service url
      * @param featureType
@@ -163,26 +157,19 @@ public abstract class BaseWFSService {
     /**
      * Executes a method that returns GML wrapped in a WFS response, converts that response using transformer and returns the lot bundled in a
      * WFSTransformedResponse
-     * 
+     *
      * @param method
      *            a WFS GetFeature request
-     * @param transformer
-     *            A transformer to work with the resulting WFS response
-     * @param styleSheetParams
-     *            Properties to apply to the transformer
      * @return
      * @throws PortalServiceException
      */
-    protected WFSTransformedResponse getTransformedWFSResponse(HttpRequestBase method,
-            PortalXSLTTransformer transformer, Properties styleSheetParams) throws PortalServiceException {
+    protected WFSResponse getWFSResponse(HttpRequestBase method) throws PortalServiceException {
         try {
             //Make the request and parse the response
             String responseString = httpServiceCaller.getMethodResponseAsString(method);
             OWSExceptionParser.checkForExceptionResponse(responseString);
 
-            String transformed = transformer.convert(responseString, styleSheetParams);
-
-            return new WFSTransformedResponse(responseString, transformed, method);
+            return new WFSResponse(responseString, method);
         } catch (Exception ex) {
             throw new PortalServiceException(method, ex);
         }
@@ -227,7 +214,7 @@ public abstract class BaseWFSService {
                     "wfs:WFS_Capabilities/wfs:FeatureTypeList/wfs:FeatureType/wfs:MetadataURL", new WFSNamespaceContext());
             NodeList metadataURLNodes = (NodeList) xPathGetMetadataURL.evaluate(responseDoc, XPathConstants.NODESET);
             Map<String, String> metadataURLs = new HashMap<String, String>();
-                        
+
             for (int i = 0; i < nameNodes.getLength(); i++) {
                 String typeName = nameNodes.item(i).getTextContent();
                 typeNames[i] = typeName;
@@ -241,7 +228,7 @@ public abstract class BaseWFSService {
             parsedGetCap.setFeatureTypes(typeNames);
             parsedGetCap.setFeatureAbstracts(featureAbstracts);
             parsedGetCap.setMetadataURLs(metadataURLs);
-            
+
             return parsedGetCap;
         } catch (Exception e) {
             throw new PortalServiceException(method, e);
@@ -255,7 +242,7 @@ public abstract class BaseWFSService {
 
     /**
      * Download a wfs based on the type and filter.
-     * 
+     *
      * @param serviceUrl
      *            a Web Feature Service URL
      * @param type
@@ -281,7 +268,7 @@ public abstract class BaseWFSService {
 
     /**
      * Download a CSV based on the type and filter.
-     * 
+     *
      * @param serviceUrl
      *            a Web Feature Service URL
      * @param type

--- a/src/main/java/org/auscope/portal/core/services/responses/wfs/WFSResponse.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wfs/WFSResponse.java
@@ -4,41 +4,41 @@ import org.apache.http.client.methods.HttpRequestBase;
 
 /**
  * Simplified view of a response from a WFS
- * 
+ *
  * @author Josh Vote
  */
 public class WFSResponse {
-    /** The response gml */
-    private String gml;
+    /** The response data */
+    private String data;
 
     /** The method used to make the request */
     private HttpRequestBase method;
 
     /**
      * Creates a new instance of this class
-     * 
-     * @param gml
+     *
+     * @param data
      *            The original WFS response as returned by the service
      * @param method
      *            the method used to make the request
      */
-    public WFSResponse(String gml, HttpRequestBase method) {
-        this.gml = gml;
+    public WFSResponse(String data, HttpRequestBase method) {
+        this.data = data;
         this.method = method;
     }
 
     /**
      * Gets the original WFS response as returned by the service
-     * 
+     *
      * @return
      */
-    public String getGml() {
-        return gml;
+    public String getData() {
+        return data;
     }
 
     /**
      * Gets the method used to make the request
-     * 
+     *
      * @return
      */
     public HttpRequestBase getMethod() {

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureRenderer.js
@@ -77,7 +77,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureRenderer', {
     _handleDownloadManagerSuccess : function(dm, actualFilterParams, data, debugInfo, onlineResource, layer, icon) {
         var me = this;
         //Parse our KML into a set of overlays and markers
-        var parser = Ext.create('portal.layer.renderer.wfs.KMLParser', {kml : data.kml, map : me.map});
+        var parser = Ext.create('portal.layer.renderer.wfs.GMLParser', {gml : data.gml, map : me.map});
         var primitives = parser.makePrimitives(icon, onlineResource, layer);
 
         //Add our single points and overlays to the overlay manager (which will add them to the map)

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
@@ -89,7 +89,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
     _handleDownloadManagerSuccess : function(dm, actualFilterParams, data, debugInfo, onlineResource, layer, icon) {
         var me = this;
         //Parse our KML into a set of overlays and markers
-        var parser = Ext.create('portal.layer.renderer.wfs.KMLParser', {kml : data.kml, map : me.map});
+        var parser = Ext.create('portal.layer.renderer.wfs.GMLParser', {kml : data.gml, map : me.map});
         var primitives = parser.makePrimitives(icon, onlineResource, layer);
 
         //Add our single points and overlays to the overlay manager (which will add them to the map)

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
@@ -89,7 +89,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
     _handleDownloadManagerSuccess : function(dm, actualFilterParams, data, debugInfo, onlineResource, layer, icon) {
         var me = this;
         //Parse our KML into a set of overlays and markers
-        var parser = Ext.create('portal.layer.renderer.wfs.GMLParser', {kml : data.gml, map : me.map});
+        var parser = Ext.create('portal.layer.renderer.wfs.GMLParser', {gml : data.gml, map : me.map});
         var primitives = parser.makePrimitives(icon, onlineResource, layer);
 
         //Add our single points and overlays to the overlay manager (which will add them to the map)

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/GMLParser.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/GMLParser.js
@@ -1,0 +1,198 @@
+/**
+ * A class for parsing a GML document into a list of Marker and Overlay primitives.
+ */
+Ext.define('portal.layer.renderer.wfs.GMLParser', {
+    /**
+     * portal.map.BaseMap - The map to generate primitives for
+     */
+    map : null,
+
+
+    /**
+     * Must the following config
+     * {
+     *  gml - string - a String of KML that will be parsed
+     *  map - portal.map.BaseMap - The map to generate primitives for
+     * }
+     */
+    constructor : function(config) {
+        this.rootNode = portal.util.xml.SimpleDOM.parseStringToDOM(config.gml);
+        this.map = config.map;
+        this.callParent(arguments);
+    },
+
+    //Given a series of space seperated tuples, return a list of portal.map.Point
+    generateCoordList : function(coordsAsString, srsName) {
+        var coordinateList = coordsAsString.split(' ');
+        var parsedCoordList = [];
+        
+        for (var i = 0; i < coordinateList.length; i+=2) {
+            this.forceLonLat(coordinateList, srsName, i);
+
+            parsedCoordList.push(Ext.create('portal.map.Point', {
+                latitude : parseFloat(coordinateList[i + 1]),
+                longitude : parseFloat(coordinateList[i])
+            }));
+        }
+
+        return parsedCoordList;
+    },
+    
+    getSrsName : function(node) {
+        var srsName = node.getAttribute("srsName");
+        if (Ext.isEmpty(srsName)) {
+            srsName = node.getAttribute("srs");
+        }
+        
+        if (!srsName) {
+            return '';
+        }
+        
+        return srsName;
+    },
+    
+    /**
+     * Forces lon/lat coords into coords (an array). Swaps coords[offset] and coords[offset + 1] if srsName requires it
+     */
+    forceLonLat : function(coords, srsName, offset) {
+        if (!offset) {
+            offset = 0;
+        }
+        
+        if (srsName.startsWith('http://www.opengis.net/gml/srs/epsg.xml#4283')) {
+            //lat/lon
+            var tmp = coords[offset];
+            coords[offset] = coords[offset + 1];
+            coords[offset + 1] = tmp;
+        } else if (srsName.startsWith('EPSG') ||
+                   srsName.startsWith('http://www.opengis.net/gml/srs/epsg.xml') ||
+                   srsName.startsWith('urn:x-ogc:def:crs:EPSG')) {
+            //lon/lat (no action required)
+        } else {
+            //fallback to lat/lon
+            var tmp = coords[offset];
+            coords[offset] = coords[offset + 1];
+            coords[offset + 1] = tmp;
+        }
+    },
+
+    parseLineString : function(onlineResource, layer, name, description, lineStringNode) {
+        var srsName = this.getSrsName(lineStringNode);
+        var parsedCoordList = this.generateCoordList(portal.util.xml.SimpleDOM.getNodeTextContent(lineStringNode.getElementsByTagName("gml:posList")[0]), srsName);
+        if (parsedCoordList.length === 0) {
+            return null;
+        }
+
+        //I've seen a few lines come in with start/end points being EXACTLY the same with no other points. These can be ignored
+        if (parsedCoordList.length === 2) {
+            if (parsedCoordList[0].getLongitude() === parsedCoordList[1].getLongitude() &&
+                parsedCoordList[0].getLatitude() === parsedCoordList[1].getLatitude()) {
+                return null;
+            }
+        }
+        
+        return this.map.makePolyline(name, undefined, onlineResource, layer, parsedCoordList, '#FF0000', 3, 1);
+    },
+
+    //Given a root placemark node attempt to parse it as a single point and return it
+    //Returns a single portal.map.primitives.Polygon
+    parsePolygon : function(onlineResource, layer, name, description, polygonNode) {
+        var srsName = this.getSrsName(polygonNode);
+        var parsedCoordList = this.generateCoordList(portal.util.xml.SimpleDOM.getNodeTextContent(polygonNode.getElementsByTagName("gml:posList")[0]), srsName);
+        if (parsedCoordList.length === 0) {
+            return null;
+        }
+        
+        //I've seen a few lines come in with start/end points being EXACTLY the same with no other points. These can be ignored
+        if (parsedCoordList.length === 2) {
+            if (parsedCoordList[0].getLongitude() === parsedCoordList[1].getLongitude() &&
+                parsedCoordList[0].getLatitude() === parsedCoordList[1].getLatitude()) {
+                return null;
+            }
+        }
+
+        return this.map.makePolygon(name, undefined, onlineResource, layer, parsedCoordList, undefined, undefined,0.7,undefined,0.6);
+    },
+
+    //Given a root placemark node attempt to parse it as a single point and return it
+    //Returns a single portal.map.primitives.Marker
+    parsePoint : function(onlineResource, layer, name, description, icon, pointNode) {
+        var rawPoints = portal.util.xml.SimpleDOM.getNodeTextContent(pointNode.getElementsByTagName("gml:pos")[0]);
+        var coordinates = rawPoints.split(' ');
+        if (!coordinates || coordinates.length < 2) {
+            return null;
+        }
+        
+        //Workout whether we are lat/lon or lon/lat
+        var srsName = this.getSrsName(pointNode);
+        this.forceLonLat(coordinates, srsName);
+
+        var lon = coordinates[0];
+        var lat = coordinates[1];
+        var point = Ext.create('portal.map.Point', {latitude : parseFloat(lat), longitude : parseFloat(lon)});
+        return this.map.makeMarker(name, description, undefined, onlineResource, layer, point, icon);
+    },
+
+    makePrimitives : function(icon, onlineResource, layer) {
+        var primitives = [];
+        var wfsFeatureCollection = portal.util.xml.SimpleDOM.getMatchingChildNodes(this.rootNode, null, "FeatureCollection");
+
+        //Read through our wfs:FeatureCollection and gml:featureMember(s) elements
+        if (Ext.isEmpty(wfsFeatureCollection)) {
+            return primitives;
+        }
+        var featureMembers = portal.util.xml.SimpleDOM.getMatchingChildNodes(wfsFeatureCollection[0], null, "featureMembers");
+        if (Ext.isEmpty(featureMembers)) {
+            featureMembers = portal.util.xml.SimpleDOM.getMatchingChildNodes(wfsFeatureCollection[0], null, "featureMember");
+        }
+        if (Ext.isEmpty(featureMembers)) {
+            return primitives;
+        }
+        var features = featureMembers[0].childNodes;
+        
+        for(var i = 0; i < features.length; i++) {
+            //Pull out some general stuff that we expect all features to have
+            var featureNode = features[i]; 
+            var name = featureNode.getAttribute('gml:id');
+            var description = portal.util.xml.SimpleXPath.evaluateXPath(this.rootNode, featureNode, "gml:description", portal.util.xml.SimpleXPath.XPATH_STRING_TYPE).stringValue;
+            if (Ext.isEmpty(description)) {
+                description = portal.util.xml.SimpleXPath.evaluateXPath(this.rootNode, featureNode, "gml:name", portal.util.xml.SimpleXPath.XPATH_STRING_TYPE).stringValue;
+                if (Ext.isEmpty(description)) {
+                    description = name; //resort to gml ID if we have to
+                }
+            }
+            
+            //Look for geometry under this feature
+            var pointNodes = featureNode.getElementsByTagName("gml:Point");
+            var polygonNodes = featureNode.getElementsByTagName("gml:Polygon");
+            var lineStringNodes = featureNode.getElementsByTagName("gml:LineString");
+            
+            //Parse the geometry we found into map primitives
+            for (var geomIndex = 0; geomIndex < polygonNodes.length; geomIndex++) {
+                mapItem = this.parsePolygon(onlineResource, layer, name, description, polygonNodes[geomIndex]);
+                if (mapItem !== null) {
+                    primitives.push(mapItem);
+                }
+            }
+            
+            for (var geomIndex = 0; geomIndex < pointNodes.length; geomIndex++) {
+                mapItem = this.parsePoint(onlineResource, layer, name, description, icon, pointNodes[geomIndex]);
+                if (mapItem !== null) {
+                    primitives.push(mapItem);
+                }
+            }
+            
+            for (var geomIndex = 0; geomIndex < lineStringNodes.length; geomIndex++) {
+                mapItem = this.parseLineString(onlineResource, layer, name, description, lineStringNodes[geomIndex]);
+                if (mapItem !== null) {
+                    primitives.push(mapItem);
+                }
+            }
+        }
+
+
+        return primitives;
+    }
+});
+
+

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/GMLParser.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/GMLParser.js
@@ -59,20 +59,17 @@ Ext.define('portal.layer.renderer.wfs.GMLParser', {
             offset = 0;
         }
         
-        if (srsName.startsWith('http://www.opengis.net/gml/srs/epsg.xml#4283')) {
+        if (srsName.startsWith('http://www.opengis.net/gml/srs/epsg.xml#4283') || 
+            srsName.startsWith('urn:x-ogc:def:crs:EPSG')) {
             //lat/lon
             var tmp = coords[offset];
             coords[offset] = coords[offset + 1];
             coords[offset + 1] = tmp;
         } else if (srsName.startsWith('EPSG') ||
-                   srsName.startsWith('http://www.opengis.net/gml/srs/epsg.xml') ||
-                   srsName.startsWith('urn:x-ogc:def:crs:EPSG')) {
+                   srsName.startsWith('http://www.opengis.net/gml/srs/epsg.xml')) {
             //lon/lat (no action required)
         } else {
-            //fallback to lat/lon
-            var tmp = coords[offset];
-            coords[offset] = coords[offset + 1];
-            coords[offset + 1] = tmp;
+            //fallback to lon/lat
         }
     },
 
@@ -189,7 +186,6 @@ Ext.define('portal.layer.renderer.wfs.GMLParser', {
                 }
             }
         }
-
 
         return primitives;
     }

--- a/src/main/webapp/portal-core/jsimports.htm
+++ b/src/main/webapp/portal-core/jsimports.htm
@@ -114,6 +114,7 @@
 <script src="portal-core/js/portal/layer/renderer/wfs/FeatureRenderer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/renderer/wfs/KMLParser.js" type="text/javascript"></script>
+<script src="portal-core/js/portal/layer/renderer/wfs/GMLParser.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/renderer/csw/CSWRenderer.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/layer/renderer/kml/KMLRenderer.js" type="text/javascript"></script>
 

--- a/src/test/java/org/auscope/portal/core/services/TestBaseWFSService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestBaseWFSService.java
@@ -11,7 +11,7 @@ import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;
 import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker.ResultType;
 import org.auscope.portal.core.services.responses.wfs.WFSCountResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSGetCapabilitiesResponse;
-import org.auscope.portal.core.services.responses.wfs.WFSTransformedResponse;
+import org.auscope.portal.core.services.responses.wfs.WFSResponse;
 import org.auscope.portal.core.test.PortalTestClass;
 import org.auscope.portal.core.test.ResourceUtil;
 import org.auscope.portal.core.xslt.PortalXSLTTransformer;
@@ -155,7 +155,7 @@ public class TestBaseWFSService extends PortalTestClass {
     }
 
     @Test(expected = PortalServiceException.class)
-    public void testTransformOwsError() throws Exception {
+    public void testOwsError() throws Exception {
         final InputStream responseStream = getClass().getResourceAsStream("/OWSExceptionSample1.xml");
 
         context.checking(new Expectations() {
@@ -165,11 +165,11 @@ public class TestBaseWFSService extends PortalTestClass {
             }
         });
 
-        service.getTransformedWFSResponse(mockMethod, mockTransformer, mockProperties);
+        service.getWFSResponse(mockMethod);
     }
 
     @Test(expected = PortalServiceException.class)
-    public void testTransformConnectError() throws Exception {
+    public void testConnectError() throws Exception {
         context.checking(new Expectations() {
             {
                 oneOf(mockHttpServiceCaller).getMethodResponseAsString(mockMethod);
@@ -177,33 +177,26 @@ public class TestBaseWFSService extends PortalTestClass {
             }
         });
 
-        service.getTransformedWFSResponse(mockMethod, mockTransformer, mockProperties);
+        service.getWFSResponse(mockMethod);
     }
 
     @Test
-    public void testTransform() throws Exception {
+    public void testResponse() throws Exception {
         final String responseString = new java.util.Scanner(
                 ResourceUtil
                         .loadResourceAsStream("org/auscope/portal/core/test/responses/wfs/commodityGetFeatureResponse.xml"))
                 .useDelimiter("\\A").next();
 
-        final String convertedString = "transformed-string";
-
         context.checking(new Expectations() {
             {
                 oneOf(mockHttpServiceCaller).getMethodResponseAsString(mockMethod);
                 will(returnValue(responseString));
-
-                oneOf(mockTransformer).convert(with(any(String.class)), with(same(mockProperties)));
-                will(returnValue(convertedString));
             }
         });
 
-        WFSTransformedResponse response = service
-                .getTransformedWFSResponse(mockMethod, mockTransformer, mockProperties);
+        WFSResponse response = service.getWFSResponse(mockMethod);
         Assert.assertNotNull(response);
-        Assert.assertEquals(responseString, response.getGml());
-        Assert.assertEquals(convertedString, response.getTransformed());
+        Assert.assertEquals(responseString, response.getData());
         Assert.assertSame(mockMethod, response.getMethod());
     }
 


### PR DESCRIPTION
An old hangover from earlier portals is the WFS -> GML -> KML -> OpenLayers Primitives pathway for WFS responses.

It's problematic because
a) It's a whole lot of CPU/Bandwidth wasted
b) It stuffs us around when you consider non GML responses from WFS (eg CSV)

The actual portal controllers will need to strip out the KML generation code.