### PR TITLE
ANVGL-13 Added alias to CSWRecordPanel

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWRecordPanel.js
@@ -3,6 +3,7 @@
  * records conforming to the portal.csw.CSWRecord Model
  */
 Ext.define('portal.widgets.panel.CSWRecordPanel', {
+    alias: 'widget.cswrecordpanel',
     extend : 'portal.widgets.panel.BaseRecordPanel',
 
     constructor : function(cfg) {


### PR DESCRIPTION
Referencing CSWRecordPanel using an xtype is currently not possible. This adds a widget alias to fix that.