### PR TITLE
AUS-2634: Fix for Earth resource mine information window does not appear

### DIFF
--- a/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
@@ -241,7 +241,7 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
                             // layers get filtered based on the service provider
                             // or from a single provider and based on the layer name
                             if (resourcesToIterate[k].get('name') != serviceFilter &&
-                                    this._getDomain(resourcesToIterate[k].get('url')) != serviceFilter) {
+                                    this._getDomain(resourcesToIterate[k].get('url')) != this._getDomain(serviceFilter)) {
                                 continue;
                             }
                         }


### PR DESCRIPTION
Fix for Earth resource mine information window does not appear when map is clicked.
Introduced by GPT-133. Need to apply __getDomain() to both sides of
equivalence test.