### PR TITLE
AUS-2628: Fix to 'Northern Yilgarn "Scatter Plot" does not appear, in…

### DIFF
--- a/src/main/java/org/auscope/portal/core/util/CSVUtil.java
+++ b/src/main/java/org/auscope/portal/core/util/CSVUtil.java
@@ -8,6 +8,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
 
 public class CSVUtil {
 
@@ -42,22 +44,33 @@ public class CSVUtil {
         }
         HashMap<String, ArrayList<String>> result = new HashMap<String, ArrayList<String>>();
 
+        // Adds in an empty ArrayList for each column name
         for (String column : columns) {
             result.put(column, new ArrayList<String>());
         }
 
         String line = "";
+
+        // 'doneCols' is used to make sure that duplicate columns are not processed twice
+        Set<String> doneCols = new HashSet<String>();
+
+        // Loop over each line of CSV, setting the desired columns' values
         while ((line = csvReader.readLine()) != null) {
             if (line.isEmpty())
                 continue;
+
             String[] tokens = line.split(",(?=([^\"]*\"[^\"]*\")*[^\"]*$)", -1);
             for (int i = 0; i < columnIndex.length; i++) {
-                if (columnIndex[i] < tokens.length) {
-                    result.get(columns[i]).add(tokens[columnIndex[i]]);
-                } else {
-                    result.get(columns[i]).add("");
+                if (!doneCols.contains(columns[i])) {
+                    if (columnIndex[i] < tokens.length) {
+                        result.get(columns[i]).add(tokens[columnIndex[i]]);
+                    } else {
+                        result.get(columns[i]).add("");
+                    }
+                    doneCols.add(columns[i]);
                 }
             }
+            doneCols.clear();
         }
 
         return result;

--- a/src/test/java/org/auscope/portal/core/util/TestCSVUtil.java
+++ b/src/test/java/org/auscope/portal/core/util/TestCSVUtil.java
@@ -88,4 +88,17 @@ public class TestCSVUtil extends PortalTestClass {
         Assert.assertEquals("JHP9", columns.get("name").get(1));
 
     }
+    
+    /** 
+     * Tests that if you input duplicate columns to 'getColumnOfInterest', it returns the correct number of elements
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDuplicateCols() throws Exception {
+        String[] dup_names = {"name","name","FID"};
+        HashMap<String, ArrayList<String>> columns = csvUtil.getColumnOfInterest(dup_names);
+        Assert.assertEquals(5, columns.get("name").size());
+        Assert.assertEquals(5, columns.get("FID").size());
+    }
 }


### PR DESCRIPTION
Fix to 'Northern Yilgarn "Scatter Plot" does not appear, instead
I get a "Resource failed to load" error box'. This occurs when user selects the
same x-axis and y-axis, and a bug meant that 'CSVUtil' would return too
many values, thus causing an exception.