### PR TITLE
Render map if SLD invalid

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
@@ -79,8 +79,8 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
             var sld_body = response.responseText;
             this.sld_body = sld_body;
             if(sld_body.indexOf("<?xml version=")!=0){
-                this._updateStatusforWMS(wmsUrl, "error: invalid SLD response");
-                return
+                sld_body = null;
+                this.sld_body = sld_body;
             }
         }
     


### PR DESCRIPTION
If the SLD response is invalid, default to rendering the native-styled layer from the service.

This change to behaviour will differ from FeatureWithMapRenderer, which fails to render the layer if the SLD is invalid. We have chosen to return an empty SLD for our Scanned Maps Layers if no filter parameters are applied, and therefore use the styling supplied by the service.