### PR TITLE
ANVGL-146 Added a googlemap key placeholder

### DIFF
--- a/src/main/webapp/portal-core/jsimports-openlayers.jsp
+++ b/src/main/webapp/portal-core/jsimports-openlayers.jsp
@@ -71,4 +71,4 @@
 <script src="portal-core/js/portal/map/openlayers/primitives/Polygon.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/map/openlayers/primitives/Polyline.js" type="text/javascript"></script>
 <script src="portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js" type="text/javascript"></script>
-<script src="https://maps.google.com/maps/api/js?v=3.8&sensor=false"></script>
+<script src="https://maps.google.com/maps/api/js?v=3.8&sensor=false&key=${googleKey}"></script>


### PR DESCRIPTION
Added a simple googleKey placeholder to the gmap API. If not available, spring will replace it with empty string which still works fine with gmap.