### PR TITLE
VGLOPS 3 - License info (XPath modification)

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecordTransformer.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecordTransformer.java
@@ -60,7 +60,7 @@ public class CSWRecordTransformer {
     private static final String DATASETURIEXPRESSION = "gmd:dataSetURI/gco:CharacterString";
     private static final String SUPPLEMENTALINFOEXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:supplementalInformation/gco:CharacterString";
     private static final String LANGUAGEEXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:language/gco:CharacterString";
-    private static final String OTHERCONSTRAINTSEXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints/gco:CharacterString";
+    private static final String OTHERCONSTRAINTSEXPRESSION = "gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:MD_LegalConstraints/(gmd:otherConstraints/gco:CharacterString | gmd:reference/gmd:CI_Citation/gmd:title/gco:CharacterString)";
     private static final String DATAQUALITYSTATEMENTEXPRESSION = "gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:statement/gco:CharacterString";
     private static final String LAYERNAME = "gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:name/gco:CharacterString";
 


### PR DESCRIPTION
Changed the CWS record transformer's "other" constraints XPath to cater for the few records that have a slightly different XML structure.

This can be tested by displaying the metadata panel with the "Complete Bouguer Gravity Anomaly Grid of Onshore Australia 2016" or "Bouguer Gravity Anomaly Grid of Onshore Australia 2016" CWS records.