### PR TITLE
AUS-2762: Fix to problem where layer query pop-up fails to appear

### DIFF
--- a/src/main/webapp/portal-core/js/portal/map/openlayers/FeatureWithLocationHandler.js
+++ b/src/main/webapp/portal-core/js/portal/map/openlayers/FeatureWithLocationHandler.js
@@ -14,7 +14,7 @@ portal.map.openlayers.FeatureWithLocationHandler = OpenLayers.Class(OpenLayers.H
      * of the event handler
      */
     lastHandledEvent : null,
-    mouseDragFlag: true,
+    mouseDragFlag: false,
     downX: 0,
     downY: 0,
     handle : function(event) {
@@ -28,7 +28,7 @@ portal.map.openlayers.FeatureWithLocationHandler = OpenLayers.Class(OpenLayers.H
         if (!handled) {
             var type = event.type;
             if (type === 'click' && !this.mouseDragFlag) {
-                handled = true;            	
+                handled = true;                
                 this.callback('click', [null, event]);                
             } else if (type === 'mousedown') {
                 this.downX = event.xy.x;


### PR DESCRIPTION
The "mouseDragFlag" was initially set to "true". This meant that any incoming "click" events are not acted upon, until the first "mousedown" then "mouseup" where distance < 5. This doesn't occur readily.
By setting it to "false", incoming "click" events are handled. 
I have checked that there is no regression of AUS-2592.5, i.e. dragging the map does not invoke a query.
I have tested this on IE, Chrome & Firefox.