### PR TITLE
Fixed feature count being reported as geometry count

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureRenderer.js
@@ -79,7 +79,8 @@ Ext.define('portal.layer.renderer.wfs.FeatureRenderer', {
         //Parse our KML into a set of overlays and markers
         var parser = Ext.create('portal.layer.renderer.wfs.GMLParser', {gml : data.gml, map : me.map});
         var primitives = parser.makePrimitives(icon, onlineResource, layer);
-
+        var count = parser.getFeatureCount();
+        
         //Add our single points and overlays to the overlay manager (which will add them to the map)
         this.primitiveManager.addPrimitives(primitives);
 
@@ -89,7 +90,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureRenderer', {
         }
 
         //store the status
-        this.renderStatus.updateResponse(onlineResource.get('url'), (primitives.length) + " record(s) retrieved.");
+        this.renderStatus.updateResponse(onlineResource.get('url'), count == null ? ('Unknown number of features retrieved.') : (count + " feature(s) retrieved."));
 
         //we are finished
         this._finishDownloadManagerResponse(primitives);

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
@@ -91,6 +91,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
         //Parse our KML into a set of overlays and markers
         var parser = Ext.create('portal.layer.renderer.wfs.GMLParser', {gml : data.gml, map : me.map});
         var primitives = parser.makePrimitives(icon, onlineResource, layer);
+        var count = parser.getFeatureCount();
 
         //Add our single points and overlays to the overlay manager (which will add them to the map)
         this.primitiveManager.addPrimitives(primitives);
@@ -101,7 +102,7 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
         }
 
         //store the status
-        this.renderStatus.updateResponse(onlineResource.get('url'), (primitives.length) + " record(s) retrieved.");
+        this.renderStatus.updateResponse(onlineResource.get('url'), count == null ? ('Unknown number of features retrieved.') : (count + " feature(s) retrieved."));
 
         //we are finished
         this._finishDownloadManagerResponse(primitives);

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/GMLParser.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/GMLParser.js
@@ -130,6 +130,23 @@ Ext.define('portal.layer.renderer.wfs.GMLParser', {
         return this.map.makeMarker(name, description, undefined, onlineResource, layer, point, icon);
     },
 
+    /**
+     * Returns the feature count as reported by the WFS response. Returns null if the count cannot be parsed.
+     */
+    getFeatureCount : function() {
+        var wfsFeatureCollection = portal.util.xml.SimpleDOM.getMatchingChildNodes(this.rootNode, null, "FeatureCollection");
+        if (Ext.isEmpty(wfsFeatureCollection)) {
+            return null;
+        }
+        
+        var count = parseInt(wfsFeatureCollection[0].getAttribute('numberOfFeatures'));
+        if (Ext.isNumber(count)) {
+            return count;
+        }
+        
+        return null;
+    },
+    
     makePrimitives : function(icon, onlineResource, layer) {
         var primitives = [];
         var wfsFeatureCollection = portal.util.xml.SimpleDOM.getMatchingChildNodes(this.rootNode, null, "FeatureCollection");


### PR DESCRIPTION
We are currently reporting on number of geometry primitives returned as our "feature count". This doesn't work when you have feature types with > 1 geometry.

Changed feature count reporting to use the feature count as reported by the WFS response.