### PR TITLE
GPT-236 Check for SLD tag and apply filter params to SLD request

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
@@ -47,10 +47,13 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
             var wmsLayer = wmsResources[i].get('name');
             var wmsOpacity = filterer.getParameter('opacity');
             
+            var filterParams = (Ext.Object.toQueryString(filterer.getMercatorCompatibleParameters()));
             var proxyUrl = this.parentLayer.get('source').get('proxyStyleUrl');
+
             if(proxyUrl){
+                var styleurl =  proxyUrl = Ext.urlAppend(proxyUrl,filterParams);
                 Ext.Ajax.request({
-                    url: Ext.urlAppend(proxyUrl),
+                    url: Ext.urlAppend(styleurl),
                     timeout : 180000,
                     scope : this,
                     success: Ext.bind(this._getRenderLayer,this,[wmsResources[i], wmsUrl, wmsLayer, wmsOpacity, filterer],true),
@@ -75,7 +78,7 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
         if (response !== null) {
             var sld_body = response.responseText;
             this.sld_body = sld_body;
-            if(sld_body.indexOf("<?xml version=")!=0){
+            if(sld_body.indexOf("<?xml version=")!=0 && sld_body.indexOf("<StyledLayerDescriptor") != 0){
                 this._updateStatusforWMS(wmsUrl, "error: invalid SLD response");
                 return
             }

--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
@@ -78,7 +78,7 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
         if (response !== null) {
             var sld_body = response.responseText;
             this.sld_body = sld_body;
-            if(sld_body.indexOf("<?xml version=")!=0 && sld_body.indexOf("<StyledLayerDescriptor") != 0){
+            if(sld_body.indexOf("<?xml version=")!=0){
                 this._updateStatusforWMS(wmsUrl, "error: invalid SLD response");
                 return
             }


### PR DESCRIPTION
Some ArcGIS services do not like the XML declaration in the SLD_BODY
parameter, so we must leave it off. Therefore the portal needs to
check whether there is either a <?xml or <StyledLayerDescriptor partial
tag. We also apply the filterer parameters here to the SLD proxy request,
following what is done in FeatureWithMapRenderer.js