### PR TITLE
GPT-152 QLD Tenements and working with ArcGIS Server

### DIFF
--- a/src/main/java/org/auscope/portal/core/view/ViewCSWRecordFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewCSWRecordFactory.java
@@ -126,7 +126,7 @@ public class ViewCSWRecordFactory {
         obj.put("name", res.getName());
         obj.put("description", res.getDescription().toString());
         obj.put("version", res.getVersion());
-
+        obj.put("applicationProfile", res.getApplicationProfile());
         return obj;
     }
 

--- a/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
@@ -25,6 +25,7 @@ public class ViewKnownLayerFactory {
         obj.put("description", k.getDescription());
         obj.put("id", k.getId());
         obj.put("proxyUrl", k.getProxyUrl());
+        obj.put("proxyGetFeatureInfoUrl", k.getProxyGetFeatureInfoUrl());
         obj.put("proxyCountUrl", k.getProxyCountUrl());
         obj.put("proxyStyleUrl", k.getProxyStyleUrl());
         obj.put("proxyDownloadUrl", k.getProxyDownloadUrl());

--- a/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
+++ b/src/main/java/org/auscope/portal/core/view/ViewKnownLayerFactory.java
@@ -49,7 +49,6 @@ public class ViewKnownLayerFactory {
         obj.put("feature_count", k.getFeature_count());
         obj.put("order", k.getOrder());
         obj.put("singleTile", k.getSingleTile());
-        obj.put("forceWMSGet", k.getForceWMSGet());
         obj.put("staticLegendUrl", k.getStaticLegendUrl());
         
         String group = "Others";

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -71,12 +71,6 @@ public class KnownLayer implements Serializable {
      * (many is the default).
      */
     private Boolean singleTile = Boolean.FALSE;
-    
-    /** For cases where POSTing an SLD to a WMS service is not possible (eg ArcGIS) 
-     *  (default is not to force and let the JS framework decide based on URL length
-     *  which usually results in a POST)   
-     */
-    private Boolean forceWMSGet = Boolean.FALSE;
 
     /** A URL to use to grab a canned legend graphic for the layer (optional). */
     private String staticLegendUrl;
@@ -383,14 +377,6 @@ public class KnownLayer implements Serializable {
     public void setSingleTile(Boolean singleTile) {
         this.singleTile = singleTile;
     }
-
-	public Boolean getForceWMSGet() {
-		return forceWMSGet;
-	}
-
-	public void setForceWMSGet(Boolean forceWMSGet) {
-		this.forceWMSGet = forceWMSGet;
-	}
 
     public String getStaticLegendUrl() {
         return staticLegendUrl;

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -35,6 +35,9 @@ public class KnownLayer implements Serializable {
     /** URL to proxy data requests through */
     private String proxyUrl;
 
+    /** URL to proxy WMS Get Feature Info requests through */
+    private String proxyGetFeatureInfoUrl;
+    
     /** URL to proxy data count requests through */
     private String proxyCountUrl;
 
@@ -204,6 +207,14 @@ public class KnownLayer implements Serializable {
     public void setProxyUrl(String proxyUrl) {
         this.proxyUrl = proxyUrl;
     }
+    
+    public String getProxyGetFeatureInfoUrl() {
+		return proxyGetFeatureInfoUrl;
+	}
+
+	public void setProxyGetFeatureInfoUrl(String proxyGetFeatureInfoUrl) {
+		this.proxyGetFeatureInfoUrl = proxyGetFeatureInfoUrl;
+	}
 
     /**
      * Gets the URL to proxy data count requests through

--- a/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
+++ b/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
@@ -34,7 +34,6 @@ Ext.define('portal.knownlayer.KnownLayer', {
         { name: 'feature_count', type: 'string'}, //GetFeatureInfo feature_count attribute, 0 would be to default to whatever is set on the server.
         { name: 'order', type: 'string'},	// Order of the layers within a group
         { name: 'singleTile', type: 'boolean'},    // Whether the layer should be requested as a single image (ie not tiled)
-        { name: 'forceWMSGet', type: 'boolean'},    // Whether the layer should always use a GET request for WMS
         { name: 'staticLegendUrl', type: 'string'}    // A URL to use to grab a canned legend graphic for the layer, optional.
     ],
 

--- a/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
+++ b/src/main/webapp/portal-core/js/portal/knownlayer/KnownLayer.js
@@ -18,6 +18,7 @@ Ext.define('portal.knownlayer.KnownLayer', {
         { name: 'description', type: 'string' }, //A human readable description of this KnownLayer
         { name: 'group', type: 'string' }, //A term in which like KnownLayers can be grouped under
         { name: 'proxyUrl', type: 'string' }, //A URL of a backend controller method for fetching available data with a filter specific for this KnonwLayer
+        { name: 'proxyGetFeatureInfoUrl', type: 'string' }, // A URL of a backend controller method for processing the WMS Get Feature Info response
         { name: 'proxyCountUrl', type: 'string' }, //A URL of a backend controller method for fetching the count of data available (eg for WFS a URL that will set featureType=hits)
         { name: 'proxyStyleUrl', type: 'string' }, // A URL of a backend controller method for fetching style
         { name: 'proxyDownloadUrl', type: 'string' }, // A URL of a backend controller method for download request

--- a/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
+++ b/src/main/webapp/portal-core/js/portal/layer/legend/wms/WMSLegendForm.js
@@ -42,13 +42,14 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
             var dimensions = {maxWidth:330,height:30}; // Of all graphics so can resize window - accumulative height, max width (allow for title)
 
             for (var j = 0; j < wmsOnlineResources.length; j++) {
-
-                var width = config.sld_body ? null : this.getWidth();
+                var applicationProfile = wmsOnlineResources[j].get('applicationProfile');
+                var width = this._determineWidth(applicationProfile, config.sld_body);
 
                 portal.layer.legend.wms.WMSLegend.generateLegendUrl(
                     wmsOnlineResources[j].get('url'), 
                     wmsOnlineResources[j].get('name'),
                     wmsOnlineResources[j].get('version'),
+                    applicationProfile,
                     width,
                     config.sld_body,
                     config.isSld_body,
@@ -91,14 +92,16 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
         
         // do some AJAX stuff to populate the list of image URLS
         for (loopIndex; loopIndex < wmsOnlineResources.length; loopIndex++) {
-
-            var width = config.sld_body ? null : this.getWidth();
-
+            var applicationProfile = wmsOnlineResources[loopIndex].get('applicationProfile');
+            var width = this._determineWidth(applicationProfile, config.sld_body);
+            
+           
             var handler = portal.layer.legend.wms.WMSLegend.generateLegendUrl(
                     
                 wmsOnlineResources[loopIndex].get('url'), 
                 wmsOnlineResources[loopIndex].get('name'),
                 wmsOnlineResources[loopIndex].get('version'),
+                applicationProfile,
                 width,
                 config.sld_body,
                 config.isSld_body,
@@ -159,6 +162,16 @@ Ext.define('portal.layer.legend.wms.WMSLegendForm', {
             form.setWidth(dimensions.maxWidth);
         };
         image.src=url;
+    },
+    
+    _determineWidth : function(applicationProfile, sld_body) {
+        if (applicationProfile && applicationProfile.indexOf("Esri:ArcGIS Server") > -1) {
+            return 300;
+        } else if (sld_body) {
+            return null;
+        } else {
+            return this.getWidth();
+        }
     }
 
 });

--- a/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/primitives/WMSOverlay.js
@@ -26,9 +26,12 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
         if(wmsOnlineResources.length > 0 && wmsOnlineResources[0].get('version')){
             wmsVersion = wmsOnlineResources[0].get('version');
         }        
-                        
+        var applicationProfile = "";
+        if(wmsOnlineResources.length > 0 && wmsOnlineResources[0].get('applicationProfile')){
+            applicationProfile = wmsOnlineResources[0].get('applicationProfile');
+        } 
+        
         var singleTile = cfg.layer.get('source').get('singleTile');
-        var forceWMSGet = cfg.layer.get('source').get('forceWMSGet');
         
         var cswboundingBox= this._getCSWBoundingBox(cswRecord);        
 
@@ -54,13 +57,13 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
             additionalOptions.ratio = 1;
         }
         
-        if (forceWMSGet == false) {
+        if (applicationProfile !== "Esri:ArcGIS Server") {
         	additionalOptions.tileOptions.maxGetUrlLength = 1500;
         }
         
         if(this.getSld_body() && this.getSld_body().length > 0){            
             options.sld_body = this.getSld_body();
-            options.styles = this._getStylesFromSLD();
+            options.styles = this._getStylesFromSLD(applicationProfile);
             options.tiled = true;
         } 
 
@@ -84,12 +87,14 @@ Ext.define('portal.map.openlayers.primitives.WMSOverlay', {
      */
     
 
-    _getStylesFromSLD : function() {
-        if (this.getWmsUrl().toUpperCase().indexOf("MAPSERVER/WMSSERVER") < 0) return null;
-        var sld = portal.util.xml.SimpleDOM.parseStringToDOM(this.getSld_body());
-        // GPT-MS : This would be better as an XPath
-        // '/StyledLayerDescriptor/UserStyle/Name" but I couldn't get it to work.
-        return sld.getElementsByTagName("UserStyle")[0].getElementsByTagName("Name")[0].textContent;
+    _getStylesFromSLD : function(applicationProfile) {
+        if (applicationProfile && applicationProfile.indexOf("Esri:ArcGIS Server") > -1) {
+            var sld = portal.util.xml.SimpleDOM.parseStringToDOM(this.getSld_body());
+            // GPT-MS : This would be better as an XPath
+            // '/StyledLayerDescriptor/UserStyle/Name" but I couldn't get it to work.
+            return sld.getElementsByTagName("UserStyle")[0].getElementsByTagName("Name")[0].textContent;
+        }
+        return null;
     },
     
     _getCSWBoundingBox : function(cswrecords){

--- a/src/test/java/org/auscope/portal/core/view/TestViewCSWRecordFactory.java
+++ b/src/test/java/org/auscope/portal/core/view/TestViewCSWRecordFactory.java
@@ -53,6 +53,7 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
         final String orName = "ascom";
         final String orDesc = "desc";
         final OnlineResourceType orType = OnlineResourceType.WFS;
+        final String applicationProfile = "Esri:ArcGIS Server/x";
 
         final double bboxNorth = 10;
         final double bboxSouth = 5;
@@ -87,6 +88,7 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
         onlineResExpectation.put("description", orDesc);
         onlineResExpectation.put("type", orType.name());
         onlineResExpectation.put("version", version);
+        onlineResExpectation.put("applicationProfile", applicationProfile);
 
         geoExpectation.put("type", "bbox");
         geoExpectation.put("eastBoundLongitude", bboxEast);
@@ -138,6 +140,7 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
         onlineResExpectation_1.put("description", orDesc_1);
         onlineResExpectation_1.put("type", orType_1.name());
         onlineResExpectation_1.put("version", version);
+        onlineResExpectation_1.put("applicationProfile", applicationProfile);
 
         context.checking(new Expectations() {
             {
@@ -224,6 +227,8 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
                 will(returnValue(orUrl));
                 allowing(mockOnlineRes).getVersion();
                 will(returnValue(version));
+                allowing(mockOnlineRes).getApplicationProfile();
+                will(returnValue(applicationProfile));
 
                 allowing(mockOnlineRes_1).getDescription();
                 will(returnValue(orDesc_1));
@@ -235,6 +240,8 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
                 will(returnValue(orUrl_1));
                 allowing(mockOnlineRes_1).getVersion();
                 will(returnValue(version));
+                allowing(mockOnlineRes_1).getApplicationProfile();
+                will(returnValue(applicationProfile));
 
                 allowing(mockResponsibleParty).getOrganisationName();
                 will(returnValue(contactOrg));
@@ -270,6 +277,7 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
         final String orName = "ascom";
         final String orDesc = "desc";
         final OnlineResourceType orType = OnlineResourceType.WFS;
+        final String applicationProfile = "Esri:ArcGIS Server/x";
 
         final double bboxNorth = 10;
         final double bboxSouth = 5;
@@ -352,6 +360,8 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
                 will(returnValue(orType));
                 allowing(mockOnlineRes).getLinkage();
                 will(returnValue(orUrl));
+                allowing(mockOnlineRes).getApplicationProfile();
+                will(returnValue(applicationProfile));
 
                 allowing(mockResponsibleParty).getOrganisationName();
                 will(returnValue(contactOrg));
@@ -391,6 +401,7 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
         final String orName = "ascom";
         final String orDesc = "desc";
         final OnlineResourceType orType = OnlineResourceType.WFS;
+        final String applicationProfile = "Esri:ArcGIS Server/x";
 
         final double bboxNorth = 10;
         final double bboxSouth = 5;
@@ -423,6 +434,7 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
         onlineResExpectation.put("description", orDesc);
         onlineResExpectation.put("type", orType.name());
         onlineResExpectation.put("version", version);
+        onlineResExpectation.put("applicationProfile", applicationProfile);
 
         geoExpectation.put("type", "bbox");
         geoExpectation.put("eastBoundLongitude", bboxEast);
@@ -482,6 +494,8 @@ public class TestViewCSWRecordFactory extends PortalTestClass {
                 will(returnValue(orUrl));
                 allowing(mockOnlineRes).getVersion();
                 will(returnValue(version));
+                allowing(mockOnlineRes).getApplicationProfile();
+                will(returnValue(applicationProfile));
 
                 allowing(mockResponsibleParty).getOrganisationName();
                 will(returnValue(contactOrg));


### PR DESCRIPTION
Uses the applicationProfile field of ISO metadata to determine whether a WMS service is provided by Esri. Format of the applicationProfile is specified by USGIN at the link below 

http://usgin.github.io/usginspecs/USGIN_ISO_Metadata.htm

>  applicationProfile is required if the CI_OnlineResource/linkage does not connect to a web page, and another software application is needed to use the indicated file resource. The applicationProfile character string should specify the software using the following recommended syntax: “vendor:application name/application version”, e.g. “Microsoft:Word/2007”