### PR TITLE
AUS-2685 Full replacement of BaseRecordPanel Ext.grid.Panel implementation

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/Layer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/Layer.js
@@ -124,32 +124,6 @@ Ext.define('portal.layer.Layer', {
         var renderer = this.get('renderer');      
         this.removeDataFromMap();                  
         renderer.displayData(this.getAllOnlineResources(), this.get('filterer'), Ext.emptyFn);
-        
-        var group = 'group';
-        if(this.get('sourceType')=='CSWRecord'){
-            group='contactOrg';
-        }
-        
-        //VT: Custom layer doesn't contain group
-        if(this.get('source').get(group)){
-            this._expandGridGroup(this.get('source').get(group));
-        }
-                       
-    },
-    
-    _expandGridGroup : function(groupname){
-        var activeTab = Ext.getCmp('auscope-tabs-panel').getActiveTab();
-        for (var i = 0; i < activeTab.features.length; i++) {
-            if (activeTab.features[i] instanceof Ext.grid.feature.Grouping) {
-                // try to expand the group but fail gracefully if not possible
-                // for example because the group may be obtained from the "contactOrg" field
-                // GA Portal thinks the group name of a Custom layer is "Geoscience Australia"
-                try {
-                    activeTab.features[i].expand(groupname,true);
-                }
-                catch(e) {}
-            }
-        }        
     },
     
    removeDataFromMap:function(){

--- a/src/main/webapp/portal-core/js/portal/widgets/layout/AccordianDefault.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/layout/AccordianDefault.js
@@ -1,0 +1,94 @@
+/**
+ * An extension to the ExtJS accordian layout. The original layout
+ * would always flick back to an above/below panel when the current
+ * panel is collapsed. This extension allows a "default" panel to
+ * be reselected instead
+ */
+Ext.define('portal.widgets.layout.AccordianDefault', {
+    extend : 'Ext.layout.container.Accordion',
+    alias : 'layout.accordiondefault',
+    type : 'accordiondefault',
+
+    defaultQuery : null,
+
+    /**
+     * Adds the following config:
+     * 
+     * defaultId : String - itemId of the panel to always open when the current panel is collapsed 
+     */
+    constructor : function(config) {
+        this.defaultQuery = '#' + config.defaultId;
+        this.callParent(arguments);
+    },
+    
+    /**
+     * Stops all future animations running until resumeAnimations is called
+     * 
+     * This function is not re-entrant
+     */
+    suspendAnimations: function() {
+        this.animate = false;
+        this.originalAnimatePolicy = this.animatePolicy;
+        this.animatePolicy = null;
+    },
+    
+    /**
+     * 
+     * Resumes all future animations. 
+     * 
+     * This function is not re-entrant
+     */
+    resumeAnimations: function() {
+        if (Ext.isObject(this.originalAnimatePolicy)) {
+            this.animate = true;
+            this.animatePolicy = this.originalAnimatePolicy;
+            this.originalAnimatePolicy = null;
+        }
+    },
+
+    /**
+     * Override the default implementation with one that chooses the next expand
+     * target using our "defaultQuery"
+     * 
+     * This was overridden from the Ext 5.1.1 implementation. Future Ext versions
+     * may require this to be reworked
+     */
+    onBeforeComponentCollapse : function(comp) {
+        var me = this, owner = me.owner, toExpand, expanded, previousValue;
+
+        if (me.owner.items.getCount() === 1) {
+            // do not allow collapse if there is only one item
+            return false;
+        }
+
+        if (!me.processing) {
+            me.processing = true;
+            previousValue = owner.deferLayouts;
+            owner.deferLayouts = true;
+            //portal-core change
+            toExpand = comp.previousSibling(me.defaultQuery)
+                    || comp.nextSibling(me.defaultQuery);
+            //end portal-core change
+
+            // If we are allowing multi, and the "toCollapse" component is NOT
+            // the only expanded Component,
+            // then ask the box layout to collapse it to its header.
+            if (me.multi) {
+                expanded = me.getExpanded();
+
+                // If the collapsing Panel is the only expanded one, expand the
+                // following Component.
+                // All this is handling fill: true, so there must be at least
+                // one expanded,
+                if (expanded.length === 1) {
+                    toExpand.expand();
+                }
+
+            } else if (toExpand) {
+                toExpand.expand();
+            }
+            owner.deferLayouts = previousValue;
+            me.processing = false;
+        }
+    }
+});

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -20,11 +20,6 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
 
     constructor : function(cfg) {
         var me = this;
-
-        var groupingFeature = Ext.create('Ext.grid.feature.Grouping',{
-            groupHeaderTpl: '{name} ({[values.rows.length]} {[values.rows.length > 1 ? "Items" : "Item"]})',
-            startCollapsed : true
-        });
        
         me.listeners = Object.extend(me.listenersHere, cfg.listeners);
         
@@ -33,12 +28,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
 
         Ext.apply(cfg, {
             cls : 'auscope-dark-grid',
-            hideHeaders : true,
-            features : [groupingFeature],
-            viewConfig : {
-                emptyText : '<p class="centeredlabel">No records match the current filter.</p>',
-                preserveScrollOnRefresh: true
-            },          
+            emptyText : '<p class="centeredlabel">No records match the current filter.</p>',
             dockedItems : [{
                 xtype : 'toolbar',
                 dock : 'top',
@@ -63,104 +53,70 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                    
                 }]
             }],
-            columns : [{
-                //Loading icon column
-                xtype : 'clickcolumn',
-                dataIndex : 'active',
-                renderer : me._deleteRenderer,
-                hasTip : true,
-                tipRenderer : function(value, layer, column, tip) {
-                    if(layer.get('active')){
+            titleField: 'name',
+            titleIndex: 2,
+            tools: [{
+                field: 'active',
+                clickHandler: Ext.bind(me._deleteClickHandler, me),
+                stopEvent: false,
+                tipRenderer: function(value, layer, tip) {
+                    if(value) {
                         return 'Click to remove layer from map';
-                    }else{
+                    } else {
                         return 'Click to anywhere on this row to select drop down menu';
                     }
                 },
-                width: 32,
-                listeners : {
-                    columnclick : Ext.bind(me._deleteClickHandler, me)
-                }
+                iconRenderer: me._deleteRenderer
             },{
-                //Loading icon column
-                xtype : 'clickcolumn',
-                dataIndex : 'loading',
-                renderer : me._loadingRenderer,
-                hasTip : true,
-                tipRenderer : Ext.bind(me._loadingTipRenderer, me),
-                width: 32,
-                listeners : {
-                    columnclick : Ext.bind(me._loadingClickHandler, me)
-                }
+                field: 'loading',
+                stopEvent: true,
+                clickHandler: Ext.bind(me._loadingClickHandler, me),
+                tipRenderer: Ext.bind(me._loadingTipRenderer, me),
+                iconRenderer: Ext.bind(me._loadingRenderer, this)
             },{
-                //Title column
-                text : 'Title',
-                dataIndex : 'name',
-                flex: 1,
-                renderer : me._titleRenderer
-            },{
-                //Service information column
-                xtype : 'clickcolumn',
-                dataIndex : 'serviceInformation',
-                width: 32,
-                renderer : me._serviceInformationRenderer,
-                hasTip : true,
-                tipRenderer : function(value, layer, column, tip) {
+                field: 'serviceInformation',
+                stopEvent: true,
+                clickHandler: Ext.bind(me._serviceInformationClickHandler, me),
+                tipRenderer: function(layer, tip) {
                     return 'Click for detailed information about the web services this layer utilises.';
                 },
-                listeners : {
-                    columnclick : Ext.bind(me._serviceInformationClickHandler, me)
-                }
+                iconRenderer: Ext.bind(me._serviceInformationRenderer, me)
             },{
-                //Spatial bounds column
-                xtype : 'clickcolumn',
-                dataIndex : 'spatialBoundsRenderer',
-                width: 32,
-                renderer : me._spatialBoundsRenderer,
-                hasTip : true,
-                tipRenderer : function(value, layer, column, tip) {
-                    return 'Click to see the bounds of this layer, double click to pan the map to those bounds.';
+                field: 'spatialBoundsRenderer',
+                stopEvent: true,
+                clickHandler: Ext.bind(me._spatialBoundsClickHandler, me),
+                doubleClickHandler: Ext.bind(me._spatialBoundsDoubleClickHandler, me),
+                tipRenderer: function(layer, tip) {
+                    return 'Click to see the bounds of this layer, double click to pan the map to those bounds';
                 },
-                listeners : {
-                    columnclick : Ext.bind(me._spatialBoundsClickHandler, me),
-                    columndblclick : Ext.bind(me._spatialBoundsDoubleClickHandler, me)
-                }
+                iconRenderer: Ext.bind(me._spatialBoundsRenderer, me)
             }],
-          plugins:[{                
-              ptype : 'rowexpandercontainer',
-              pluginId : 'maingrid_rowexpandercontainer',
-              toggleColIndexes: [0, 2],
-              generateContainer : function(record, parentElId, grid) {                  
-                  //VT:if this is deserialized, we don't need to regenerate the layer
-                  if(record.get('layer')) {                        
-                      newLayer =  record.get('layer');                                    
-                  }else if(record instanceof portal.csw.CSWRecord){                        
-                      newLayer = cfg.layerFactory.generateLayerFromCSWRecord(record);                                                     
-                  }else{
-                      newLayer = cfg.layerFactory.generateLayerFromKnownLayer(record);                      
-                  }           
-                  record.set('layer',newLayer);
-                  var filterForm = cfg.layerFactory.formFactory.getFilterForm(newLayer).form; //ALWAYS recreate filter form - see https://jira.csiro.au/browse/AUS-2588
-                  filterForm.setLayer(newLayer);
-                  var filterPanel = me._getInlineLayerPanel(filterForm, parentElId, this);
-                  
-                  //Update the layer panel to use
-                  if (filterForm) {
-                      var filterer = newLayer.get('filterer');
-                      if (filterer) {
-                          var existingParams = filterer.getParameters();
-                          filterForm.getForm().setValues(existingParams);
-                      }
-                  }
-                  grid.updateLayout({
-                      defer:false,
-                      isRoot:false
-                  });                    
-                  return filterPanel;
-             }
-         },{
-          ptype: 'celltips'
-         }]
-                  
+            childPanelGenerator: function(record) {                  
+                var newLayer = null;
+                
+                //VT:if this is deserialized, we don't need to regenerate the layer
+                if(record.get('layer')) {                        
+                    newLayer =  record.get('layer');                                    
+                }else if(record instanceof portal.csw.CSWRecord){                        
+                    newLayer = cfg.layerFactory.generateLayerFromCSWRecord(record);                                                     
+                }else{
+                    newLayer = cfg.layerFactory.generateLayerFromKnownLayer(record);                      
+                }           
+                record.set('layer',newLayer);
+                var filterForm = cfg.layerFactory.formFactory.getFilterForm(newLayer).form; //ALWAYS recreate filter form - see https://jira.csiro.au/browse/AUS-2588
+                filterForm.setLayer(newLayer);
+                var filterPanel = me._getInlineLayerPanel(filterForm);
+                
+                //Update the layer panel to use
+                if (filterForm) {
+                    var filterer = newLayer.get('filterer');
+                    if (filterer) {
+                        var existingParams = filterer.getParameters();
+                        filterForm.getForm().setValues(existingParams);
+                    }
+                }
+                return filterPanel;
+           }
         });
 
         me.callParent(arguments);
@@ -170,14 +126,13 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
         me.callParent();
     },
 
-    _getInlineLayerPanel : function(filterForm, parentElId){                             
+    _getInlineLayerPanel : function(filterForm){                             
         var me = this;   
         var panel = Ext.create('portal.widgets.panel.FilterPanel', {    
             menuFactory : this.menuFactory,
             filterForm  : filterForm, 
             detachOnRemove : false,
             map         : this.map,
-            renderTo    : parentElId,
             menuItems : []
         });   
         
@@ -360,43 +315,28 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
         }
     },
 
-    _deleteRenderer : function(value, metaData, record, row, col, store, gridView) {
+    _deleteRenderer : function(value, record) {
         if (value) {
-            return Ext.DomHelper.markup({
-                tag : 'img',
-                width : 16,
-                height : 16,
-                src: 'portal-core/img/trash.png'
-            });
+            return 'portal-core/img/trash.png';
         } else {
-            return Ext.DomHelper.markup({
-                tag : 'img',
-                width : 16,
-                height : 16,
-                src: 'portal-core/img/play_blue.png'
-            });
+            return 'portal-core/img/play_blue.png';
         }
     },
     
-    _deleteClickHandler :  function(value, record, rowIdx, tip) {
+    _deleteClickHandler :  function(value, record) {
         var layer = record.get('layer');
         if(layer && record.get('active')){
             ActiveLayerManager.removeLayer(layer);
-            this.fireEvent('cellclick',this,undefined,undefined,layer,undefined,rowIdx);
+            this.fireEvent('cellclick',this,undefined,undefined,layer,undefined,undefined);
         }
     },
 
     /**
      * Renderer for the loading column
      */
-    _loadingRenderer : function(value, metaData, record, row, col, store, gridView) {
+    _loadingRenderer : function(value, record) {
         if (value) {
-            return Ext.DomHelper.markup({
-                tag : 'img',
-                width : 16,
-                height : 16,
-                src: 'portal-core/img/loading.gif'
-            });
+            return 'portal-core/img/loading.gif';
         } else {
             
             if(record.get('active')){
@@ -406,38 +346,16 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                 var errorCount = this._statusListErrorCount(listOfStatus);
                 var sizeOfList = Ext.Object.getSize(listOfStatus);
                 if(errorCount > 0 && errorCount == sizeOfList){
-                    return Ext.DomHelper.markup({
-                        tag : 'img',
-                        width : 16,
-                        height : 16,
-                        src: 'portal-core/img/exclamation.png'
-                    });
+                    return 'portal-core/img/exclamation.png';
                 }else if(errorCount > 0 && errorCount < sizeOfList){
-                    return Ext.DomHelper.markup({
-                        tag : 'img',
-                        width : 16,
-                        height : 16,
-                        src: 'portal-core/img/warning.png'
-                    });
+                    return 'portal-core/img/warning.png';
                 }else{
-                    return Ext.DomHelper.markup({
-                        tag : 'img',
-                        width : 16,
-                        height : 16,
-                        src: 'portal-core/img/tick.png'
-                    });
+                    return 'portal-core/img/tick.png';
                 }
                 
             }else{
-                return Ext.DomHelper.markup({
-                    tag : 'img',
-                    width : 16,
-                    height : 16,
-                    src: 'portal-core/img/notloading.gif'
-                });
+                return 'portal-core/img/notloading.gif';
             }
-            
-            
         }
     },
     
@@ -462,7 +380,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
      * A renderer for generating the contents of the tooltip that shows when the
      * layer is loading
      */
-    _loadingTipRenderer : function(value, record, column, tip) {
+    _loadingTipRenderer : function(value, record, tip) {
         var layer = record.get('layer');
         if(!layer){//VT:The layer has yet to be created.
             return 'No status has been recorded';
@@ -481,7 +399,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
         return renderer.renderStatus.renderHtml();
     },
     
-    _loadingClickHandler : function(value, record, rowIdx, tip) {
+    _loadingClickHandler : function(value, record) {
         
         var layer = record.get('layer');
         

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CommonBaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CommonBaseRecordPanel.js
@@ -1,7 +1,7 @@
 /**
  * An abstract base class to be extended.
  *
- * Represents a grid panel for containing layers
+ * Represents a pseudo grid panel (see AUS-2685) for containing layers
  * that haven't yet been added to the map. Each row
  * will be grouped under a heading, contain links
  * to underlying data sources and have a spatial location
@@ -17,7 +17,7 @@
  *
  */
 Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
-    extend : 'Ext.grid.Panel',
+    extend : 'portal.widgets.panel.RecordPanel',
     alias: 'widget.commonbaserecordpanel',
     browseCatalogueDNSMessage : false, //VT: Flags the do not show message when browse catalogue is clicked.
     map : null,
@@ -115,7 +115,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
     /**
      * Renderer used in Column definitions that will be done on subclasses.  Useful to define here.
      * 
-     * Internal method, acts as an ExtJS 4 column renderer function for rendering
+     * Internal method, acts as a renderer function for rendering
      * the title of the record.
      *
      * http://docs.sencha.com/ext-js/4-0/#!/api/Ext.grid.column.Column-cfg-renderer
@@ -127,15 +127,14 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
     /**
      * Renderer used in Column definitions that will be done on subclasses.  Useful to define here.
      *
-     * Internal method, acts as an ExtJS 4 column renderer function for rendering
+     * Internal method, acts as a renderer function for rendering
      * the service information of the record.
      *
-     * http://docs.sencha.com/ext-js/4-0/#!/api/Ext.grid.column.Column-cfg-renderer
      */
-    _serviceInformationRenderer : function(value, metaData, record, row, col, store, gridView) {
+    _serviceInformationRenderer : function(value, record) {
         
         if(record.get('resourceProvider')=="kml"){
-            return this._generateHTMLIconMarkup('portal-core/img/kml.png');
+            return 'portal-core/img/kml.png';
         }
         
         var onlineResources = this.getOnlineResourcesForRecord(record);
@@ -159,7 +158,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
             }
         }
         
-        return this._generateHTMLIconMarkup(iconPath);
+        return iconPath;
     },
     
     /**
@@ -200,20 +199,18 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
     /**
      * Renderer used in Column definitions that will be done on subclasses.  Useful to define here.
      *
-     * Internal method, acts as an ExtJS 4 column renderer function for rendering
+     * Internal method, acts as an renderer function for rendering
      * the spatial bounds column of the record.
-     *
-     * http://docs.sencha.com/ext-js/4-0/#!/api/Ext.grid.column.Column-cfg-renderer
      */
-    _spatialBoundsRenderer : function(value, metaData, record, row, col, store, gridView) {
+    _spatialBoundsRenderer : function(value, record) {
         var spatialBounds = this.getSpatialBoundsForRecord(record);
 
         if (spatialBounds.length > 0 || record.internalId == 'portal-InSar-reports') {                                   
             var icon = null;
             if (this.mapExtentIcon) {
-                icon = this._generateHTMLIconMarkup(this.mapExtentIcon);
+                icon = this.mapExtentIcon;
             } else {
-                icon = this._generateHTMLIconMarkup('portal-core/img/magglass.gif');
+                icon = 'portal-core/img/magglass.gif';
             }
             return icon;
         }
@@ -226,7 +223,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
      *
      * Show a popup containing info about the services that 'power' this layer
      */
-    _serviceInformationClickHandler : function(column, record, rowIndex, colIndex) {
+    _serviceInformationClickHandler : function(value, record) {
         var cswRecords = this.getCSWRecordsForRecord(record);
         if (!cswRecords || cswRecords.length === 0) {
             return;
@@ -247,7 +244,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
      *
      * On single click, show a highlight of all BBoxes
      */
-    _spatialBoundsClickHandler : function(column, record, rowIndex, colIndex) {
+    _spatialBoundsClickHandler : function(value, record) {
         var spatialBoundsArray;
         if (record.internalId == 'portal-InSar-reports') {
             spatialBoundsArray = this.getWholeGlobeBounds();
@@ -298,7 +295,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
      *
      * On double click, move the map so that specified bounds are visible
      */
-    _spatialBoundsDoubleClickHandler : function(column, record, rowIndex, colIndex) {
+    _spatialBoundsDoubleClickHandler : function(value, record) {
         var spatialBoundsArray;
         if (record.internalId == 'portal-InSar-reports') {
             spatialBoundsArray = this.getWholeGlobeBounds();
@@ -321,7 +318,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
      * A renderer for generating the contents of the tooltip that shows when the
      * layer is loading
      */
-    _loadingTipRenderer : function(value, record, column, tip) {
+    _loadingTipRenderer : function(value, record, tip) {
         var layer = record.get('layer');
         if(!layer){//VT:The layer has yet to be created.
             return 'No status has been recorded';
@@ -340,7 +337,7 @@ Ext.define('portal.widgets.panel.CommonBaseRecordPanel', {
         return renderer.renderStatus.renderHtml();
     },
     
-    _loadingClickHandler : function(value, record, rowIdx, tip) {
+    _loadingClickHandler : function(value, record) {
         
         var layer = record.get('layer');
         

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/RecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/RecordPanel.js
@@ -1,0 +1,291 @@
+/**
+ * Ext.panel.Panel extension to roughly reproduce an Ext.grid.Panel for displaying
+ * grouped layer records with custom panels on each layer's expander 
+ * 
+ * The old grid panel was deprecated as part of AUS-2685
+ */
+Ext.define('portal.widgets.panel.RecordPanel', {
+    extend : 'Ext.panel.Panel',
+    xtype : 'recordpanel',
+    
+    config: {
+        store: null,
+        titleField: 'name',
+        titleIndex: 0,
+        tools: null,
+        childPanelGenerator: Ext.emptyFn
+    },
+    
+    toolFieldMap: null, //A map of tool config objects keyed by field name
+    recordRowMap: null, //A map of RecordRowPanel itemId's keyed by their recordId
+    
+    /**
+     * Extends Ext.panel.Panel and adds the following:
+     * {
+     *  store: Ext.data.Store - Contains the layer elements
+     *  titleField: String - The field in store's underlying data model that will populate the title of each record
+     *  titleIndex: Number - The 0 based index of where the title field will fit in amongst tools (default - 0)
+     *  tools: Object[] - The additional tool columns, each bound to fields in the underlying data model
+     *             field - String -The field name in the model to bind this tool icon to
+     *             stopEvent: Boolean - If true, click events will not propogate upwards from this tool.
+     *             clickHandler - function(value, record) - Called whenever this tool is clicked. No return value.
+     *             doubleClickHandler - function(value, record) - Called whenever this tool is clicked. No return value.
+     *             tipRenderer - function(value, record, tip) - Called whenever a tooltip is generated. Return HTML content to display in tip
+     *             iconRenderer - function(value, record) - Called whenever the underlying field updates. Return String URL to icon that will be displayed in tip.
+     *  childPanelGenerator: function(record) - Called when records are added to the store. Return a generated Ext.Container for display in the specified row's expander
+     * }
+     */
+    constructor : function(config) {        
+        //Ensure we setup the correct layout
+        Ext.apply(config, {
+            layout: {
+                type: 'accordion',
+                collapseFirst: true,
+                fill: false,
+                multi: true
+            },
+            autoScroll: true,
+            plugins: ['collapsedaccordian']
+        });
+        
+        this.callParent(arguments);
+        
+        this._generateToolFieldMap();
+        
+        this.store.on({
+            update: this.onStoreUpdate,
+            load: this.onStoreLoad,
+            beforeload: this.onStoreBeforeLoad,
+            filterchange: this.onStoreFilterChange,
+            scope: this
+        });
+    },
+
+    /**
+     * Populates toolFieldMap with the contents of the current tool config
+     */
+    _generateToolFieldMap: function() {
+        this.toolFieldMap = {};
+        
+        Ext.each(this.tools, function(toolCfg) {
+            if (Ext.isEmpty(this.toolFieldMap[toolCfg.field])) {
+                this.toolFieldMap[toolCfg.field] = toolCfg;
+            } else {
+                throw 'Multiple tools with the same field value unsupported';
+            }
+        }, this);
+    },
+    
+    /**
+     * Enumerates each RecordGroupPanel and passes them one by one to callback
+     */
+    _eachGroup: function(callback, scope) {
+        this.items.each(function(recordGroupPanel) {
+            if (recordGroupPanel instanceof portal.widgets.panel.RecordGroupPanel) { 
+                callback.call(scope, recordGroupPanel);
+            }
+        });
+    },
+    
+    /**
+     * Enumerates each RecordRowPanel and passes them one by one to callback
+     */
+    _eachRow: function(callback, scope) {
+        this._eachGroup(function(recordGroupPanel) {
+            recordGroupPanel.items.each(function(recordRowPanel) {
+                if (recordRowPanel instanceof portal.widgets.panel.RecordRowPanel) {
+                    callback.call(scope, recordRowPanel);
+                }
+            });
+        });
+    },
+    
+    /**
+     * Simple wrapper around a tool click event that extracts the current
+     * record field value and passes it to the delegate
+     */
+    _clickMarshaller: function(record, fieldName, handler) {
+        var value = record.get(fieldName);
+        handler.call(this, value, record);
+    },
+    
+    /**
+     * Installs all tooltips for the specified recordRowPanel. Ensure this is only
+     * called once per recordRowPanel or tooltips will leak.
+     */
+    _installToolTips: function(recordRowPanel) {
+        var record = this.store.getById(recordRowPanel.recordId);
+        recordRowPanel.tipMap = {};
+        
+        //Install a unique tooltip for each tool
+        Ext.each(this.tools, function(tool) {
+            recordRowPanel.tipMap[tool.field] = Ext.create('Ext.tip.ToolTip', {
+                target: recordRowPanel.getHeader().down('#' + tool.field).getEl(),
+                trackMouse: true,
+                listeners: {
+                    beforeshow: function(tip) {
+                        var content = tool.tipRenderer(record.get(tool.field), record, tip);
+                        tip.update(content);
+                    }
+                }
+            });
+        });
+        
+        //Ensure we destroy the tips if we remove this panel
+        recordRowPanel.on('destroy', function(recordRowPanel) {
+            for (var key in recordRowPanel.tipMap) {
+                recordRowPanel.tipMap[key].destroy();
+            }
+            recordRowPanel.tipMap = {};
+        });
+    },
+    
+    /**
+     * Handle updating renderers/tips for the modified fields
+     */
+    onStoreUpdate: function(store, record, operation, modifiedFieldNames, details) {
+        if (!this.items.getCount()) {
+            return;
+        }
+        
+        //Figure out what fields we actually need to update
+        var fieldsToUpdate = [];
+        Ext.each(modifiedFieldNames, function(modifiedField) {
+            if (!Ext.isEmpty(this.toolFieldMap[modifiedField])) {
+                fieldsToUpdate.push(modifiedField);
+            }
+        }, this);
+        if (Ext.isEmpty(fieldsToUpdate)) {
+            return;
+        }
+        
+        //Update the modifiedFields
+        var itemId = this.recordRowMap[record.getId()];
+        var recordRowPanel = this.down('#' + itemId);
+        if (!recordRowPanel) {
+            return;
+        }
+        
+        Ext.each(fieldsToUpdate, function(field) {
+            var tool = this.toolFieldMap[field];
+            var img = recordRowPanel.down('#' + field);
+            var newSrc = tool.iconRenderer(record.get(field), record);
+            
+            img.setSrc(newSrc);
+        }, this);
+    },
+
+    /**
+     * When the store starts loading, begin prepping the panel for displaying
+     * records
+     */
+    onStoreBeforeLoad: function(store, operation) {
+        if (!this.rendered) {
+            return;
+        }
+        
+        if (!this.loadMask) {
+            this.loadMask = new Ext.LoadMask({
+                msg: 'Loading...',
+                target: this
+            });
+        } 
+        
+        this.loadMask.show();
+    },
+    
+    /**
+     * When a filter changes, we need to enumerate each record row to see if it's currently in the filtered store (or not)
+     * and shift its visibility accordingly
+     */
+    onStoreFilterChange: function(store, filters) {
+        this.getLayout().suspendAnimations();
+        
+        this._eachRow(function(recordRowPanel) {
+            var filtered = store.find('id', recordRowPanel.recordId) < 0; //we cant use store.getById as that bypasses any filters
+            recordRowPanel.setHidden(filtered);
+        }, this);
+        
+        this._eachGroup(function(recordGroupPanel) {
+            recordGroupPanel.refreshTitleCount();
+            if (recordGroupPanel.visibleItemCount) {
+                recordGroupPanel.setHidden(false);
+            } else {
+                recordGroupPanel.setHidden(true);
+            }
+        });
+        
+        this.getLayout().resumeAnimations();
+    },
+    
+    /**
+     * When we receive a new set of records, update all items in the display
+     */
+    onStoreLoad: function(store, records, successful) {
+        if (this.loadMask) {
+            this.loadMask.hide();
+        }
+        
+        //Clear out the panel first (dont use removeAll otherwise we'll remove
+        //our #collapsedtarget hidden items from CollapsedAccordianLayout
+        for (var i = this.items.getCount() - 1; i >= 0; i--) {
+            var item = this.items.getAt(i);
+            if (item instanceof portal.widgets.panel.RecordGroupPanel) {
+                this.remove(item);
+            }
+        }
+        this.recordRowMap = {};
+        
+        //Run through our groups of records, creating new 
+        //items as we go 
+        var newItems = [];
+        var groups = store.getGroups();
+        groups.each(function(groupObj) {
+            var rows = [];
+            
+            //Create a RecordRowPanel for each row we receive
+            Ext.each(groupObj.items, function(record) {
+                var tools = [];
+                Ext.each(this.tools, function(tool) {
+                    var fieldValue = record.get(tool.field);
+                    var clickBind = Ext.isEmpty(tool.clickHandler) ? null : Ext.bind(this._clickMarshaller, this, [record, tool.field, tool.clickHandler], false);
+                    var doubleClickBind = Ext.isEmpty(tool.doubleClickHandler) ? null : Ext.bind(this._clickMarshaller, this, [record, tool.field, tool.doubleClickHandler], false);
+                    tools.push({
+                        itemId: tool.field,
+                        stopEvent: tool.stopEvent,
+                        clickHandler: clickBind,
+                        doubleClickHandler: doubleClickBind,
+                        icon: tool.iconRenderer(fieldValue, record)
+                    });
+                }, this);
+                
+                var recordId = record.getId();
+                var newItemId = Ext.id(null, 'record-row-');
+                this.recordRowMap[recordId] = newItemId; 
+                rows.push({
+                    xtype: 'recordrowpanel',
+                    recordId: recordId,
+                    itemId: newItemId,
+                    title: record.get(this.titleField), 
+                    titleIndex: this.titleIndex,
+                    tools: tools,
+                    items: [this.childPanelGenerator(record)],
+                    listeners: {
+                        scope: this,
+                        afterrender: this._installToolTips
+                    }
+                });
+            }, this);
+            
+            var newGroup = {
+                xtype: 'recordgrouppanel',
+                title: groupObj.getConfig().groupKey,
+                items: rows
+            };
+            
+            newItems.push(newGroup);
+        }, this);
+        
+        this.add(newItems);
+    }
+});

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/RecordRowPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/RecordRowPanel.js
@@ -1,0 +1,92 @@
+/**
+ * Ext.panel.Panel extensions to emulate the display of a grid panel row for a CommonBaseRecordPanel widget.
+ * 
+ * The grid panel was deprecated as part of AUS-2685
+ */
+Ext.define('portal.widgets.panel.RecordRowPanel', {
+    extend : 'Ext.panel.Panel',
+    xtype : 'recordrowpanel',
+    
+    config: {
+        titleIndex: 0,
+        tools: null
+    },
+    
+    /**
+     * {
+     *  title: String - title for this row panel
+     *  titleIndex: Number - 0 based position of the title amongst all tools. (default 0)
+     * 
+     *  tools: Object[] - The additional tool columns, each bound to fields in the underlying data model
+     *             clickHandler - function() - Called whenever this tool is clicked. No return value.
+     *             doubleClickHandler - function() - Called whenever this tool is double clicked. No return value.
+     *             icon - String - the icon to be displayed
+     *             stopEvent - Boolean - whether the click events should be stopped propogating upwards
+     * }
+     */
+    constructor : function(config) {
+        var headerItems = [];
+        Ext.each(config.tools, function(tool, index) {
+            var leftMargin = '5';
+            var rightMargin = '5';
+            if (index == 0) {
+                leftMargin = '0';
+            }
+            
+            if (index == (config.tools.length - 1)) {
+                rightMargin = '0';
+            }
+            
+            headerItems.push({
+                xtype : 'image',
+                itemId: tool.itemId,
+                width : 16,
+                height : 16,
+                margin : Ext.util.Format.format('0 {0} 0 {1}', rightMargin, leftMargin),
+                src : tool.icon,
+                plugins : [{
+                    ptype: 'clickableimage', 
+                    stopEvent: !!tool.stopEvent
+                }],
+                listeners : {
+                    click : Ext.isEmpty(tool.clickHandler) ? Ext.emptyFn : tool.clickHandler,
+                    dblclick : Ext.isEmpty(tool.doubleClickHandler) ? Ext.emptyFn : tool.doubleClickHandler
+                }
+            });
+        });
+        
+        var title = config.title;
+        
+        delete config.tools;
+        delete config.title;
+        
+        Ext.apply(config, {
+            layout : 'fit',
+            border: true,
+            bodyStyle: {
+                'border-color': '#ededed'
+            },
+            header : {
+                titlePosition : Ext.isNumber(config.titleIndex) ? config.titleIndex : 0,
+                border: false,
+                style : {
+                    'background-color':'white',
+                    'border-color': '#ededed'
+                },
+                items : headerItems,
+                padding: '8 0 8 0',
+                height: 30,
+                title: {
+                    text: title,
+                    margin: '0 0 0 10',
+                    style: {
+                        'font-size': '13px',
+                        'font-weight': 'normal',
+                        'color': '#000000'
+                    }
+                }
+            }
+        });
+        this.callParent(arguments);
+    }
+});

--- a/src/main/webapp/portal-core/js/portal/widgets/plugins/ClickableImage.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/plugins/ClickableImage.js
@@ -1,0 +1,42 @@
+/**
+ * Plugin to apply to Ext.Image components. Adds a "click" event
+ * to the image by binding to the rendered DOM click event
+ */
+Ext.define('portal.widgets.plugins.ClickableImage', {
+    extend : 'Ext.plugin.Abstract',
+    alias : 'plugin.clickableimage',
+
+    stopEvent : false,
+
+    /**
+     * stopEvent - Boolean - if true, the event will be stopped from propogating upwards. Defaults to false
+     */
+    constructor : function(config) {
+        this.stopEvent = !!config.stopEvent;
+    },
+
+    init : function(cmp) {
+        if (cmp.rendered) {
+            this.installEvents(cmp);
+        } else {
+            cmp.on('afterrender', this.installEvents, this);
+        }
+    },
+
+    installEvents : function(cmp) {
+        var el = cmp.getEl();
+        el.on('click', function(e, t, eOpts) {
+            if (this.stopEvent) {
+                e.stopEvent();
+            }
+            cmp.fireEvent('click', cmp, e);
+        }, this);
+        
+        el.on('dblclick', function(e, t, eOpts) {
+            if (this.stopEvent) {
+                e.stopEvent();
+            }
+            cmp.fireEvent('dblclick', cmp, e);
+        }, this);
+    }
+});

--- a/src/main/webapp/portal-core/js/portal/widgets/plugins/CollapsedAccordianLayout.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/plugins/CollapsedAccordianLayout.js
@@ -1,0 +1,33 @@
+
+/**
+ * Collapsed accordian can be applied to any container using the accordian layout.
+ * 
+ * This will allow all accordian panels to be closed (default behaviour is that one is always open)
+ */
+Ext.define('portal.widgets.plugins.CollapsedAccordian', {
+    extend : 'Ext.plugin.Abstract',
+    alias : 'plugin.collapsedaccordian',
+
+    statics : {
+        HIDDEN_ID : 'collapsedtarget'
+    },
+
+    init : function(cmp) {
+        cmp.insert(0, {
+            xtype : 'panel',
+            hidden : true,
+            itemId : portal.widgets.plugins.CollapsedAccordian.HIDDEN_ID,
+            collapsed : false
+        });
+
+        var cfg = Ext.apply({}, cmp.initialConfig);
+        var layoutCfg = cfg.layout;
+        if (Ext.isString(layoutCfg)) {
+            layoutCfg = {};
+        }
+
+        layoutCfg.type = 'accordiondefault';
+        layoutCfg.defaultId = portal.widgets.plugins.CollapsedAccordian.HIDDEN_ID;
+        cmp.setLayout(layoutCfg)
+    }
+});

--- a/src/main/webapp/portal-core/jsimports.jsp
+++ b/src/main/webapp/portal-core/jsimports.jsp
@@ -2,7 +2,6 @@
 <link rel="stylesheet" type="text/css" href="portal-core/js/ext-5.1.1/build/packages/ext-theme-neptune/build/resources/ext-theme-neptune-all.css">
 <link rel="stylesheet" type="text/css" href="portal-core/js/ext-5.1.1/build/packages/sencha-charts/build/neptune/resources/sencha-charts-all.css">
 
-
 <!-- link extjs 5 -->
 <script type="text/javascript" src="portal-core/js/ext-5.1.1/build/ext-all-debug.js?v=${buildTimestamp}"></script>
 <script type="text/javascript" src="portal-core/js/ext-5.1.1/build/packages/ext-ux/build/ext-ux-debug.js?v=${buildTimestamp}"></script>
@@ -141,6 +140,10 @@
 <script src="portal-core/js/portal/widgets/grid/plugin/RowContextMenu.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/grid/plugin/RowExpanderContainer.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/grid/plugin/InlineContextMenu.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/widgets/layout/AccordianDefault.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/widgets/panel/RecordGroupPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/widgets/panel/RecordRowPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/widgets/panel/RecordPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/panel/CommonBaseRecordPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/panel/BaseRecordPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/panel/CSWConstraintsPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
@@ -152,6 +155,8 @@
 <script src="portal-core/js/portal/widgets/panel/KnownLayerPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/panel/LayerPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/panel/OnlineResourcesPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/widgets/plugins/ClickableImage.js?v=${buildTimestamp}" type="text/javascript"></script>
+<script src="portal-core/js/portal/widgets/plugins/CollapsedAccordianLayout.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/tab/ActivePreRenderTabPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/window/CSWRecordConstraintsWindow.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/window/CSWSelectionWindow.js?v=${buildTimestamp}" type="text/javascript"></script>
@@ -164,8 +169,6 @@
 <script src="portal-core/js/portal/widgets/model/CSWServices.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/panel/CSWFilterFormPanel.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/widgets/FilterPanelMenuFactory.js?v=${buildTimestamp}" type="text/javascript"></script>
-
-
 
 <script src="portal-core/js/portal/charts/BaseD3Chart.js?v=${buildTimestamp}" type="text/javascript"></script>
 <script src="portal-core/js/portal/charts/3DScatterPlot.js?v=${buildTimestamp}" type="text/javascript"></script>


### PR DESCRIPTION
This contains breaking changes to extensions to CommonBaseRecordPanel/BaseRecordPanel. 

The current implementation of the rowexpandercontainer is a mess due to ExtJS 5 blowing away all DOM elements on group/row collapse. This is our attempt to have something identical in functionality but without any of the flakiness.

The approach has been to abandon Ext.grid.Panel in favour of several nested Ext.panel.Panel objects in a modified accordian layout. The nested accordian panels emulate the groups/rows/rowexpander panels.

The new implementation is more or less the same as the old Ext.grid.Panel widget. It however does NOT emulate the original configuration API identically so there are some minor breaking changes.