### PR TITLE
GPT-47 display organisation not state in query menu

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/querier/QueryTargetHandler.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/QueryTargetHandler.js
@@ -127,12 +127,11 @@ Ext.define('portal.layer.querier.QueryTargetHandler', {
             });
 
             var shortTitle = cswRecord.get('name');
-            var maxTitleLength = 90;
-//            if (onlineResource && onlineResource.get('name')) {
-//                shortTitle += ' - ' + onlineResource.get('name');
-//            }
-            shortTitle += ' - ' + cswRecord.get('adminArea');
-
+            var maxTitleLength = 120;
+            
+            // append the name of the organisation that supplied the record
+            shortTitle += ' - ' + cswRecord.get('contactOrg');
+            
             if(shortTitle.length > maxTitleLength) {
                 shortTitle = shortTitle.substr(0, maxTitleLength) + "...";
             }

--- a/src/main/webapp/portal-core/js/portal/layer/querier/QueryTargetHandler.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/QueryTargetHandler.js
@@ -120,17 +120,52 @@ Ext.define('portal.layer.querier.QueryTargetHandler', {
                 continue;
             }
 
-
             point = Ext.create('portal.map.Point', {
                 latitude : queryTargets[i].get('lat'),
                 longitude : queryTargets[i].get('lng')
             });
 
+
             var shortTitle = cswRecord.get('name');
+            
+            // abbreviate the service provider name
+            var provider = cswRecord.get('contactOrg');   
+            
+            // list of service providers 
+            var SERVICE_PROVIDERS = [
+                'CSIRO',
+                'Geoscience Australia',
+                'Northern Territory',
+                'Queensland',
+                'South Australia',
+                'Tasmania',
+                'Victoria',
+                'Western Australia'
+            ];
+            
+            for (var i = 0; i < SERVICE_PROVIDERS.length; i++) {                
+                if (String.prototype.includes) {
+                    if (provider.includes(SERVICE_PROVIDERS[i])) {
+                        provider = SERVICE_PROVIDERS[i];
+                        break;
+                    } else if (provider.includes('NSW')) {
+                        provider = 'New South Wales';
+                    }
+                } else {
+                    // try using contains()
+                    if (provider.contains(SERVICE_PROVIDERS[i])) {
+                        provider = SERVICE_PROVIDERS[i];
+                        break;
+                    } else if (provider.contains('NSW')) {
+                        provider = 'New South Wales';
+                    }  
+                }
+            }       
+            
             var maxTitleLength = 120;
             
             // append the name of the organisation that supplied the record
-            shortTitle += ' - ' + cswRecord.get('contactOrg');
+            shortTitle += ' - ' + provider;
             
             if(shortTitle.length > maxTitleLength) {
                 shortTitle = shortTitle.substr(0, maxTitleLength) + "...";


### PR DESCRIPTION
- Use the contact org rather than state in the name
- Made the menu a little bit wider to accommodate the (probably) longer name