### PR TITLE
GPT-255  remove downloads from service information dialog aus

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
@@ -52,7 +52,7 @@ Ext.define('portal.widgets.panel.CSWMetadataPanel', {
                 items : [{
                     xtype : 'displayfield',
                     fieldLabel : 'Source',
-                    value : Ext.util.Format.format('<a target="_blank" href="{0}">Link back to registry</a>', source)
+                    value : Ext.util.Format.format('<a target="_blank" href="{0}">Full metadata and downloads</a>', source)
                 },{
                     xtype : 'displayfield',
                     fieldLabel : 'Title',

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
@@ -49,41 +49,49 @@ Ext.define('portal.widgets.panel.CSWMetadataPanel', {
             layout : 'fit',
             items : [{
                 xtype : 'fieldset',
-                items : [{
-                    xtype : 'displayfield',
-                    fieldLabel : 'Source',
-                    value : Ext.util.Format.format('<a target="_blank" href="{0}">Full metadata and downloads</a>', source)
-                },{
-                    xtype : 'displayfield',
-                    fieldLabel : 'Title',
-                    anchor : '100%',
-                    value : this.cswRecord.get('name')
-                }, {
-                    xtype : 'textarea',
-                    fieldLabel : 'Abstract',
-                    anchor : '100%',
-                    value : this.cswRecord.get('description'),
-                    readOnly : true
-                },{
-                    xtype : 'displayfield',
-                    fieldLabel : 'Keywords',
-                    anchor : '100%',
-                    value : keywordsString
-                },{
-                    xtype : 'displayfield',
-                    fieldLabel : 'Contact Org',
-                    anchor : '100%',
-                    value : this.cswRecord.get('contactOrg')
-                }]
-                .concat(this.extraItems)
-                .concat({
-                    fieldLabel : 'Resources',
-                    xtype : 'onlineresourcepanel',
-                    cswRecords : this.cswRecord
-                })
+                items : this._getMetadataItems(source,keywordsString)
             }]
         });
 
         this.callParent(arguments);
+    },
+
+    _getMetadataItems : function(source,keywordsString) {
+      var items = [{
+        xtype : 'displayfield',
+        fieldLabel : 'Source',
+        value : Ext.util.Format.format('<a target="_blank" href="{0}">Full metadata and downloads</a>', source)
+      },{
+        xtype : 'displayfield',
+        fieldLabel : 'Title',
+        anchor : '100%',
+        value : this.cswRecord.get('name')
+      }, {
+        xtype : 'textarea',
+        fieldLabel : 'Abstract',
+        anchor : '100%',
+        value : this.cswRecord.get('description'),
+        readOnly : true
+      },{
+        xtype : 'displayfield',
+        fieldLabel : 'Keywords',
+        anchor : '100%',
+        value : keywordsString
+      },{
+        xtype : 'displayfield',
+        fieldLabel : 'Contact Org',
+        anchor : '100%',
+        value : this.cswRecord.get('contactOrg')
+      }];
+      items.concat(this.extraItems);
+      if (this.cswRecord!=null) {
+        items.concat({
+                    fieldLabel : 'Resources',
+                    xtype : 'onlineresourcepanel',
+                    cswRecords : this.cswRecord
+                });
+      }
+      return items;
     }
+      
 });

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js
@@ -276,7 +276,7 @@ Ext.define('portal.widgets.panel.OnlineResourcePanelRow', {
                     //ensure we have a type we want to describe
                     var group = portal.csw.OnlineResource.typeToString(onlineResources[j].get('type'),onlineResources[j].get('version'));
                     if (!group) {
-                        group = "Downloads"; // If unsupported type, call it 'Downloads'
+                        continue; //don't include anything else
                     }
 
                     dataItems.push(Ext.create('portal.widgets.panel.OnlineResourcePanelRow',{

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js
@@ -276,7 +276,7 @@ Ext.define('portal.widgets.panel.OnlineResourcePanelRow', {
                     //ensure we have a type we want to describe
                     var group = portal.csw.OnlineResource.typeToString(onlineResources[j].get('type'),onlineResources[j].get('version'));
                     if (!group) {
-                        continue; //don't include anything else
+                        group = "Downloads"; // If unsupported type, call it 'Downloads'
                     }
 
                     dataItems.push(Ext.create('portal.widgets.panel.OnlineResourcePanelRow',{


### PR DESCRIPTION
GPT-148 meant to populate the CSW metadata panel with Download links, but this was causing issues with the online resources panels for featured layers. I reversed that change, while removing the online resources panel unless there are records found.