### PR TITLE
ANVGL-70 Added VM status lookups to CloudComputeService

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
@@ -21,6 +21,26 @@ abstract public class CloudComputeService {
         AWSEc2,
     }
 
+    /**
+     * The status of a compute instance (not the job status) as reported by the remote cloud.
+     * @author Josh Vote (CSIRO)
+     *
+     */
+    public enum InstanceStatus {
+        /**
+         * Job is still waiting to start
+         */
+        Pending,
+        /**
+         * Instance is running
+         */
+        Running,
+        /**
+         * The instance could not be found or it's in a terminated state.
+         */
+        Missing,
+    }
+
     @SuppressWarnings("unused")
     private final Log logger = LogFactory.getLog(getClass());
 
@@ -199,7 +219,7 @@ abstract public class CloudComputeService {
      *
      * @param job
      *            The job whose execution should be terminated
-     * @throws PortalServiceException 
+     * @throws PortalServiceException
      */
     abstract public void terminateJob(CloudJob job) throws PortalServiceException;
 
@@ -253,4 +273,15 @@ abstract public class CloudComputeService {
      * @return
      */
     abstract public String getConsoleLog(CloudJob job, int numLines) throws PortalServiceException;
+
+    /**
+     * Attempts to lookup low level status information about this job's compute instance from the remote cloud.
+     *
+     * Having no computeInstanceId set will result in an exception being thrown.
+     *
+     * @param job
+     * @return
+     * @throws PortalServiceException
+     */
+    abstract public InstanceStatus getJobStatus(CloudJob job) throws PortalServiceException;
 }

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
@@ -1,0 +1,166 @@
+package org.auscope.portal.core.services.cloud;
+
+import java.util.Arrays;
+
+import junit.framework.Assert;
+
+import org.auscope.portal.core.cloud.CloudJob;
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.cloud.CloudComputeService.InstanceStatus;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.jmock.Expectations;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.ec2.AmazonEC2;
+import com.amazonaws.services.ec2.AmazonEC2Client;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
+import com.amazonaws.services.ec2.model.DescribeInstanceStatusResult;
+import com.amazonaws.services.ec2.model.InstanceState;
+
+public class TestCloudComputeServiceAws extends PortalTestClass{
+
+    private class TestableJob extends CloudJob {
+
+    }
+
+    private class TestableCCS extends CloudComputeServiceAws {
+
+        private AmazonEC2Client testableClient;
+
+        public TestableCCS(AmazonEC2Client client) {
+            super("", "");
+            testableClient = client;
+        }
+
+        protected AmazonEC2 getEc2Client(CloudJob job) throws PortalServiceException {
+            return testableClient;
+        }
+    }
+
+    private AmazonEC2Client mockClient = context.mock(AmazonEC2Client.class);
+    private DescribeInstanceStatusResult mockDescribeResult = context.mock(DescribeInstanceStatusResult.class);
+    private com.amazonaws.services.ec2.model.InstanceStatus mockStatus = context.mock(com.amazonaws.services.ec2.model.InstanceStatus.class);
+    private InstanceState mockState = context.mock(InstanceState.class);
+    private CloudComputeServiceAws service;
+
+    @Before
+    public void setup() {
+        service = new TestableCCS(mockClient);
+    }
+
+    @Test
+    public void testJobStatus_ParseRunning() throws Exception {
+        CloudJob job = new TestableJob();
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+
+        context.checking(new Expectations() {{
+            oneOf(mockClient).describeInstanceStatus(with(any(DescribeInstanceStatusRequest.class)));
+            will(returnValue(mockDescribeResult));
+
+            allowing(mockDescribeResult).getInstanceStatuses();
+            will(returnValue(Arrays.asList(mockStatus)));
+
+            allowing(mockStatus).getInstanceState();
+            will(returnValue(mockState));
+
+            allowing(mockState).getName();
+            will(returnValue("running"));
+        }});
+
+        Assert.assertEquals(InstanceStatus.Running, service.getJobStatus(job));
+    }
+
+    @Test
+    public void testJobStatus_ParsePending() throws Exception {
+        CloudJob job = new TestableJob();
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+
+        context.checking(new Expectations() {{
+            oneOf(mockClient).describeInstanceStatus(with(any(DescribeInstanceStatusRequest.class)));
+            will(returnValue(mockDescribeResult));
+
+            allowing(mockDescribeResult).getInstanceStatuses();
+            will(returnValue(Arrays.asList(mockStatus)));
+
+            allowing(mockStatus).getInstanceState();
+            will(returnValue(mockState));
+
+            allowing(mockState).getName();
+            will(returnValue("pending"));
+        }});
+
+        Assert.assertEquals(InstanceStatus.Pending, service.getJobStatus(job));
+    }
+
+    @Test
+    public void testJobStatus_ParseTerminated() throws Exception {
+        CloudJob job = new TestableJob();
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+
+        context.checking(new Expectations() {{
+            oneOf(mockClient).describeInstanceStatus(with(any(DescribeInstanceStatusRequest.class)));
+            will(returnValue(mockDescribeResult));
+
+            allowing(mockDescribeResult).getInstanceStatuses();
+            will(returnValue(Arrays.asList(mockStatus)));
+
+            allowing(mockStatus).getInstanceState();
+            will(returnValue(mockState));
+
+            allowing(mockState).getName();
+            will(returnValue("terminated"));
+        }});
+
+        Assert.assertEquals(InstanceStatus.Missing, service.getJobStatus(job));
+    }
+
+    @Test
+    public void testJobStatus_ParseMissingException() throws Exception {
+        CloudJob job = new TestableJob();
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+
+        final AmazonServiceException ex = new AmazonServiceException("Testing Exception");
+        ex.setErrorCode("InvalidInstanceID.NotFound");
+
+        context.checking(new Expectations() {{
+            oneOf(mockClient).describeInstanceStatus(with(any(DescribeInstanceStatusRequest.class)));
+            will(throwException(ex));
+        }});
+
+        Assert.assertEquals(InstanceStatus.Missing, service.getJobStatus(job));
+    }
+
+    @Test(expected=PortalServiceException.class)
+    public void testJobStatus_BadResponse() throws Exception {
+        CloudJob job = new TestableJob();
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+
+        final AmazonServiceException ex = new AmazonServiceException("Testing Exception");
+        ex.setErrorCode("unrecognized-ID");
+        ex.setStatusCode(503);
+
+        context.checking(new Expectations() {{
+            oneOf(mockClient).describeInstanceStatus(with(any(DescribeInstanceStatusRequest.class)));
+            will(throwException(ex));
+        }});
+
+        service.getJobStatus(job);
+    }
+}


### PR DESCRIPTION
Added a getJobStatus method to the CloudComputeService base. This returns a very low level status on a job VM which can be used for reporting accurate information to the end user about the status of their compute jobs.

Unit tests for both AWS/NeCTAR implementations are also included.

Changes are backwards compatible.