### PR TITLE
GPT-206 Fixed tenements layer first time render issue

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wfs/FeatureWithMapRenderer.js
@@ -283,7 +283,12 @@ Ext.define('portal.layer.renderer.wfs.FeatureWithMapRenderer', {
 
 
     _getRenderLayer : function(response,opts,wmsResource, wmsUrl, wmsLayer, wmsOpacity,wfsResources,filterer){
-        var sld_body = response.responseText;
+        
+    	if(wmsOpacity === undefined){
+    		wmsOpacity = filterer.parameters.opacity;
+    	}
+    	
+    	var sld_body = response.responseText;
         this.sld_body = sld_body;
         if(sld_body.indexOf("<?xml version=")!=0){
             this._updateStatusforWFSWMS(wmsUrl, "error: invalid SLD response");


### PR DESCRIPTION
Investigation to the tenement layer not rendered at first attempt issue found that the wmsOpacity variable can be undefined when the layer is loaded the first time and this caused the issue. Added a check to the value of the variable and if undefined use the opacity in filterer.  