### PR TITLE
AUS-2639: UI bug when adding KML layer

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/Layer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/Layer.js
@@ -80,7 +80,8 @@ Ext.define('portal.layer.Layer', {
             var onlineResourcesForLayer = [];
             var cswRecords = layerStore.data.items[i].data.cswRecords;
             for (var j = 0; j < cswRecords.length; j++) {
-                onlineResourcesForLayer = onlineResourcesForLayer.concat(cswRecords[j].data.onlineResources);
+			    if (cswRecords[j].data.onlineResources)
+                    onlineResourcesForLayer = onlineResourcesForLayer.concat(cswRecords[j].data.onlineResources);
             }
 
             var layerNameArray = [];


### PR DESCRIPTION
The KML layer, unlike most other layers, leaves 'onlineResources' as
'null', so an additional check is needed.