### PR TITLE
ANVGL-130 Fixed folders in storage crashing file listing

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
@@ -22,6 +22,7 @@ import org.jclouds.blobstore.KeyNotFoundException;
 import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.BlobMetadataImpl;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.blobstore.options.ListContainerOptions;
@@ -80,7 +81,7 @@ public class CloudStorageService {
     private boolean stripExpectHeader;
 
     private boolean requireSts=false;
-    
+
     /**
      * Returns whether AWS cross account authorization is mandatory.
      * @return whether AWS cross account authorization is mandatory.
@@ -263,7 +264,7 @@ public class CloudStorageService {
         } else {
             if(isRequireSts())
                 throw new PortalServiceException("AWS cross account access is required, but not configured");
-            
+
             ContextBuilder builder = ContextBuilder.newBuilder(provider).overrides(properties);
 
             if (accessKey != null && secretKey != null)
@@ -563,6 +564,11 @@ public class CloudStorageService {
 
                 //Turn our StorageMetadata objects into simpler CloudFileInformation objects
                 for (StorageMetadata md : currentMetadataPage) {
+                    //Skip objects that are not files
+                    if (md.getType() != StorageType.BLOB) {
+                        continue;
+                    }
+
                     long fileSize = 1L;
                     if (md instanceof BlobMetadataImpl) {
                         ContentMetadata cmd = ((BlobMetadataImpl) md).getContentMetadata();
@@ -571,6 +577,7 @@ public class CloudStorageService {
                         ContentMetadata cmd = ((MutableBlobMetadataImpl) md).getContentMetadata();
                         fileSize = cmd.getContentLength();
                     }
+
                     jobFiles.add(new CloudFileInformation(md.getName(), fileSize, md.getUri().toString()));
                 }
 

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -16,6 +16,7 @@ import org.jclouds.blobstore.domain.Blob;
 import org.jclouds.blobstore.domain.BlobBuilder.PayloadBlobBuilder;
 import org.jclouds.blobstore.domain.PageSet;
 import org.jclouds.blobstore.domain.StorageMetadata;
+import org.jclouds.blobstore.domain.StorageType;
 import org.jclouds.blobstore.domain.internal.BlobMetadataImpl;
 import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.blobstore.options.ListContainerOptions;
@@ -81,7 +82,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that requests for listing files successfully call all dependencies
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -90,9 +91,11 @@ public class TestCloudStorageService extends PortalTestClass {
 
         final BlobMetadataImpl mockStorageMetadata1 = context.mock(BlobMetadataImpl.class, "mockStorageMetadata1");
         final BlobMetadataImpl mockStorageMetadata2 = context.mock(BlobMetadataImpl.class, "mockStorageMetadata2");
+        final BlobMetadataImpl mockStorageMetadata3 = context.mock(BlobMetadataImpl.class, "mockStorageMetadata3");
 
         final MutableContentMetadata mockObj1ContentMetadata = context.mock(MutableContentMetadata.class, "mockObj1Md");
         final MutableContentMetadata mockObj2ContentMetadata = context.mock(MutableContentMetadata.class, "mockObj2Md");
+        final MutableContentMetadata mockObj3ContentMetadata = context.mock(MutableContentMetadata.class, "mockObj3Md");
         final PageSet<? extends StorageMetadata> mockPageSet = context.mock(PageSet.class);
 
         LinkedList<MutableBlobMetadataImpl> ls = new LinkedList<MutableBlobMetadataImpl>();
@@ -118,7 +121,7 @@ public class TestCloudStorageService extends PortalTestClass {
                 will(returnValue(null));
 
                 allowing(mockPageSet).iterator();
-                will(returnValue(Arrays.asList(mockStorageMetadata1, mockStorageMetadata2).iterator()));
+                will(returnValue(Arrays.asList(mockStorageMetadata1, mockStorageMetadata2, mockStorageMetadata3).iterator()));
 
                 allowing(mockStorageMetadata1).getName();
                 will(returnValue(obj1Key));
@@ -126,8 +129,11 @@ public class TestCloudStorageService extends PortalTestClass {
                 will(returnValue(new URI(obj1Bucket)));
                 allowing(mockStorageMetadata1).getContentMetadata();
                 will(returnValue(mockObj1ContentMetadata));
+                allowing(mockStorageMetadata1).getType();
+                will(returnValue(StorageType.BLOB));
                 allowing(mockObj1ContentMetadata).getContentLength();
                 will(returnValue(obj1Length));
+
 
                 allowing(mockStorageMetadata2).getName();
                 will(returnValue(obj2Key));
@@ -135,8 +141,15 @@ public class TestCloudStorageService extends PortalTestClass {
                 will(returnValue(new URI(obj2Bucket)));
                 allowing(mockStorageMetadata2).getContentMetadata();
                 will(returnValue(mockObj2ContentMetadata));
+                allowing(mockStorageMetadata2).getType();
+                will(returnValue(StorageType.BLOB));
                 allowing(mockObj2ContentMetadata).getContentLength();
                 will(returnValue(obj2Length));
+
+                allowing(mockStorageMetadata3).getContentMetadata();
+                will(returnValue(mockObj3ContentMetadata));
+                allowing(mockStorageMetadata3).getType();
+                will(returnValue(StorageType.FOLDER));
             }
         });
 
@@ -151,7 +164,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that requests for uploading files successfully call all dependencies
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -207,7 +220,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that requests for deleting files successfully call all dependencies
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -227,7 +240,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that no exceptions occur during base key generation edge cases
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -256,7 +269,7 @@ public class TestCloudStorageService extends PortalTestClass {
      *
      * And searched for all files whose prefix begins 'job5' (i.e. to list all files in the job5 directory), you would get BOTH of the above files returned. We
      * need to manage this edge case by ensuring our prefixes don't overlap like that.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -277,7 +290,7 @@ public class TestCloudStorageService extends PortalTestClass {
             Assert.assertFalse(test.startsWith(base));
         }
     }
-    
+
     @Test(expected=PortalServiceException.class)
     public void testStsRequired() throws Exception {
         CloudStorageService stsService = new CloudStorageService("dummy1", "dummy2", "dummy3");


### PR DESCRIPTION
Currently any non "file" objects in cloud storage under a job prefix will cause exceptions to be thrown. This usually won't manifest unless a third party tool is also writing to job storage areas.

This will be backwards compatible.