### PR TITLE
GPT-191 IE 11 styling

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -67,6 +67,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                 //Loading icon column
                 xtype : 'clickcolumn',
                 dataIndex : 'active',
+                tdCls : 'noTextOverflow',
                 renderer : me._deleteRenderer,
                 hasTip : true,
                 tipRenderer : function(value, layer, column, tip) {
@@ -85,6 +86,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                 xtype : 'clickcolumn',
                 dataIndex : 'loading',
                 renderer : me._loadingRenderer,
+                tdCls : 'noTextOverflow',
                 hasTip : true,
                 tipRenderer : Ext.bind(me._loadingTipRenderer, me),
                 width: 32,


### PR DESCRIPTION
With this change and a corresponding change to your css you will be able to remove the elipsis from specific columns (look at the known layers columns in IE11 and you will see the problem...)
 the elipsis is a text-overflow style. You could do this with padding, margins etc instead but this is how I did it:

in styles.css I added a rule:
    .noTextOverflow .x-grid-cell-inner  {
        text-overflow: clip !important;
    }