### PR TITLE
GPT-148 Change source text and default for online resources

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
@@ -52,7 +52,7 @@ Ext.define('portal.widgets.panel.CSWMetadataPanel', {
                 items : [{
                     xtype : 'displayfield',
                     fieldLabel : 'Source',
-                    value : Ext.util.Format.format('<a target="_blank" href="{0}">Link back to registry</a>', source)
+                    value : Ext.util.Format.format('<a target="_blank" href="{0}">Full metadata and downloads</a>', source)
                 },{
                     xtype : 'displayfield',
                     fieldLabel : 'Title',

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js
@@ -276,7 +276,7 @@ Ext.define('portal.widgets.panel.OnlineResourcePanelRow', {
                     //ensure we have a type we want to describe
                     var group = portal.csw.OnlineResource.typeToString(onlineResources[j].get('type'),onlineResources[j].get('version'));
                     if (!group) {
-                        continue; //don't include anything else
+                        group = "Downloads"; // If unsupported type, call it 'Downloads'
                     }
 
                     dataItems.push(Ext.create('portal.widgets.panel.OnlineResourcePanelRow',{


### PR DESCRIPTION
Online resources did not display if the protocol/type was 'Unsupported'.
Now if the type is Unsupported these online resources are grouped under 'Downloads'