### PR TITLE
ANVGL-13 Made config options overridable

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -54,7 +54,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
             }];
         }
         
-        Ext.apply(cfg, {
+        Ext.applyIf(cfg, {
             cls : 'auscope-dark-grid',
             emptyText : '<p class="centeredlabel">No records match the current filter.</p>',
             dockedItems : dockedItems,


### PR DESCRIPTION
BaseRecordPanel can now be further extended by child classes by allowing all constructor config options to be overridable by default.