### PR TITLE
VGL-171 Cloud Compute/Storage NeCTAR Fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <!-- Project properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jclouds.version>1.9.1</jclouds.version>
+        <jclouds.version>2.0.0-SNAPSHOT</jclouds.version>
     </properties>
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>
@@ -315,6 +315,14 @@
             <id>cgsrv8.arrc.csiro.au</id>
             <name>AuScope Nexus - PortalRepo</name>
             <url>http://cgsrv8.arrc.csiro.au/nexus/content/groups/PortalRepository/</url>
+        </repository>
+        
+        <repository>
+            <id>jclouds-snapshots</id>
+            <url>https://repository.apache.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
     <!-- Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <!-- Project properties -->
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jclouds.version>1.8.1</jclouds.version>
+        <jclouds.version>1.9.1</jclouds.version>
     </properties>
     <build>
         <finalName>${project.artifactId}-${project.version}</finalName>

--- a/src/main/java/org/auscope/portal/core/cloud/CloudJob.java
+++ b/src/main/java/org/auscope/portal/core/cloud/CloudJob.java
@@ -80,6 +80,11 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
     }
 
     public String setProperty(String key, String value) {
+        if (value == null) {
+            String oldValue = properties.get(key);
+            properties.remove(key);
+            return oldValue;
+        }
         return properties.put(key, value);
     }
 

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
@@ -29,6 +29,7 @@ import org.jclouds.blobstore.domain.internal.MutableBlobMetadataImpl;
 import org.jclouds.blobstore.options.ListContainerOptions;
 import org.jclouds.domain.Credentials;
 import org.jclouds.io.ContentMetadata;
+import org.jclouds.openstack.swift.v1.blobstore.RegionScopedBlobStoreContext;
 import org.jclouds.rest.AuthorizationException;
 import org.jclouds.sts.STSApi;
 import org.jclouds.sts.domain.UserAndSessionCredentials;
@@ -254,8 +255,13 @@ public class CloudStorageService {
         properties.setProperty("jclouds.relax-hostname", relaxHostName ? "true" : "false");
         properties.setProperty("jclouds.strip-expect-header", stripExpectHeader ? "true" : "false");
 
+        Class<? extends BlobStoreContext> targetClass = BlobStoreContext.class;
         if (regionName != null) {
-            properties.setProperty("jclouds.region", regionName);
+            if (provider.contains("openstack") || provider.contains("swift")) {
+                targetClass = RegionScopedBlobStoreContext.class;
+            } else {
+                properties.setProperty("jclouds.region", regionName);
+            }
         }
 
         if(! TextUtil.isNullOrEmpty(arn)) {
@@ -282,7 +288,7 @@ public class CloudStorageService {
                     builder2.endpoint(this.endpoint);
                 }
 
-                return builder2.buildView(BlobStoreContext.class);
+                return builder2.buildView(targetClass);
             } catch (IOException e) {
                 throw new PortalServiceException(e.getMessage(), e);
             }
@@ -300,7 +306,16 @@ public class CloudStorageService {
                 builder.endpoint(this.endpoint);
             }
 
-            return builder.build(BlobStoreContext.class);
+            return builder.build(targetClass);
+        }
+    }
+
+    private BlobStore getBlobStore(String arn, String clientSecret) throws PortalServiceException {
+        BlobStoreContext ctx = getBlobStoreContext(arn, clientSecret);
+        if (regionName != null && ctx instanceof RegionScopedBlobStoreContext) {
+            return ((RegionScopedBlobStoreContext) ctx).getBlobStore(regionName);
+        } else {
+            return ctx.getBlobStore();
         }
     }
 
@@ -549,7 +564,7 @@ public class CloudStorageService {
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
 
         try {
-            BlobStore bs = getBlobStoreContext(arn, clientSecret).getBlobStore();
+            BlobStore bs = getBlobStore(arn, clientSecret);
             Blob blob = bs.getBlob(getBucket(job), keyForJobFile(job, myKey));
             return blob.getPayload().openStream();
         } catch (Exception ex) {
@@ -598,7 +613,7 @@ public class CloudStorageService {
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
 
         try {
-            BlobStore bs = getBlobStoreContext(arn, clientSecret).getBlobStore();
+            BlobStore bs = getBlobStore(arn, clientSecret);
             StorageMetadata md = bs.blobMetadata(getBucket(job), keyForJobFile(job, myKey));
             return metadataToCloudFile(md);
         } catch (Exception ex) {
@@ -621,7 +636,7 @@ public class CloudStorageService {
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
 
         try {
-            BlobStore bs = getBlobStoreContext(arn, clientSecret).getBlobStore();
+            BlobStore bs = getBlobStore(arn, clientSecret);
             String baseKey = generateBaseKey(job);
 
             String bucketName = getBucket(job);
@@ -670,7 +685,7 @@ public class CloudStorageService {
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
 
         try {
-            BlobStore bs = getBlobStoreContext(arn, clientSecret).getBlobStore();
+            BlobStore bs = getBlobStore(arn, clientSecret);
 
             String bucketName = getBucket(job);
             bs.createContainerInLocation(null, bucketName);
@@ -710,7 +725,7 @@ public class CloudStorageService {
         String arn = job.getProperty(CloudJob.PROPERTY_STS_ARN);
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
         try {
-            BlobStore bs = getBlobStoreContext(arn, clientSecret).getBlobStore();
+            BlobStore bs = getBlobStore(arn, clientSecret);
             bs.deleteDirectory(getBucket(job), jobToBaseKey(job));
         } catch (Exception ex) {
             log.error("Error in removing job files or storage key.", ex);

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
@@ -45,27 +45,6 @@ import com.google.common.io.Files;
  */
 public class CloudStorageService {
 
-    /**
-     * The various levels of STS support that an instance of CloudStorageService can implement
-     * @author Josh Vote (CSIRO)
-     *
-     */
-    public enum STSRequirement {
-        /**
-         * Only STS enabled jobs will be allowed to read/write data using this instance. Non STS
-         * enabled jobs will error when using this class
-         */
-        Mandatory,
-        /**
-         * STS jobs will use STS as per normal, non STS jobs will use the inbuilt credentials
-         */
-        Permissable,
-        /**
-         * ALL jobs (STS or otherwise) will be forced to use the inbuilt credentials
-         */
-        ForceNone
-    }
-
     /** The bucket name used when no bucket is specified */
     public static final String DEFAULT_BUCKET = "portal-core-storage-service";
 

--- a/src/main/java/org/auscope/portal/core/services/cloud/STSRequirement.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/STSRequirement.java
@@ -1,0 +1,22 @@
+package org.auscope.portal.core.services.cloud;
+
+/**
+ * The various levels of STS support that an instance of CloudStorageService/CloudComputeService can implement
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public enum STSRequirement {
+    /**
+     * Only STS enabled jobs will be allowed to read/write data using this instance. Non STS
+     * enabled jobs will error when using this class
+     */
+    Mandatory,
+    /**
+     * STS jobs will use STS as per normal, non STS jobs will use the inbuilt credentials
+     */
+    Permissable,
+    /**
+     * ALL jobs (STS or otherwise) will be forced to use the inbuilt credentials
+     */
+    ForceNone
+}

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
@@ -2,7 +2,6 @@ package org.auscope.portal.core.services.cloud;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 
 import org.auscope.portal.core.cloud.CloudJob;
 import org.auscope.portal.core.services.PortalServiceException;
@@ -28,7 +27,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 
 public class TestCloudComputeService extends PortalTestClass {
 
@@ -65,8 +63,8 @@ public class TestCloudComputeService extends PortalTestClass {
 
     /**
      * Tests that job execution correctly calls and parses a response from AmazonEC2
-     * @throws RunNodesException 
-     * @throws PortalServiceException 
+     * @throws RunNodesException
+     * @throws PortalServiceException
      */
     @Test
     public void testExecuteJob() throws RunNodesException, PortalServiceException {
@@ -75,25 +73,6 @@ public class TestCloudComputeService extends PortalTestClass {
 
         context.checking(new Expectations() {
             {
-                oneOf(mockNovaApi).getConfiguredZones();
-                will(returnValue(Sets.newHashSet("here")));
-
-                oneOf(mockNovaApi).getAvailabilityZoneApi("here");
-                will(returnValue(mockOptAZA));
-                oneOf(mockOptAZA).get();
-                will(returnValue(mockAZA));
-                oneOf(mockAZA).list();
-                will(returnValue(mockAvailZoneList));
-                oneOf(mockAvailZoneList).iterator();
-                will(returnValue(Arrays.asList(mockAvailZone).iterator()));
-
-                allowing(mockAvailZone).getName();
-                will(returnValue("my-zone"));
-                allowing(mockAvailZone).getState();
-                will(returnValue(mockZoneState));
-                allowing(mockZoneState).available();
-                will(returnValue(true));
-
                 oneOf(mockComputeService).templateOptions();
                 will(returnValue(mockTemplateOptions));
                 oneOf(mockComputeService).templateBuilder();
@@ -102,8 +81,6 @@ public class TestCloudComputeService extends PortalTestClass {
                 oneOf(mockTemplateOptions).keyPairName("vgl-developers");
                 will(returnValue(mockTemplateOptions));
                 oneOf(mockTemplateOptions).userData(userDataString.getBytes(Charset.forName("UTF-8")));
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).availabilityZone("my-zone");
                 will(returnValue(mockTemplateOptions));
 
                 oneOf(mockTemplateBuilder).imageId(job.getComputeVmId());
@@ -130,8 +107,8 @@ public class TestCloudComputeService extends PortalTestClass {
 
     /**
      * Tests that job execution correctly calls and parses a response from AmazonEC2 when EC2 reports failure by returning 0 running instances.
-     * @throws RunNodesException 
-     * @throws PortalServiceException 
+     * @throws RunNodesException
+     * @throws PortalServiceException
      */
     @Test(expected = PortalServiceException.class)
     public void testExecuteJobFailure() throws RunNodesException, PortalServiceException {
@@ -139,25 +116,6 @@ public class TestCloudComputeService extends PortalTestClass {
 
         context.checking(new Expectations() {
             {
-                oneOf(mockNovaApi).getConfiguredZones();
-                will(returnValue(Sets.newHashSet("here")));
-
-                oneOf(mockNovaApi).getAvailabilityZoneApi("here");
-                will(returnValue(mockOptAZA));
-                oneOf(mockOptAZA).get();
-                will(returnValue(mockAZA));
-                oneOf(mockAZA).list();
-                will(returnValue(mockAvailZoneList));
-                oneOf(mockAvailZoneList).iterator();
-                will(returnValue(Arrays.asList(mockAvailZone).iterator()));
-
-                allowing(mockAvailZone).getName();
-                will(returnValue("my-zone"));
-                allowing(mockAvailZone).getState();
-                will(returnValue(mockZoneState));
-                allowing(mockZoneState).available();
-                will(returnValue(true));
-
                 oneOf(mockComputeService).templateOptions();
                 will(returnValue(mockTemplateOptions));
                 oneOf(mockComputeService).templateBuilder();
@@ -166,8 +124,6 @@ public class TestCloudComputeService extends PortalTestClass {
                 oneOf(mockTemplateOptions).keyPairName("vgl-developers");
                 will(returnValue(mockTemplateOptions));
                 oneOf(mockTemplateOptions).userData(userDataString.getBytes(Charset.forName("UTF-8")));
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).availabilityZone("my-zone");
                 will(returnValue(mockTemplateOptions));
 
                 oneOf(mockTemplateBuilder).imageId(job.getComputeVmId());
@@ -196,8 +152,8 @@ public class TestCloudComputeService extends PortalTestClass {
 
     /**
      * Tests that job execution correctly calls and parses a response from AmazonEC2 when EC2 reports failure by returning 0 running instances.
-     * @throws RunNodesException 
-     * @throws PortalServiceException 
+     * @throws RunNodesException
+     * @throws PortalServiceException
      */
     @Test(expected = PortalServiceException.class)
     public void testExecuteJobFailure_EmptyResults() throws RunNodesException, PortalServiceException {
@@ -205,25 +161,6 @@ public class TestCloudComputeService extends PortalTestClass {
 
         context.checking(new Expectations() {
             {
-
-                oneOf(mockNovaApi).getConfiguredZones();
-                will(returnValue(Sets.newHashSet("here")));
-
-                oneOf(mockNovaApi).getAvailabilityZoneApi("here");
-                will(returnValue(mockOptAZA));
-                oneOf(mockOptAZA).get();
-                will(returnValue(mockAZA));
-                oneOf(mockAZA).list();
-                will(returnValue(mockAvailZoneList));
-                oneOf(mockAvailZoneList).iterator();
-                will(returnValue(Arrays.asList(mockAvailZone).iterator()));
-
-                allowing(mockAvailZone).getName();
-                will(returnValue("my-zone"));
-                allowing(mockAvailZone).getState();
-                will(returnValue(mockZoneState));
-                allowing(mockZoneState).available();
-                will(returnValue(true));
 
                 oneOf(mockComputeService).templateOptions();
                 will(returnValue(mockTemplateOptions));
@@ -233,8 +170,6 @@ public class TestCloudComputeService extends PortalTestClass {
                 oneOf(mockTemplateOptions).keyPairName("vgl-developers");
                 will(returnValue(mockTemplateOptions));
                 oneOf(mockTemplateOptions).userData(userDataString.getBytes(Charset.forName("UTF-8")));
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).availabilityZone("my-zone");
                 will(returnValue(mockTemplateOptions));
 
                 oneOf(mockTemplateBuilder).imageId(job.getComputeVmId());
@@ -270,177 +205,6 @@ public class TestCloudComputeService extends PortalTestClass {
         });
 
         service.terminateJob(job);
-    }
-
-    /**
-     * Tests that specified zones are skipped correctly
-     * @throws RunNodesException 
-     * @throws PortalServiceException 
-     */
-    @Test
-    public void testSkippedZones() throws RunNodesException, PortalServiceException {
-        final String userDataString = "user-data-string";
-        final String expectedInstanceId = "instance-id";
-
-        service.setSkippedZones(Sets.newHashSet("my-skip-zone"));
-
-        context.checking(new Expectations() {
-            {
-                oneOf(mockNovaApi).getConfiguredZones();
-                will(returnValue(Sets.newHashSet("here")));
-
-                oneOf(mockNovaApi).getAvailabilityZoneApi("here");
-                will(returnValue(mockOptAZA));
-                oneOf(mockOptAZA).get();
-                will(returnValue(mockAZA));
-                oneOf(mockAZA).list();
-                will(returnValue(mockAvailZoneList));
-                oneOf(mockAvailZoneList).iterator();
-                will(returnValue(Arrays.asList(mockAvailZone, mockAvailZone2).iterator()));
-
-                allowing(mockAvailZone).getName();
-                will(returnValue("my-skip-zone"));
-
-                allowing(mockAvailZone2).getName();
-                will(returnValue("my-notskip-zone"));
-                allowing(mockAvailZone2).getState();
-                will(returnValue(mockZoneState));
-
-                allowing(mockZoneState).available();
-                will(returnValue(true));
-
-                oneOf(mockComputeService).templateOptions();
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockComputeService).templateBuilder();
-                will(returnValue(mockTemplateBuilder));
-
-                oneOf(mockTemplateOptions).keyPairName("vgl-developers");
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).userData(userDataString.getBytes(Charset.forName("UTF-8")));
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).availabilityZone("my-notskip-zone");
-                will(returnValue(mockTemplateOptions));
-
-                oneOf(mockTemplateBuilder).imageId(job.getComputeVmId());
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).hardwareId(job.getComputeInstanceType());
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).options(mockTemplateOptions);
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).build();
-                will(returnValue(mockTemplate));
-
-                oneOf(mockComputeService).createNodesInGroup("group-name", 1, mockTemplate);
-                will(returnValue(ImmutableSet.<NodeMetadata> of(mockMetadata)));
-
-                oneOf(mockMetadata).getId();
-                will(returnValue(expectedInstanceId));
-            }
-        });
-
-        String actualInstanceId = service.executeJob(job, userDataString);
-
-        Assert.assertEquals(expectedInstanceId, actualInstanceId);
-    }
-
-    /**
-     * Tests that job execution correctly calls and parses a response from AmazonEC2 despite the first zone failing
-     * @throws RunNodesException 
-     * @throws PortalServiceException 
-     */
-    @Test
-    public void testExecuteJobBadZone() throws RunNodesException, PortalServiceException {
-        final String userDataString = "user-data-string";
-        final String expectedInstanceId = "instance-id";
-
-        context.checking(new Expectations() {
-            {
-                oneOf(mockNovaApi).getConfiguredZones();
-                will(returnValue(Sets.newHashSet("here")));
-
-                oneOf(mockNovaApi).getAvailabilityZoneApi("here");
-                will(returnValue(mockOptAZA));
-                oneOf(mockOptAZA).get();
-                will(returnValue(mockAZA));
-                oneOf(mockAZA).list();
-                will(returnValue(mockAvailZoneList));
-                oneOf(mockAvailZoneList).iterator();
-                will(returnValue(Arrays.asList(mockAvailZone, mockAvailZone2).iterator()));
-
-                allowing(mockAvailZone).getName();
-                will(returnValue("my-zone"));
-                allowing(mockAvailZone).getState();
-                will(returnValue(mockZoneState));
-                allowing(mockAvailZone2).getName();
-                will(returnValue("my-zone-2"));
-                allowing(mockAvailZone2).getState();
-                will(returnValue(mockZoneState));
-                allowing(mockZoneState).available();
-                will(returnValue(true));
-
-                //Our first run through will throw an exception
-                oneOf(mockComputeService).templateOptions();
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockComputeService).templateBuilder();
-                will(returnValue(mockTemplateBuilder));
-
-                oneOf(mockTemplateOptions).keyPairName("vgl-developers");
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).userData(userDataString.getBytes(Charset.forName("UTF-8")));
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).availabilityZone("my-zone");
-                will(returnValue(mockTemplateOptions));
-
-                oneOf(mockTemplateBuilder).imageId(job.getComputeVmId());
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).hardwareId(job.getComputeInstanceType());
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).options(mockTemplateOptions);
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).build();
-                will(returnValue(mockTemplate));
-
-                allowing(mockException).fillInStackTrace();
-                allowing(mockException).getMessage();
-                oneOf(mockComputeService).createNodesInGroup("group-name", 1, mockTemplate);
-                will(throwException(mockException));
-
-                oneOf(mockComputeService).destroyNodesMatching(mockFilter);
-                will(returnValue(Sets.newHashSet()));
-
-                //The second will succeed
-                oneOf(mockComputeService).templateOptions();
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockComputeService).templateBuilder();
-                will(returnValue(mockTemplateBuilder));
-
-                oneOf(mockTemplateOptions).keyPairName("vgl-developers");
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).userData(userDataString.getBytes(Charset.forName("UTF-8")));
-                will(returnValue(mockTemplateOptions));
-                oneOf(mockTemplateOptions).availabilityZone("my-zone-2");
-                will(returnValue(mockTemplateOptions));
-
-                oneOf(mockTemplateBuilder).imageId(job.getComputeVmId());
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).hardwareId(job.getComputeInstanceType());
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).options(mockTemplateOptions);
-                will(returnValue(mockTemplateBuilder));
-                oneOf(mockTemplateBuilder).build();
-                will(returnValue(mockTemplate));
-
-                oneOf(mockComputeService).createNodesInGroup("group-name", 1, mockTemplate);
-                will(returnValue(ImmutableSet.<NodeMetadata> of(mockMetadata)));
-
-                oneOf(mockMetadata).getId();
-                will(returnValue(expectedInstanceId));
-            }
-        });
-
-        String actualInstanceId = service.executeJob(job, userDataString);
-
-        Assert.assertEquals(expectedInstanceId, actualInstanceId);
     }
 
     @Test

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeServiceAws.java
@@ -181,7 +181,7 @@ public class TestCloudComputeServiceAws extends PortalTestClass{
      * In this case we expect it to return pending. If it's only a few seconds in the future then it's probably just a minor date/time
      * shifting error (or a daylight savings time shift). If it's a LONG time in the future, what can we expect? It's probably overengineering
      * the checks if we start accounting for the latter.
-     * @throws PortalServiceException 
+     * @throws PortalServiceException
      */
     @Test
     public void testJobStatus_FutureJob() throws PortalServiceException  {
@@ -203,7 +203,7 @@ public class TestCloudComputeServiceAws extends PortalTestClass{
     @Test(expected=PortalServiceException.class)
     public void testStsRequired() throws PortalServiceException  {
         final TestableCCS stsService = new TestableCCS(mockClient);
-        stsService.setRequireSts(true);
+        stsService.setStsRequirement(STSRequirement.Mandatory);
         stsService.getCredentials(null, null);
     }
 

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -72,7 +72,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
                     oneOf(mockPayload).openStream();
                     will(returnValue(mockReturnedInputStream));
-                    
+
                     allowing(mockReturnedInputStream).close();
                     allowing(mockPayload).close();
                 }
@@ -113,8 +113,8 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that requests for listing files successfully call all dependencies
-     * @throws URISyntaxException 
-     * @throws PortalServiceException 
+     * @throws URISyntaxException
+     * @throws PortalServiceException
      */
     @Test
     public void testListOutputJobFiles() throws URISyntaxException, PortalServiceException  {
@@ -199,7 +199,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that requests for uploading files successfully call all dependencies
-     * @throws PortalServiceException 
+     * @throws PortalServiceException
      */
     @Test
     public void testUploadJobFiles() throws PortalServiceException {
@@ -263,7 +263,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     /**
      * Tests that requests for deleting files successfully call all dependencies
-     * @throws PortalServiceException 
+     * @throws PortalServiceException
      */
     @Test
     public void testDeleteJobFiles() throws PortalServiceException {
@@ -332,7 +332,7 @@ public class TestCloudStorageService extends PortalTestClass {
     @Test(expected=PortalServiceException.class)
     public void testStsRequired() throws PortalServiceException {
         CloudStorageService stsService = new CloudStorageService("dummy1", "dummy2", "dummy3");
-        stsService.setRequireSts(true);
+        stsService.setStsRequirement(STSRequirement.Mandatory);
         stsService.getBlobStoreContext(null, null);
     }
 


### PR DESCRIPTION
Following broad testing with the cloud compute/storage services against the latest NeCTAR Openstack deployment we discovered a number of deficiencies. The following changes have been made (some of them breaking backwards compatibility for users of the CloudComputeService/CloudStorageService)

* Replaced requireSTS boolean with a more flexible STSRequirement enum
* Stripped out region by region submission in the CloudComputeServiceNectar due to missing support at the NeCTAR end for enumerating regions
* Fixed region specific submissions for OpenStack cloud providers (regionName has only worked with AWS up until now)