### PR TITLE
AUS-2770 Added lazy loading of child panels

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/BaseRecordPanel.js
@@ -96,6 +96,7 @@ Ext.define('portal.widgets.panel.BaseRecordPanel', {
                 },
                 iconRenderer: Ext.bind(me._spatialBoundsRenderer, me)
             }],
+            lazyLoadChildPanel: true,
             childPanelGenerator: function(record) {                  
                 //For every filter panel we generate, also generate a portal.layer.Layer and 
                 //attach it to the CSWRecord/KnownLayer

--- a/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
@@ -8,13 +8,18 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
     extend : 'Ext.panel.Panel',
     xtype : 'recordpanel',
 
+    statics: {
+        LAZY_LOAD_ID: 'lazy-load'
+    },
+    
     config: {
         allowReordering: false,
         store: null,
         titleField: 'name',
         titleIndex: 0,
         tools: null,
-        childPanelGenerator: Ext.emptyFn
+        childPanelGenerator: Ext.emptyFn,
+        lazyLoadChildPanel: false
     },
 
 
@@ -40,6 +45,7 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
      *             tipRenderer - function(value, record, tip) - Called whenever a tooltip is generated. Return HTML content to display in tip
      *             iconRenderer - function(value, record) - Called whenever the underlying field updates. Return String URL to icon that will be displayed in tip.
      *  childPanelGenerator: function(record) - Called when records are added to the store. Return a generated Ext.Container for display in the specified row's expander
+     *  lazyLoadChildPanel: Boolean - If true. the childPanelGenerator won't be fired until the row is expanded (default - false)
      * }
      * 
      * And the following events:
@@ -375,7 +381,13 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
         var newItemId = Ext.id(null, 'record-row-');
         this.recordRowMap[recordId] = newItemId; 
         
-        var childPanel = this.childPanelGenerator ? this.childPanelGenerator(record) : null;
+        
+        var childPanel = null;
+        if (this.lazyLoadChildPanel) {
+            childPanel = {xtype: 'container', itemId: portal.widgets.panel.recordpanel.RecordPanel.LAZY_LOAD_ID};
+        } else {
+            childPanel = this.childPanelGenerator ? this.childPanelGenerator(record) : null;
+        }
         
         return {
             xtype: 'recordrowpanel',
@@ -385,10 +397,26 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
             titleIndex: this.titleIndex,
             groupMode: groupMode,
             tools: tools,
+            record: record,
             items: childPanel ? [childPanel] : null,
             listeners: {
                 scope: this,
-                afterrender: this._installToolTips
+                afterrender: this._installToolTips,
+                beforeexpand: function(rp) {
+                    if (!this.lazyLoadChildPanel) {
+                        return;
+                    }
+                    
+                    var placeHolder = rp.down('#' + portal.widgets.panel.recordpanel.RecordPanel.LAZY_LOAD_ID);
+                    if (!placeHolder) {
+                        return;
+                    }
+                    
+                    rp.remove(placeHolder);
+                    if (this.childPanelGenerator) {
+                        rp.add(this.childPanelGenerator(rp.record));
+                    }
+                }
             }
         };
     },


### PR DESCRIPTION
Added an optional (upfront) performance improvement for record panels with many rows with children.

When activated all child filter panels will NOT be rendered, they will be injected during the beforeexpand event.