### PR TITLE
ANVGL-13 Added empty text support to RecordPanel

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/AbstractChild.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/AbstractChild.js
@@ -26,7 +26,7 @@ Ext.define('portal.widgets.panel.recordpanel.AbstractChild', {
         if (thisPanel.getGroupMode()) {
             thisPanel.ownerCt.suspendLayouts();
             thisPanel.ownerCt.items.each(function(sibling) {
-                if (sibling.getItemId() !== portal.widgets.plugins.CollapsedAccordian.HIDDEN_ID && sibling.getId() !== thisPanel.getId()) {
+                if (sibling instanceof portal.widgets.panel.recordpanel.AbstractChild && sibling.getId() !== thisPanel.getId()) {
                     sibling.collapseChildren();
                 }
             });
@@ -39,7 +39,7 @@ Ext.define('portal.widgets.panel.recordpanel.AbstractChild', {
      */
     collapseChildren : function() {
         this.items.each(function(item) {
-            if (item.getItemId() !== portal.widgets.plugins.CollapsedAccordian.HIDDEN_ID) {
+            if (item instanceof portal.widgets.panel.recordpanel.AbstractChild) {
                 if (item.getCollapsed() === false) {
                     item.collapse();
                 }
@@ -51,7 +51,7 @@ Ext.define('portal.widgets.panel.recordpanel.AbstractChild', {
         this.callParent(arguments);
 
         this.items.each(function(item) {
-            if (item.getItemId() !== portal.widgets.plugins.CollapsedAccordian.HIDDEN_ID) {
+            if (item instanceof portal.widgets.panel.recordpanel.AbstractChild) {
                 item.on('beforeexpand', function(item) {
                     this.fireEvent('childexpand', this, item);
                 }, this);

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
@@ -26,6 +26,7 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
      * Extends Ext.panel.Panel and adds the following:
      * {
      *  allowReordering: Boolean - If true, the records will be able to be reordered by dragging and dropping. Currently only supported with non grouped stores.
+     *  emptyText: String - HTML string that will be shown when the contents of this panel are empty.
      *  store: Ext.data.Store - Contains the layer elements
      *  titleField: String - The field in store's underlying data model that will populate the title of each record
      *  titleIndex: Number - The 0 based index of where the title field will fit in amongst tools (default - 0)
@@ -56,6 +57,15 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
                 fill: false,
                 multi: grouped
             },
+            items: [{
+                xtype: 'panel',
+                itemId: 'emptytext',
+                collapsed: false,
+                header: {
+                    hidden: true
+                },
+                html: config.emptyText
+            }],
             autoScroll: true,
             plugins: ['collapsedaccordian']
         });
@@ -463,6 +473,17 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
             this.add(rows);
         }
     },
+    
+    /**
+     * Updates the empty text hidden/visible status depending on whether any records are showing.
+     */
+    _updateEmptyText: function() {
+        if (this.items.getCount() <= 2) {
+            this.down('#emptytext').setHidden(false);
+        } else {
+            this.down('#emptytext').setHidden(true);
+        }
+    },
 
     /**
      * Handle updating renderers/tips for the modified fields
@@ -546,6 +567,8 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
 
         Ext.resumeLayouts();
         this.getLayout().resumeAnimations();
+        
+        this._updateEmptyText();
     },
 
     /**
@@ -572,6 +595,8 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
         } else {
             this._generateUnGrouped();
         }
+        
+        this._updateEmptyText();
     },
 
     /**
@@ -593,6 +618,8 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
         Ext.resumeLayouts();
         this.getLayout().resumeAnimations();
         this.doLayout();
+        
+        this._updateEmptyText();
     },
 
     /**
@@ -629,6 +656,8 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
         Ext.resumeLayouts();
         this.getLayout().resumeAnimations();
         this.doLayout();
+        
+        this._updateEmptyText();
     },
 
     /**

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
@@ -478,11 +478,23 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
      * Updates the empty text hidden/visible status depending on whether any records are showing.
      */
     _updateEmptyText: function() {
-        if (this.items.getCount() <= 2) {
-            this.down('#emptytext').setHidden(false);
+        var visibleItems = 0;
+        
+        if (this.store.isGrouped()) {
+            this._eachGroup(function(recordGroupPanel) {
+                if (recordGroupPanel.isVisible()) {
+                    visibleItems++;
+                }
+            });
         } else {
-            this.down('#emptytext').setHidden(true);
+            this._eachRow(function(recordRowPanel) {
+                if (recordRowPanel.isVisible()) {
+                    visibleItems++;
+                }
+            });
         }
+        
+        this.down('#emptytext').setHidden(visibleItems !== 0);
     },
 
     /**


### PR DESCRIPTION
Added an emptyText config option to RecordPanel that supports HTML. The emptyText (if configured) will show whenever the underlying record store is empty.