### PR TITLE
VGL-200 Stopped NPE With JClouds NeCTAR Status Check

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
@@ -367,6 +367,10 @@ public class CloudComputeServiceNectar extends CloudComputeService {
 
         try {
             NodeMetadata md = computeService.getNodeMetadata(job.getComputeInstanceId());
+            if (md == null) {
+                return InstanceStatus.Missing;
+            }
+
             Status status = md.getStatus();
             switch (status) {
             case PENDING:

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
@@ -233,4 +233,16 @@ public class TestCloudComputeService extends PortalTestClass {
 
         service.getJobStatus(job);
     }
+
+    @Test
+    public void testGetJobStatus_ReturnNull() throws PortalServiceException {
+        job.setComputeInstanceId("i-running");
+
+        context.checking(new Expectations() {{
+            oneOf(mockComputeService).getNodeMetadata("i-running");
+            will(returnValue(null));
+        }});
+
+        Assert.assertEquals(InstanceStatus.Missing, service.getJobStatus(job));
+    }
 }


### PR DESCRIPTION
JClouds can occasionally return a null metadata object for requests to NeCTAR VM's for metadata. This PR fixes this.