### PR TITLE
AUS-2756 Made prim managers lazily generate layers

### DIFF
--- a/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/OpenLayersMap.js
@@ -413,7 +413,7 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
         
         // Creation and rendering of LayerSwitcher moved to renderBaseMap()
 
-        this.highlightPrimitiveManager = this.makePrimitiveManager();
+        this.highlightPrimitiveManager = this.makePrimitiveManager(true);
         this.container = container;
         this.rendered = true;
         
@@ -646,9 +646,7 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
      *
      * function()
      */
-    makePrimitiveManager : function() {
-        var newVectorLayer = this._getNewVectorLayer();
-        this.vectorLayers.push(newVectorLayer);                
+    makePrimitiveManager : function(noLazyGeneration) {
        
         var clickableLayers = this.vectorLayers
         var clickControl = new portal.map.openlayers.ClickControl(clickableLayers, {
@@ -668,7 +666,12 @@ Ext.define('portal.map.openlayers.OpenLayersMap', {
                                      
         return Ext.create('portal.map.openlayers.PrimitiveManager', {
             baseMap : this,
-            vectorLayer : newVectorLayer,
+            vectorLayerGenerator: Ext.bind(function() {
+                var newVectorLayer = this._getNewVectorLayer();
+                this.vectorLayers.push(newVectorLayer);
+                return newVectorLayer;
+            }, this),
+            noLazyGeneration: noLazyGeneration,
             listeners: {
                 //See ANVGL-106 for why we need to forcibly reorder thse
                 addprimitives : Ext.bind(function() {


### PR DESCRIPTION
All of our primitive managers (one per layer) are being generated at page load. This is generating a ton of unnecessary OpenLayer vector layers and causing performance issues for large registries.

This fixes the problem by lazy instantiation of the vector layer