### PR TITLE
Anvgl 157: Add X1 and other current AWS machine types

### DIFF
--- a/src/main/java/org/auscope/portal/core/cloud/ComputeType.java
+++ b/src/main/java/org/auscope/portal/core/cloud/ComputeType.java
@@ -28,6 +28,11 @@ public class ComputeType implements Serializable {
     /** How much does the Ephemeral disk of this compute type offer (in GB) */
     private Integer ephemeralDiskGB;
 
+    public ComputeType(String id, int vcpus, int ramMB) {
+        this.id=id;
+        this.vcpus=vcpus;
+        this.ramMB=ramMB;
+    }
     /**
      * 
      * @param id

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -291,17 +291,17 @@ public class CloudComputeServiceAws extends CloudComputeService {
     }
 
     final static ComputeType[] COMPUTE_TYPES = {
-           new ComputeType("m4.large", 2, 8000),
-           new ComputeType("m4.xlarge", 4, 16000),
-           new ComputeType("m4.2xlarge", 8, 32000),
-           new ComputeType("m4.4xlarge", 16, 64000),
-           new ComputeType("m4.10xlarge", 40, 160000), 
-           new ComputeType("c4.large", 2, 3750),
-           new ComputeType("c4.xlarge", 4, 7500),
-           new ComputeType("c4.2xlarge", 8, 15000),
-           new ComputeType("c4.4xlarge", 16, 30000),
-           new ComputeType("c4.8xlarge", 36, 60000),
-           new ComputeType("x1.32xlarge", 128, 1920000),
+            new ComputeType("x1.32xlarge", 128, 1920000),
+            new ComputeType("c4.8xlarge", 36, 60000),
+            new ComputeType("c4.4xlarge", 16, 30000),
+            new ComputeType("c4.2xlarge", 8, 15000),
+            new ComputeType("c4.xlarge", 4, 7500),
+            new ComputeType("c4.large", 2, 3750),
+            new ComputeType("m4.10xlarge", 40, 160000),
+            new ComputeType("m4.4xlarge", 16, 64000),
+            new ComputeType("m4.2xlarge", 8, 32000),
+            new ComputeType("m4.xlarge", 4, 16000),
+            new ComputeType("m4.large", 2, 8000)
     };
     
     /**
@@ -314,7 +314,7 @@ public class CloudComputeServiceAws extends CloudComputeService {
         ArrayList<ComputeType> result = new ArrayList<>();
         
         for (ComputeType type : COMPUTE_TYPES) {
-            if(type.getVcpus()>= minimumVCPUs && type.getRamMB()>= minimumRamMB) {
+            if(    (minimumVCPUs == null || type.getVcpus()>= minimumVCPUs) && (minimumRamMB == null || type.getRamMB()>= minimumRamMB)) {
                 result.add(type);
             }
         }

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -7,8 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
-import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -24,12 +22,6 @@ import org.auscope.portal.core.cloud.CloudJob;
 import org.auscope.portal.core.cloud.ComputeType;
 import org.auscope.portal.core.services.PortalServiceException;
 import org.auscope.portal.core.util.TextUtil;
-import org.jclouds.ContextBuilder;
-import org.jclouds.compute.ComputeService;
-import org.jclouds.compute.ComputeServiceContext;
-import org.jclouds.compute.domain.Hardware;
-import org.jclouds.compute.domain.Processor;
-import org.jclouds.compute.domain.Volume;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -298,72 +290,35 @@ public class CloudComputeServiceAws extends CloudComputeService {
         ec2.terminateInstances(terminateInstancesRequest);
     }
 
+    final static ComputeType[] COMPUTE_TYPES = {
+           new ComputeType("m4.large", 2, 8000),
+           new ComputeType("m4.xlarge", 4, 16000),
+           new ComputeType("m4.2xlarge", 8, 32000),
+           new ComputeType("m4.4xlarge", 16, 64000),
+           new ComputeType("m4.10xlarge", 40, 160000), 
+           new ComputeType("c4.large", 2, 3750),
+           new ComputeType("c4.xlarge", 4, 7500),
+           new ComputeType("c4.2xlarge", 8, 15000),
+           new ComputeType("c4.4xlarge", 16, 30000),
+           new ComputeType("c4.8xlarge", 36, 60000),
+           new ComputeType("x1.32xlarge", 128, 1920000),
+    };
+    
     /**
      * An array of compute types that are available through this compute service
      */
     @Override
     public ComputeType[] getAvailableComputeTypes(Integer minimumVCPUs, Integer minimumRamMB,
             Integer minimumRootDiskGB) {
-        // InstanceType[] types = InstanceType.values();
-
-        Properties overrides = new Properties();
-
-        ContextBuilder builder = ContextBuilder.newBuilder("aws-ec2").overrides(overrides);
-
-        if (devAccessKey != null && devSecretKey != null)
-            builder.credentials(devAccessKey, devSecretKey);
-
-        if (getApiVersion() != null) {
-            builder.apiVersion(getApiVersion());
-        }
-
-        if (getEndpoint() != null) {
-            builder.endpoint(getEndpoint());
-        }
-
-        try (ComputeServiceContext context = builder.buildView(ComputeServiceContext.class)) {
-            ComputeService computeService = context.getComputeService();
-            Set<? extends Hardware> hardwareSet = computeService.listHardwareProfiles();
-
-            List<ComputeType> computeTypes = new ArrayList<>();
-
-            for (Hardware hw : hardwareSet) {
-                ComputeType ct = new ComputeType(hw.getId());
-
-                ct.setDescription(hw.getName());
-                double vCpus = 0;
-                for (Processor p : hw.getProcessors()) {
-                    vCpus += p.getCores();
-                }
-                ct.setVcpus((int) vCpus);
-                ct.setRamMB(hw.getRam());
-
-                double rootDiskGB = 0;
-                double ephemeralDiskGB = 0;
-                for (Volume v : hw.getVolumes()) {
-                    if (v.isBootDevice()) {
-                        rootDiskGB += v.getSize();
-                    } else {
-                        ephemeralDiskGB += v.getSize();
-                    }
-                }
-                ct.setRootDiskGB((int) rootDiskGB);
-                ct.setEphemeralDiskGB((int) ephemeralDiskGB);
-
-                // Skip anything that doesn't match our filters
-                if (minimumVCPUs != null && minimumVCPUs > ct.getVcpus()) {
-                    continue;
-                } else if (minimumRamMB != null && minimumRamMB > ct.getRamMB()) {
-                    continue;
-                } else if (minimumRootDiskGB != null && minimumRootDiskGB > ct.getRootDiskGB()) {
-                    continue;
-                }
-
-                computeTypes.add(ct);
+        
+        ArrayList<ComputeType> result = new ArrayList<>();
+        
+        for (ComputeType type : COMPUTE_TYPES) {
+            if(type.getVcpus()>= minimumVCPUs && type.getRamMB()>= minimumRamMB) {
+                result.add(type);
             }
-
-            return computeTypes.toArray(new ComputeType[computeTypes.size()]);
         }
+        return result.toArray(new ComputeType[result.size()]);
     }
 
     /**


### PR DESCRIPTION
Fixes ANVGL-157: Added X1 machine types and change c3/m3 to c4/m4.