### PR TITLE
VGLOPS-3: Constraints textfield to show license information on metadata panel

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
@@ -83,6 +83,15 @@ Ext.define('portal.widgets.panel.CSWMetadataPanel', {
         anchor : '100%',
         value : this.cswRecord.get('contactOrg')
       }];
+      if (this.cswRecord.get('constraints') != null && this.cswRecord.get('constraints').length > 0) {
+    	  items.push({
+    		  xtype : 'textarea',
+    		  fieldLabel : 'Constraints',
+    		  anchor : '100%',
+    		  value : this.cswRecord.get('constraints'),
+    		  readOnly : true
+    	  });
+      }
       items = items.concat(this.extraItems);
       if (this.cswRecord!=null) {
           items = items.concat({


### PR DESCRIPTION
Adds a textfield to the CSWMetadataPanel to show license information (or any other constraints) as a simple comma separated list. The textfield won't be added if there are no constraints.

To test:

* Select "Available Services" -> "<any service>"
* Click the metadata button for a service in the search results that appear.