### PR TITLE
VGLOPS-13 Support for file uploads from non File sources

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
@@ -302,8 +302,13 @@ public abstract class CloudStorageService {
      * @param s
      * @return
      */
-    private static String sanitise(String s) {
-        return s.replaceAll("[^a-zA-Z0-9_\\-\\.]", "_");
+    private static String sanitise(String s, boolean allowDot) {
+        if (allowDot) {
+            return s.replaceAll("[^a-zA-Z0-9_\\-\\.]", "_");
+        } else {
+            return s.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+        }
+
     }
 
     /**
@@ -315,7 +320,7 @@ public abstract class CloudStorageService {
      */
     public String generateBaseKey(CloudFileOwner job) {
         String baseKey = String.format("%1$s%2$s-%3$010d", jobPrefix, job.getUser(), job.getId());
-        return sanitise(baseKey);
+        return sanitise(baseKey, false);
     }
 
     /**
@@ -328,7 +333,7 @@ public abstract class CloudStorageService {
      * @return
      */
     public String keyForJobFile(CloudFileOwner job, String key) {
-        return String.format("%1$s/%2$s", jobToBaseKey(job), sanitise(key));
+        return String.format("%1$s/%2$s", jobToBaseKey(job), sanitise(key, true));
     }
 
     /**

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  */
 package org.auscope.portal.core.services.cloud;
 
@@ -29,6 +29,8 @@ public abstract class CloudStorageService {
     abstract public void deleteJobFiles(CloudFileOwner job) throws PortalServiceException;
 
     abstract public void uploadJobFiles(CloudFileOwner curJob, File[] files) throws PortalServiceException;
+
+    abstract public void uploadJobFile(CloudFileOwner curJob, String fileName, InputStream data) throws PortalServiceException;
 
     abstract public CloudFileInformation getJobFileMetadata(CloudFileOwner job, String fileName) throws PortalServiceException;
 
@@ -77,7 +79,7 @@ public abstract class CloudStorageService {
     public String getSecretKey() {
         return secretKey;
     }
-    
+
     /**
      * @param secretKey the secretKey to set
      */
@@ -138,7 +140,7 @@ public abstract class CloudStorageService {
         this.endpoint = endpoint;
         this.provider = provider;
         this.regionName= regionName;
-        
+
         try {
             this.jobPrefix = "job-" + InetAddress.getLocalHost().getHostName() + "-";
         } catch (UnknownHostException e) {
@@ -223,7 +225,7 @@ public abstract class CloudStorageService {
 
     /**
      * Utility for accessing the correct bucket based on owner's configuration
-     * 
+     *
      * @param owner
      * @return
      */
@@ -301,7 +303,7 @@ public abstract class CloudStorageService {
      * @return
      */
     private static String sanitise(String s) {
-        return s.replaceAll("[^a-zA-Z0-9_\\-]", "_");
+        return s.replaceAll("[^a-zA-Z0-9_\\-\\.]", "_");
     }
 
     /**
@@ -326,7 +328,7 @@ public abstract class CloudStorageService {
      * @return
      */
     public String keyForJobFile(CloudFileOwner job, String key) {
-        return String.format("%1$s/%2$s", jobToBaseKey(job), key);
+        return String.format("%1$s/%2$s", jobToBaseKey(job), sanitise(key));
     }
 
     /**

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -454,6 +454,38 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
         }
     }
 
+    @Override
+    public void uploadJobFile(CloudFileOwner job, String fileName, InputStream data) throws PortalServiceException {
+        String arn = job.getProperty(CloudJob.PROPERTY_STS_ARN);
+        String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
+
+        try {
+            BlobStore bs = getBlobStore(arn, clientSecret);
+            String bucketName = getBucket(job);
+            bs.createContainerInLocation(null, bucketName);
+
+            Blob newBlob = bs.blobBuilder(keyForJobFile(job, fileName))
+                    .payload(data)
+                    .build();
+            bs.putBlob(bucketName, newBlob);
+
+            log.debug(fileName + " uploaded to '" + bucketName + "' container");
+
+        } catch (AuthorizationException ex) {
+            log.error("Storage credentials are not valid for job: " + job, ex);
+            throw new PortalServiceException("Storage credentials are not valid.",
+                    "Please provide valid storage credentials.");
+        } catch (KeyNotFoundException ex) {
+            log.error("Storage container does not exist for job: " + job, ex);
+            throw new PortalServiceException("Storage container does not exist.",
+                    "Please provide a valid storage container.");
+        } catch (Exception ex) {
+            log.error("Unable to upload files for job: " + job, ex);
+            throw new PortalServiceException("An unexpected error has occurred while uploading file(s) to storage.",
+                    "Please report it to " + getAdminEmail()+".");
+        }
+    }
+
     /**
      * Deletes all files including the container or directory for the specified job
      *


### PR DESCRIPTION
Currently the CloudStorageService base class only supports uploads to the cloud directly from java.io.File objects. This PR adds support for inputstream sources too.