### PR TITLE
Use keypair from CloudJob before default to one from CCS

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -166,8 +166,17 @@ public class CloudComputeServiceAws extends CloudComputeService {
             runInstancesRequest = runInstancesRequest.withIamInstanceProfile(iamInstanceProfile);
         }
 
+        // Check for a keypair in the CloudJob first, then fall back onto the
+        // default one for this instance.
+        String keypair = null;
+        if (!TextUtil.isNullOrEmpty(job.getComputeInstanceKey())) {
+            keypair = job.getComputeInstanceKey();
+        }
         if (!TextUtil.isNullOrEmpty(getKeypair())) {
-            runInstancesRequest = runInstancesRequest.withKeyName(getKeypair());
+            keypair = getKeypair();
+        }
+        if (keypair != null) {
+            runInstancesRequest = runInstancesRequest.withKeyName(keypair);
         }
 
         AmazonEC2 ec2 = getEc2Client(job);


### PR DESCRIPTION
Needed to support the fix for ANVGL-80, allowing per-user (per-job as far as portal-core is concerned) keypairs.

In the AWS implementation (CloudComputeServiceAws) we need to check for a keypair set on the job instance before falling back to the current default of using the one on the CCS instance.

