### PR TITLE
AUS-2629 Fixed render bug: 'Clicking on "Add all current page records…

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -268,9 +268,10 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                     if(!(csws instanceof Array)){
                         csws = [csws];
                     }
-                    for(var i=0; i < csws.length; i++){
+                    for(var i=csws.length-1; i>=0; i--){
                         csws[i].set('customlayer',true);
                         customPanel.getStore().insert(0,csws[i]);
+                        customPanel.ensureVisible(0);
                     }
                     
                 }


### PR DESCRIPTION
Fixed render bug: 'Clicking on "Add all current page records leaves a large blank area at the top of scroll area'

Fixed 'Clicking on "Add all current page records" also adds the rows in
the reverse order