### PR TITLE
Add visibile to Layer model

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/Layer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/Layer.js
@@ -14,6 +14,8 @@ Ext.define('portal.layer.Layer', {
         KML_RECORD : 'KMLRecord'
     },
 
+    
+    // TODO: Deprecate?
     visible : true,
 
     fields: [
@@ -29,7 +31,7 @@ Ext.define('portal.layer.Layer', {
         { name: 'cswRecords', type: 'auto'}, //The source of all underlying data is an array of portal.csw.CSWRecord objects
         { name: 'loading', type: 'boolean', defaultValue: false },//Whether this layer is currently loading data or not
         { name: 'active', type: 'boolean', defaultValue: false },//Whether this layer is current active on the map.
-        //{ name: 'loading', type: 'boolean', defaultValue: false }, //Whether this layer is currently loading data or not
+        { name: 'visible', type: 'boolean', defaultValue: true }, // Whether this layer is visible
         { name: 'filterForm', type: 'auto'}, //The portal.layer.filterer.BaseFilterForm that houses the GUI for editing this layer's filterer
         { name: 'renderOnAdd', type: 'boolean', defaultValue: false }, //If true then this layer should be rendered the moment it is added as a layer. Currently used by KML
         { name: 'deserialized', type: 'boolean', defaultValue: false }, //If true then this layer has been deserialized from a permanent link
@@ -54,7 +56,9 @@ Ext.define('portal.layer.Layer', {
     
     setLayerVisibility : function(visibility){
         this.get('renderer').setVisibility(visibility);
-        this.visible = visibility;
+        // TODO: Deprecate?
+        this.visible=visibility;
+        this.set('visible',visibility);
     },                
 
     onRenderStarted : function(renderer, onlineResources, filterer) {


### PR DESCRIPTION
Added the visible flag to the model for Layer, such that a store update event would change the icon in the ActiveLayerPanel. This means there is a duplication of visible flags in the Layer class, but I left the original there in case othe rportals depend on that flag.

The visible flag outside the model may be a candidate for deprecation, as noted in comments.