### PR TITLE
Wrap ASE in PSE on RunInstances request

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -258,7 +258,14 @@ public class CloudComputeServiceAws extends CloudComputeService {
             // Placement(getZone()));
         }
 
-        RunInstancesResult runInstances = ec2.runInstances(runInstancesRequest);
+        // Wrap any AWS exception into a PortalServiceException
+        RunInstancesResult runInstances;
+        try {
+            runInstances = ec2.runInstances(runInstancesRequest);
+        }
+        catch (AmazonServiceException ex) {
+            throw new PortalServiceException("AWS RunInstances request failed", ex);
+        }
 
         // TAG EC2 INSTANCES
         List<Instance> instances = runInstances.getReservation().getInstances();


### PR DESCRIPTION
Wrap any AmazonServiceException on a RunInstances request in a PortalServiceException to re-throw, matching the throws clause on executeJob. ANVGL is catching PSEs, not other exceptions.