### PR TITLE
GPT-181 added button

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/window/PermanentLinkWindow.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/window/PermanentLinkWindow.js
@@ -57,6 +57,7 @@ Ext.define('portal.widgets.window.PermanentLinkWindow', {
                 autoHeight : true,
                 items : [{
                     xtype : 'textfield',
+                    id: 'linkField',
                     anchor : '100%',
                     fieldLabel : 'Paste this link',
                     labelStyle: 'font-weight:bold;',
@@ -70,8 +71,22 @@ Ext.define('portal.widgets.window.PermanentLinkWindow', {
                          }
                     }
                 }]
+            }],
+            // in the ancient tradition of implementing odd ideas as requested by users...
+            // add a button that copies the text field content to the clipboard. Yuck.
+            buttons: [{
+                xtype: 'button',
+                text: 'Copy to clipboard',
+                handler: function(button) {
+                    if (window.clipboardData && window.clipboardData.setData) {
+                        return clipboardData.setData("Text", Ext.getCmp('linkField').value); 
+                    } else {
+                        document.getElementById('linkField-inputEl').focus();
+                        document.getElementById('linkField-inputEl').select();
+                        document.execCommand('copy');
+                    }
+                }
             }]
-
         });
 
         this.callParent(arguments);


### PR DESCRIPTION
This is a change to the Permanent Link window. It adds a button to offer the user an alternative and more intuitive way to copy the permanent link text to the clipboard.
The users asked for this.
If you click out of the field it is not selected anymore and they didn't know how to select all easily.
I know they could just do Ctrl+a or slow three-click (to select all) and then Ctrl+c (to copy) but this button adds to useability so I dont have a huge problem with implementing it. CSIRO guys might want to push back on this, I'm half inclined to insist on user training as well but yknow.