### PR TITLE
Added standardised JSON Ajax wrapper

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/downloader/coverage/OPeNDAPDownloader.js
+++ b/src/main/webapp/portal-core/js/portal/layer/downloader/coverage/OPeNDAPDownloader.js
@@ -201,22 +201,17 @@ Ext.define('portal.layer.downloader.coverage.OPeNDAPDownloader', {
      */
     _onWindowOpen : function(win, eOpts, opendapUrl, variableName) {
         //Download our variable list - this will be used to generate our form parameters
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url     : 'opendapGetVariables.do',
             scope : this,
             params  : {
                 opendapUrl : opendapUrl,
                 variableName : variableName
             },
-            callback : function(options, success, response) {
+            callback : function(success, data, message) {
                 //Check for errors
                 if (!success) {
-                    this._updateLoadingStatus(win, 'Error (' + response.status + '): ' + response.statusText);
-                    return;
-                }
-                var responseObj = Ext.JSON.decode(response.responseText);
-                if (!responseObj.success) {
-                    this._updateLoadingStatus(win, 'Error: ' + responseObj.msg);
+                    this._updateLoadingStatus(win, 'Error: ' + message);
                     return;
                 }
 
@@ -224,7 +219,7 @@ Ext.define('portal.layer.downloader.coverage.OPeNDAPDownloader', {
                 this._updateLoadingStatus(win, null);
 
                 //Update our form with the downloaded variables
-                this._variableListToWindow(win, responseObj.data);
+                this._variableListToWindow(win, data);
             }
         });
     },

--- a/src/main/webapp/portal-core/js/portal/layer/downloader/coverage/WCSDownloader.js
+++ b/src/main/webapp/portal-core/js/portal/layer/downloader/coverage/WCSDownloader.js
@@ -18,7 +18,7 @@ Ext.define('portal.layer.downloader.coverage.WCSDownloader', {
     showWCSDownload : function (serviceUrl, layerName, map, ftpURL) {
         var currentVisibleBounds = map.getVisibleMapBounds();
         me = this;
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url         : 'describeCoverage.do',
             timeout     : 180000,
             params      : {
@@ -26,24 +26,18 @@ Ext.define('portal.layer.downloader.coverage.WCSDownloader', {
                 layerName       : layerName
             },
             //This gets called if the server returns an error
-            failure     : function(response, options) {
-                Ext.Msg.alert('Error Describing Coverage', 'Error (' + response.status + '): ' + response.statusText);
+            failure     : function(message) {
+                Ext.Msg.alert('Error Describing Coverage', 'ERROR: ' + message);
             },
             //This gets called if the server returned HTTP 200 (the actual response object could still be bad though)
-            success : function(response, options) {
-                var responseObj = Ext.JSON.decode(response.responseText);
-
-                //Generate an error / success fragment to display to the user
-                if (!responseObj.success) {
-                    Ext.Msg.alert('Error Describing Coverage', 'There was an error whilst communicating with ' + serviceUrl);
-                    return;
-                } else if (responseObj.data.length === 0) {
+            success : function(data, message) {
+                if (data.length === 0) {
                     Ext.Msg.alert('Error Describing Coverage', 'The URL ' + serviceUrl + ' returned no parsable DescribeCoverage records');
                     return;
                 }
 
                 //We only parse the first record (as there should only be 1)
-                var rec = responseObj.data[0];
+                var rec = data[0];
                 var interpolationAllowed = rec.supportedInterpolations.length === 0 || rec.supportedInterpolations[0] !== 'none';
 
                 if (!rec.temporalDomain) {

--- a/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/KLWFSDownloader.js
+++ b/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/KLWFSDownloader.js
@@ -349,20 +349,15 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
         params.bbox = bbox ? Ext.JSON.encode(bbox) : '';
         
         el.setHtml('<img src="portal-core/img/dotdotdot.gif" width="16" height="16">'); //our loading placeholder
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url: countUrl,
             params: params,
             timeout: 5 * 60 * 1000, //5 minutes  
-            callback: function(options, success, response) {
+            callback: function(success, data) {
                 if (!success) {
                     el.setHtml('Error');
                 } else {
-                    var responseObj = Ext.JSON.decode(response.responseText);
-                    if (!responseObj.success) {
-                        el.setHtml('Error');
-                    } else {
-                        el.setHtml(responseObj.data);
-                    }
+                    el.setHtml(responseObj.data);
                 }
             }
         });

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegend.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegend.js
@@ -102,7 +102,7 @@ Ext.define('portal.layer.legend.wms.WMSLegend', {
     
         /* Hits the WMS controller to doa  getCapabilties call on the layer and retrieve the LegendGraphicURL element */
         generateLegendGraphicFromGetCapabilities : function(wmsURL,wmsName,wmsVersion,width,sld_body,isSld_body,styles, callback) {
-            Ext.Ajax.request({
+            portal.util.Ajax.request({
                 url: "getLegendURL.do",
                 timeout : 30000,    // Yes this seems a long time but was necessary
                 params : {
@@ -111,16 +111,10 @@ Ext.define('portal.layer.legend.wms.WMSLegend', {
                     layerName : wmsName
                 },
                 scope : this,
-                success: function(response, options){
-                    var text = response.responseText;
-                    console.log("getLegendURL.do call success - response text: ",text, "options: ", options);
-                    callback(JSON.parse(response.responseText)["data"]);
+                success: function(data, message){
+                    callback(data);
                 },
-                failure: function(response, opts) {
-                    var status = response.status;
-                    var statusMsg = response.statusText;
-
-                    console.log("getLegendURL.do call failure - layerName: ", opts.params.layerName, ", url: ", wmsURL, ", status: ", status, ", status text: ",statusMsg, ".  Try alternate method.");
+                failure: function(message) {
                     var getLegendGraphicUrl = portal.layer.legend.wms.WMSLegend.generateImageUrl(wmsURL,wmsName,wmsVersion,width,sld_body,isSld_body,styles);
                     callback(getLegendGraphicUrl);
                 }

--- a/src/main/webapp/portal-core/js/portal/layer/querier/coverage/WCSQuerier.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/coverage/WCSQuerier.js
@@ -42,7 +42,7 @@ Ext.define('portal.layer.querier.coverage.WCSQuerier', {
         var allOnlineResources = queryTarget.get('cswRecord').get('onlineResources');
         var opendapResources = portal.csw.OnlineResource.getFilteredFromArray(allOnlineResources, portal.csw.OnlineResource.OPeNDAP);
 
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url: 'describeCoverage.do',
             timeout : 180000,
             params      : {
@@ -51,14 +51,13 @@ Ext.define('portal.layer.querier.coverage.WCSQuerier', {
                 //cswRecord       : queryTarget.get('cswRecord')
             },
             scope : this,
-            callback : function(options, success, response) {
+            callback : function(success, data, message) {
                 if(success){
-                    var responseObj = Ext.JSON.decode(response.responseText);
-                    if (!responseObj.data) { //LJ: AUS-2598 ASTER mask hanging when server is down.
+                    if (!data) { //LJ: AUS-2598 ASTER mask hanging when server is down.
                         callback(this, [this._generateErrorComponent('There was a problem when looking up the point')], queryTarget);
                         return;
                     }                    
-                    var record = responseObj.data[0];
+                    var record = data[0];
                     var spatialFunc=function(item) {
                         var s = '';
                         if (item.type === 'Envelope' || item.type === 'EnvelopeWithTimePeriod') {

--- a/src/main/webapp/portal-core/js/portal/layer/querier/wfs/featuresources/WFSFeatureByPropertySource.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/wfs/featuresources/WFSFeatureByPropertySource.js
@@ -31,7 +31,7 @@ Ext.define('portal.layer.querier.wfs.featuresources.WFSFeatureByPropertySource',
         var value = this.value ? this.value : featureId;
 
         var me = this;
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url : 'requestFeatureByProperty.do',
             params : {
                 serviceUrl : wfsUrl,
@@ -39,20 +39,14 @@ Ext.define('portal.layer.querier.wfs.featuresources.WFSFeatureByPropertySource',
                 property : this.property,
                 value : value
             },
-            callback : function(options, success, response) {
+            callback : function(success, data) {
                 if (!success) {
                     callback(null, featureId, featureType, wfsUrl);
                     return;
                 }
 
-                var jsonResponse = Ext.JSON.decode(response.responseText);
-                if (!jsonResponse.success) {
-                    callback(null, featureId, featureType, wfsUrl);
-                    return;
-                }
-
                 // Load our xml string into DOM, extract the first feature
-                var xmlDocument = portal.util.xml.SimpleDOM.parseStringToDOM(jsonResponse.data.gml);
+                var xmlDocument = portal.util.xml.SimpleDOM.parseStringToDOM(data.gml);
                 if (!xmlDocument) {
                     callback(null, featureId, featureType, wfsUrl);
                     return;

--- a/src/main/webapp/portal-core/js/portal/layer/querier/wfs/featuresources/WFSFeatureSource.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/wfs/featuresources/WFSFeatureSource.js
@@ -29,23 +29,17 @@ Ext.define('portal.layer.querier.wfs.featuresources.WFSFeatureSource', {
         });
 
         var me = this;
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url : 'requestFeature.do',
             params : params,
-            callback : function(options, success, response) {
+            callback : function(success, data) {
                 if (!success) {
                     callback(null, featureId, featureType, wfsUrl);
                     return;
                 }
 
-                var jsonResponse = Ext.JSON.decode(response.responseText);
-                if (!jsonResponse.success) {
-                    callback(null, featureId, featureType, wfsUrl);
-                    return;
-                }
-
                 // Load our xml string into DOM, extract the first feature
-                var xmlDocument = portal.util.xml.SimpleDOM.parseStringToDOM(jsonResponse.data.gml);
+                var xmlDocument = portal.util.xml.SimpleDOM.parseStringToDOM(data.gml);
                 if (!xmlDocument) {
                     callback(null, featureId, featureType, wfsUrl);
                     return;

--- a/src/main/webapp/portal-core/js/portal/util/Ajax.js
+++ b/src/main/webapp/portal-core/js/portal/util/Ajax.js
@@ -1,0 +1,103 @@
+/**
+ * This is a portal core specialisation/alternative to Ext.Ajax.request that specialises
+ * in receiving JSON responses in the form:
+ * 
+ *  {
+ *    success : Boolean - Whether the request was successful (as reported by the server)
+ *    data : (Optional) Object/Array - Any response information from the server
+ *    message : (Optional) String - Any extra human readable information reported by the server
+ *    debugInfo : (Optional) Object - Any extra debug information pertaining to the request and its processing
+ *  }
+ *  
+ *  Any other types of response formats should be made through Ext.Ajax.request as per normal
+ */
+Ext.define('portal.util.Ajax', {
+    singleton: true,
+    
+    /**
+     * Handles all parsing logic and error conditions for a boolean success flag and a XMLHttpRequest object
+     * 
+     * @param success Boolean - whether the remote connection was successful
+     * @param response XMLHttpRequest - response object
+     * @param callback function(success, data, message, debugInfo)
+     *               success - Boolean - true if the connection succeeded AND the server reported success. false otherwise
+     *               data - Array/Object - contents of the data response (if any)
+     *               message - String - String message returned by server if connection succeeded, otherwise a generic HTTP error message
+     *               debugInfo - Object - debug object returned by server (if any)
+     */
+    parseResponse: function(success, response, callback) {
+        if (!success) {
+            var message = response.status ? 
+                            response.status + ': ' + response.statusText :
+                            'Network Error: Cannot connect to server.';
+
+            callback(false, undefined, message, undefined);
+            return;
+        }
+        
+        try {
+            var responseObj = Ext.JSON.decode(response.responseText);
+            callback(responseObj.success === true, responseObj.data, responseObj.msg, responseObj.debugInfo);
+            return;
+        } catch(err) {
+            console.log('ERROR parsing Ajax response:', err);
+            callback(false, undefined, undefined, undefined);
+            return;
+        }
+    },
+    
+    /**
+     * Exactly the same as Ext.Ajax.request with the following changes/additions:
+     * 
+     *  callback - function(success, data, message, debugInfo)
+     *               success - Boolean - true if the connection succeeded AND the server reported success. false otherwise
+     *               data - Array/Object - contents of the data response (if any)
+     *               message - String - String message returned by server if connection succeeded, otherwise a generic HTTP error message
+     *               debugInfo - Object - debug object returned by server (if any)
+     *               
+     *  success - function(data, message, debugInfo) - This will be called IFF the connection succeeds AND the response object indicates success
+     *               data - Array/Object - contents of the data response (if any)
+     *               message - String - String message returned by server if connection succeeded, otherwise a generic HTTP error message
+     *               debugInfo - Object - debug object returned by server (if any)
+     *               
+     *  failure - function(message, debugInfo) - This will be called if the connection fail OR the response object indicates failure
+     *               message - String - String message returned by server if connection succeeded, otherwise a generic HTTP error message
+     *               debugInfo - Object - debug object returned by server (if any)
+     */
+    request: function(cfg) {
+        //We do all injection via callback and then offload back 
+        //to the user defined success/failure/callback functions
+        var userCallbacks = {
+            success: cfg.success ? Ext.bind(cfg.success, cfg.scope) : undefined,
+            failure: cfg.failure ? Ext.bind(cfg.failure, cfg.scope) : undefined,
+            callback: cfg.callback ? Ext.bind(cfg.callback, cfg.scope) : undefined,
+        };
+        delete cfg.failure;
+        delete cfg.success;
+        delete cfg.scope;
+        
+        var scope = cfg.scope;
+        cfg.callback = Ext.bind(function(options, success, response, userCallbacks) {
+            //Because we need to parse the response before we can workout whether to call success/failure callbacks
+            //We need to go another level deeper with our wrapping functions. This final callback will decide what user callbacks
+            //to fire and in what order depending on the results of the parseResponse function.
+            portal.util.Ajax.parseResponse(success, response, Ext.bind(function(success, data, message, debugInfo, userCallbacks) {
+                if (userCallbacks.callback) {
+                    userCallbacks.callback(success, data, message, debugInfo);
+                }
+                
+                if (success) {
+                    if (userCallbacks.success) {
+                        userCallbacks.success(data, message, debugInfo);
+                    }
+                } else {
+                    if (userCallbacks.failure) {
+                        userCallbacks.failure(message, debugInfo);
+                    }
+                }
+            }, undefined, [userCallbacks], true));
+        }, undefined, [userCallbacks], true);
+        
+        return Ext.Ajax.request(cfg);
+    }
+});

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWFilterFormPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWFilterFormPanel.js
@@ -613,18 +613,18 @@ Ext.define('portal.widgets.panel.CSWFilterFormPanel', {
 
         var customRegistryForm = this.query('form[itemId=customRegistryFormID]')[0]
 
-        Ext.Ajax.request({
+        portal.util.Ajax.request({
             url: 'getCSWGetCapabilities.do',
             scope : this,
             params: {
                 cswServiceUrl: customRegistryForm.getValues().DNA_serviceUrl
             },
-            callback : function(options, success, response) {
+            callback : function(success, data) {
                 //Check for errors
                 //VT: title should be extracted from the response;
                 if (success) {
                     //VT if title == null pop up box to ask user for title;
-                    var title = Ext.decode(response.responseText).data.title;
+                    var title = data.title;
 
 
                     var registry=Ext.getCmp('registryTabCheckboxGroup');

--- a/src/main/webapp/portal-core/jsimports.jsp
+++ b/src/main/webapp/portal-core/jsimports.jsp
@@ -28,6 +28,7 @@
 <script src="portal-core/js/portal/util/help/InstructionManager.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/util/xml/SimpleDOM.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/util/xml/SimpleXPath.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/util/Ajax.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/util/Base64.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/util/BBoxType.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/util/BBox.js?v=${buildTimestamp}" type="text/javascript"></script>


### PR DESCRIPTION
Added a wrapper around Ext.Ajax.request that specialises it to the "standard" JSON format returned by all JSON controllers. Updated the few instances in portal-core where appropriate.

This change does not require a migration to portal.util.Ajax.request from Ext.Ajax. It's just a convenience method to reduce Ajax boilerplate. 