### PR TITLE
Better handling of unset computeInstanceId in job status query on AWS.

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -414,7 +414,8 @@ public class CloudComputeServiceAws extends CloudComputeService {
         }
 
         if (StringUtils.isEmpty(job.getComputeInstanceId())) {
-            throw new PortalServiceException("No compute instance ID has been set");
+            logger.debug("Unexpected missing job ID in getJobStatus(). Will return 'pending'. Local status: "+job.getStatus());
+            return InstanceStatus.Pending;
         }
 
         DescribeInstanceStatusRequest request = new DescribeInstanceStatusRequest();

--- a/src/main/java/org/auscope/portal/core/view/JSONView.java
+++ b/src/main/java/org/auscope/portal/core/view/JSONView.java
@@ -43,12 +43,15 @@ public class JSONView extends AbstractView {
     protected void renderMergedOutputModel(Map<String, Object> model, HttpServletRequest request,
             HttpServletResponse response) throws IOException {
         response.setContentType(getContentType());
-
+        String content;
+        
         if (jsonArray != null) { //convert just the array
-            response.getWriter().write(JSONSerializer.toJSON(jsonArray, cfg).toString());
+            content = JSONSerializer.toJSON(jsonArray, cfg).toString();
         } else { //send of the object
-            response.getWriter().write(JSONSerializer.toJSON(model, cfg).toString());
+            content = JSONSerializer.toJSON(model, cfg).toString();
         }
+        
+        response.getWriter().write(content);
     }
 
 }


### PR DESCRIPTION
Now returning "pending" when computeInstanceId is not set in getJobStatus(). Also writing debug message to log.

Saving JSON content to local variable before writing to response to make debugging easier.