### PR TITLE
Check for opacity in rendering of layer

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
+++ b/src/main/webapp/portal-core/js/portal/layer/renderer/wms/LayerRenderer.js
@@ -74,6 +74,10 @@ Ext.define('portal.layer.renderer.wms.LayerRenderer', {
     },
     
     _getRenderLayer : function(response,opts,wmsResource, wmsUrl, wmsLayer, wmsOpacity,filterer){
+    	
+    	if(wmsOpacity === undefined){
+             wmsOpacity = filterer.parameters.opacity;
+        }
         var sld_body = "";
         if (response !== null) {
             var sld_body = response.responseText;


### PR DESCRIPTION
WMS Opacity is checked in numerous places in the renderers and filter forms - need to refactor the behaviour for handling opacity. 