### PR TITLE
Fixed null bbox breaking getMercatorCompatibleParameters

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/filterer/Filterer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/filterer/Filterer.js
@@ -55,19 +55,19 @@ Ext.define('portal.layer.filterer.Filterer', {
 
         var bbox = this.getSpatialParam();            	
 
-        if(bbox.crs=='EPSG:4326'){
-            var bounds = new OpenLayers.Bounds(bbox.westBoundLongitude, bbox.southBoundLatitude, bbox.eastBoundLongitude, bbox.northBoundLatitude);
-            bounds = bounds.transform('EPSG:4326','EPSG:3857');
-            bbox = Ext.create('portal.util.BBox', {
-                northBoundLatitude : bounds.top,
-                southBoundLatitude : bounds.bottom,
-                eastBoundLongitude : bounds.right,
-                westBoundLongitude : bounds.left,
-                crs : 'EPSG:3857'
-            });
-        }
-
-        if (bbox) {
+        if(bbox) {
+            if (bbox.crs=='EPSG:4326') {
+                var bounds = new OpenLayers.Bounds(bbox.westBoundLongitude, bbox.southBoundLatitude, bbox.eastBoundLongitude, bbox.northBoundLatitude);
+                bounds = bounds.transform('EPSG:4326','EPSG:3857');
+                bbox = Ext.create('portal.util.BBox', {
+                    northBoundLatitude : bounds.top,
+                    southBoundLatitude : bounds.bottom,
+                    eastBoundLongitude : bounds.right,
+                    westBoundLongitude : bounds.left,
+                    crs : 'EPSG:3857'
+                });
+            }
+            
             params[portal.layer.filterer.Filterer.BBOX_FIELD] = Ext.JSON.encode(bbox);
         }
 


### PR DESCRIPTION
A null bounding box will cause a JS error when getMercatorCompatibleParameters is called. This is unnecessary and causes issues in some edge cases.

Changed to make the parameter generation a little more robust w.r.t. null values.