### PR TITLE
ANVGL-112 Made status checks delay for new VMs

### DIFF
--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
@@ -2,6 +2,7 @@ package org.auscope.portal.core.services.cloud;
 
 import java.util.Arrays;
 import java.util.Date;
+import java.util.concurrent.TimeUnit;
 
 import junit.framework.Assert;
 
@@ -162,6 +163,34 @@ public class TestCloudComputeServiceAws extends PortalTestClass{
 
         final AmazonServiceException ex = new AmazonServiceException("Testing Exception");
         ex.setErrorCode("InvalidInstanceID.NotFound");
+
+        context.checking(new Expectations() {{
+
+        }});
+
+        Assert.assertEquals(InstanceStatus.Pending, service.getJobStatus(job));
+    }
+
+    /**
+     * In case we have some time issues and a job's submit date is in the future
+     *
+     * In this case we expect it to return pending. If it's only a few seconds in the future then it's probably just a minor date/time
+     * shifting error (or a daylight savings time shift). If it's a LONG time in the future, what can we expect? It's probably overengineering
+     * the checks if we start accounting for the latter.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testJobStatus_FutureJob() throws Exception {
+        CloudJob job = new TestableJob();
+
+        Date now = new Date();
+        Date submitTime = new Date(now.getTime() + TimeUnit.DAYS.toMillis(2)); //Throw the submit 2 days into the future to simulate some weird clock behavior
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+        job.setSubmitDate(submitTime);
 
         context.checking(new Expectations() {{
 

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
@@ -1,6 +1,7 @@
 package org.auscope.portal.core.services.cloud;
 
 import java.util.Arrays;
+import java.util.Date;
 
 import junit.framework.Assert;
 
@@ -79,6 +80,9 @@ public class TestCloudComputeServiceAws extends PortalTestClass{
     public void testJobStatus_ParsePending() throws Exception {
         CloudJob job = new TestableJob();
 
+        Date now = new Date();
+        Date submitTime = new Date(now.getTime() - (CloudComputeServiceAws.STATUS_PENDING_SECONDS * 1000) - 1000);
+
         job.setComputeInstanceId("testable-id");
         job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
         job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
@@ -142,6 +146,28 @@ public class TestCloudComputeServiceAws extends PortalTestClass{
         }});
 
         Assert.assertEquals(InstanceStatus.Missing, service.getJobStatus(job));
+    }
+
+    @Test
+    public void testJobStatus_NewJobPending() throws Exception {
+        CloudJob job = new TestableJob();
+
+        Date now = new Date();
+        Date submitTime = new Date(now.getTime() - (CloudComputeServiceAws.STATUS_PENDING_SECONDS * 1000) + 1000);
+
+        job.setComputeInstanceId("testable-id");
+        job.setProperty(CloudJob.PROPERTY_STS_ARN, "sts-arn");
+        job.setProperty(CloudJob.PROPERTY_CLIENT_SECRET, "client-secret");
+        job.setSubmitDate(submitTime);
+
+        final AmazonServiceException ex = new AmazonServiceException("Testing Exception");
+        ex.setErrorCode("InvalidInstanceID.NotFound");
+
+        context.checking(new Expectations() {{
+
+        }});
+
+        Assert.assertEquals(InstanceStatus.Pending, service.getJobStatus(job));
     }
 
     @Test(expected=PortalServiceException.class)


### PR DESCRIPTION
AWS is a bit funny about describe instance status requests on a newly requested VM. I've made the code a little bit more robust by ensuring that "newly submitted" VM's don't get a remote request, instead they are assumed to be Pending.

Change is backwards compatible.