### PR TITLE
ANVGL-106 Fixed some z-index bugs with "top level" layers

### DIFF
--- a/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
@@ -668,7 +668,21 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
                                      
         return Ext.create('portal.map.openlayers.PrimitiveManager', {
             baseMap : this,
-            vectorLayer : newVectorLayer
+            vectorLayer : newVectorLayer,
+            listeners: {
+                //See ANVGL-106 for why we need to forcibly reorder thse
+                addprimitives : Ext.bind(function() {
+                    //Move highlight layer to top
+                    var highlightLayer = this.highlightPrimitiveManager.vectorLayer;
+                    this.map.setLayerIndex(highlightLayer, this.map.layers.length);
+                    
+                    //Move drawing layer to top
+                    var ctrls = this.map.getControlsByClass('OpenLayers.Control.DrawFeature');
+                    if (!Ext.isEmpty(ctrls)) {
+                        this.map.setLayerIndex(ctrls[0].layer, this.map.layers.length);
+                    }
+                }, this)
+            }
         });
     },
 


### PR DESCRIPTION
When using the "select data" control in OpenLayers, the rubber bound bounding box appears "underneath" any WMS layers making it rather useless.

Similarly the map highlights (from magnifying glass links) appear at the bottom of the z-index stack.

This patches an OpenLayers bug for the first problem and creates a forced re-ordering of our highlight layers for the second.

