### PR TITLE
GPT-138 handle spaces in query parameters

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/http/HttpServiceCaller.java
+++ b/src/main/java/org/auscope/portal/core/server/http/HttpServiceCaller.java
@@ -5,6 +5,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.ConnectException;
+import java.net.URI;
+import java.net.URLDecoder;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 
@@ -12,6 +14,7 @@ import org.apache.commons.httpclient.HttpException;
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.Charsets;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.HttpEntity;
@@ -182,6 +185,18 @@ public class HttpServiceCaller {
             }
         }
 
+        //decode and re-encode the query portion of the URI.
+        if (StringUtils.isNotBlank(method.getURI().getQuery())) {        	
+            String decodedQuery = URLDecoder.decode(method.getURI().getQuery(), "UTF-8");        
+            // the URI constructor does the encoding for us (" " -> "%20" etc)
+            URI uri = new URI(method.getURI().getScheme(),
+            		method.getURI().getHost(),
+            		method.getURI().getPath(),
+            		decodedQuery,
+            		method.getURI().getFragment());
+            method.setURI(uri);         	
+        }          
+        
         // make the call
         HttpResponse response = httpClient.execute(method);
 


### PR DESCRIPTION
The portal-core code that constructs the URL already encodes the parameters for us, but it turns spaces into plus signs. That's actually correct but some servers reject them (they expect "%20" for spaces).
This change decodes the query segment of the URI and then uses the URI constructor which also encodes, but turns spaces into "%20".