### PR TITLE
ANVGL-82 Moved bucket names to CloudFileOwner

### DIFF
--- a/src/main/java/org/auscope/portal/core/cloud/CloudFileOwner.java
+++ b/src/main/java/org/auscope/portal/core/cloud/CloudFileOwner.java
@@ -10,28 +10,28 @@ package org.auscope.portal.core.cloud;
 public interface CloudFileOwner {
     /**
      * A user name to associate with these files
-     * 
+     *
      * @return
      */
     public String getUser();
 
     /**
      * Unique ID identifying this owner
-     * 
+     *
      * @return
      */
     public Integer getId();
 
     /**
      * The key prefix for all files associated with this object in the specified storage bucket
-     * 
+     *
      * @return
      */
     public String getStorageBaseKey();
 
     /**
      * The key prefix for all files associated with this job in the specified storage bucket
-     * 
+     *
      * @param storageBaseKey
      *            The base key to set. Can be null/empty
      * @return
@@ -45,4 +45,11 @@ public interface CloudFileOwner {
      * @return the property value
      */
     public String getProperty(String key);
+
+    /**
+     * Returns the storage bucket to be used to store files. If null, no specific bucket is
+     * required by this cloud file and the default bucket of the underlying service should be used.
+     * @return The storage bucket or null
+     */
+    public String getStorageBucket();
 }

--- a/src/main/java/org/auscope/portal/core/cloud/CloudJob.java
+++ b/src/main/java/org/auscope/portal/core/cloud/CloudJob.java
@@ -54,13 +54,13 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
     protected String storageBaseKey;
     /** The unique ID of the storage service this job has been using */
     protected String storageServiceId;
-    
+
     transient protected Map<String, String> properties = new HashMap<>();
 
     public final static String PROPERTY_STS_ARN = "sts_arn";
     public final static String PROPERTY_CLIENT_SECRET = "client_secret";
     public final static String PROPERTY_S3_ROLE = "s3_role";
-    
+
     /**
      * Creates a new cloud job will null entries for every field
      */
@@ -70,7 +70,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Creates a new cloud job with the following fields
-     * 
+     *
      * @param id
      *            Unique ID identifying this job
      */
@@ -89,7 +89,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Unique ID identifying this job
-     * 
+     *
      * @return
      */
     public Integer getId() {
@@ -98,7 +98,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Unique ID identifying this job
-     * 
+     *
      * @param id
      */
     public void setId(Integer id) {
@@ -107,7 +107,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Descriptive name of this job
-     * 
+     *
      * @return
      */
     public String getName() {
@@ -116,7 +116,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Descriptive name of this job
-     * 
+     *
      * @param name
      */
     public void setName(String name) {
@@ -125,7 +125,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Long description of this job
-     * 
+     *
      * @return
      */
     public String getDescription() {
@@ -134,7 +134,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Long description of this job
-     * 
+     *
      * @param description
      */
     public void setDescription(String description) {
@@ -143,7 +143,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Email address of job submitter
-     * 
+     *
      * @return
      */
     public String getEmailAddress() {
@@ -152,7 +152,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * Email address of job submitter
-     * 
+     *
      * @param emailAddress
      */
     public void setEmailAddress(String emailAddress) {
@@ -161,7 +161,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * user name of job submitter
-     * 
+     *
      * @return
      */
     public String getUser() {
@@ -170,7 +170,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * user name of job submitter
-     * 
+     *
      * @param user
      */
     public void setUser(String user) {
@@ -179,7 +179,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * date/time when this job was submitted
-     * 
+     *
      * @return
      */
     public Date getSubmitDate() {
@@ -188,7 +188,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * date/time when this job was submitted
-     * 
+     *
      * @param submitDate
      */
     public void setSubmitDate(Date submitDate) {
@@ -197,7 +197,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * date/time when this job was processed
-     * 
+     *
      * @return
      */
     public Date getProcessDate() {
@@ -206,7 +206,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * date/time when this job was processed
-     * 
+     *
      * @param processDate
      */
     public void setProcessDate(Date processDate) {
@@ -226,7 +226,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * descriptive status of this job
-     * 
+     *
      * @return
      */
     public String getStatus() {
@@ -235,7 +235,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * descriptive status of this job
-     * 
+     *
      * @param status
      */
     public void setStatus(String status) {
@@ -244,7 +244,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * the ID of the VM that will be used to run this job
-     * 
+     *
      * @return
      */
     public String getComputeVmId() {
@@ -253,7 +253,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * the ID of the VM that will be used to run this job
-     * 
+     *
      * @param computeVmId
      */
     public void setComputeVmId(String computeVmId) {
@@ -262,7 +262,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * the ID of the VM instance that is running this job (will be null if no job is currently running)
-     * 
+     *
      * @return
      */
     public String getComputeInstanceId() {
@@ -271,7 +271,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * the ID of the VM instance that is running this job (will be null if no job is currently running)
-     * 
+     *
      * @param computeInstanceId
      */
     public void setComputeInstanceId(String computeInstanceId) {
@@ -308,7 +308,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * The unique ID of the compute service this job has been using
-     * 
+     *
      * @return
      */
     public String getComputeServiceId() {
@@ -317,7 +317,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * The unique ID of the compute service this job has been using
-     * 
+     *
      * @param computeServiceId
      */
     public void setComputeServiceId(String computeServiceId) {
@@ -326,7 +326,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * The unique ID of the storage service this job has been using
-     * 
+     *
      * @return
      */
     public String getStorageServiceId() {
@@ -335,7 +335,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * The unique ID of the storage service this job has been using
-     * 
+     *
      * @param storageServiceId
      */
     public void setStorageServiceId(String storageServiceId) {
@@ -344,7 +344,7 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * The key prefix for all files associated with this job in the specified storage bucket
-     * 
+     *
      * @return
      */
     public String getStorageBaseKey() {
@@ -353,10 +353,18 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
      * The key prefix for all files associated with this job in the specified storage bucket
-     * 
+     *
      * @param storageBaseKey
      */
     public void setStorageBaseKey(String storageBaseKey) {
         this.storageBaseKey = storageBaseKey;
+    }
+
+    /**
+     * Default behaviour is to offload bucket requirements to the CloudStorageService.
+     */
+    @Override
+    public String getStorageBucket() {
+        return null;
     }
 }


### PR DESCRIPTION
Dynamic bucket name creation responsiblity really belongs as part of the CloudFileOwner.

This will be backwards compatible for "old style" static bucket name. The only "dynamic" bucket name stuff is in ANVGL and that's already got a pull open to deal with this change.