### PR TITLE
AUS-2774 Fixed problem with empty download when layer has not been added

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/KLWFSDownloader.js
+++ b/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/KLWFSDownloader.js
@@ -107,7 +107,7 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
                         boxLabel : 'Filter my download using the current visible map bounds.',
                         name : 'wfs-download-radio',
                         inputValue : portal.layer.downloader.wfs.WFSDownloader.DOWNLOAD_CURRENTLY_VISIBLE,
-                        hidden : !isDifferentBBox,
+                        hidden : !isDifferentBBox || Ext.Object.isEmpty(currentlyVisibleBBox),
                         checked : isDifferentBBox
 
                     },{
@@ -119,7 +119,7 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
                         },
                         width : 18,
                         height : 21,
-                        hidden : !isDifferentBBox,
+                        hidden : !isDifferentBBox || Ext.Object.isEmpty(currentlyVisibleBBox),
                         style : 'padding:3px 0px 0px 0px;',
                         listeners : {
                             render : Ext.bind(this._configureImageClickHandlers, this, [currentlyVisibleBBox], true)
@@ -128,8 +128,8 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
                         boxLabel : 'Filter my download using the original bounds that were used to load the layer.',
                         name : 'wfs-download-radio',
                         inputValue : portal.layer.downloader.wfs.WFSDownloader.DOWNLOAD_ORIGINALLY_VISIBLE,
-                        checked : !isDifferentBBox && originallyVisibleBBox !== null,
-                        hidden : originallyVisibleBBox === null
+                        checked : !isDifferentBBox && !Ext.Object.isEmpty(originallyVisibleBBox),
+                        hidden : Ext.Object.isEmpty(originallyVisibleBBox)
                     },{
                         xtype : 'box',
                         autoEl : {
@@ -140,7 +140,7 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
                         width : 18,
                         height : 21,
                         style : 'padding:3px 0px 0px 0px;',
-                        hidden : originallyVisibleBBox === null,
+                        hidden : Ext.Object.isEmpty(originallyVisibleBBox),
                         listeners : {
                             render : Ext.bind(this._configureImageClickHandlers, this, [originallyVisibleBBox], true)
                         }
@@ -148,7 +148,7 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
                         boxLabel : 'Don\'t filter my download. Return all available data.',
                         name : 'wfs-download-radio',
                         inputValue : portal.layer.downloader.wfs.WFSDownloader.DOWNLOAD_ALL,
-                        checked : !isDifferentBBox && originallyVisibleBBox === null
+                        checked : !isDifferentBBox && Ext.Object.isEmpty(originallyVisibleBBox)
                     }]
                 },{
 
@@ -240,8 +240,11 @@ Ext.define('portal.layer.downloader.wfs.KLWFSDownloader', {
                                 me._doDownload(layer, renderedFilterer, resources, sEmail, outputFormat);
                                 break;
                             default:
-                                me._doDownload(layer, renderedFilterer, resources, sEmail, outputFormat);
-                                break;
+                                if (!Ext.Object.isEmpty(renderedFilterer.getParameters())) {
+                                    me._doDownload(layer, renderedFilterer, resources, sEmail, outputFormat);
+                                } else if (!Ext.Object.isEmpty(currentFilterer.getParameters())) {
+                                    me._doDownload(layer, currentFilterer, resources, sEmail, outputFormat);
+                                }
                             }
 
                             //popup.close();

--- a/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/WFSDownloader.js
+++ b/src/main/webapp/portal-core/js/portal/layer/downloader/wfs/WFSDownloader.js
@@ -65,8 +65,11 @@ Ext.define('portal.layer.downloader.wfs.WFSDownloader', {
                        me._doDownload(layer, renderedFilterer, resources);
                        break;
                    default:
-                       me._doDownload(layer, renderedFilterer, resources);
-                       break;
+                       if (!Ext.Object.isEmpty(renderedFilterer.getParameters())) {
+                           me._doDownload(layer, renderedFilterer, resources);
+                       } else if (!Ext.Object.isEmpty(currentFilterer.getParameters())) {
+                           me._doDownload(layer, currentFilterer, resources);
+                       }
                    }
 
                    popup.close();
@@ -96,7 +99,7 @@ Ext.define('portal.layer.downloader.wfs.WFSDownloader', {
                         boxLabel : 'Filter my download using the current visible map bounds.',
                         name : 'wfs-download-radio',
                         inputValue : portal.layer.downloader.wfs.WFSDownloader.DOWNLOAD_CURRENTLY_VISIBLE,
-                        hidden : !isDifferentBBox,
+                        hidden : !isDifferentBBox || Ext.Object.isEmpty(currentlyVisibleBBox),
                         checked : isDifferentBBox
 
                     },{
@@ -108,7 +111,7 @@ Ext.define('portal.layer.downloader.wfs.WFSDownloader', {
                         },
                         width : 18,
                         height : 21,
-                        hidden : !isDifferentBBox,
+                        hidden : !isDifferentBBox || Ext.Object.isEmpty(currentlyVisibleBBox),
                         style : 'padding:3px 0px 0px 0px;',
                         listeners : {
                             render : Ext.bind(this._configureImageClickHandlers, this, [currentlyVisibleBBox], true)
@@ -117,8 +120,8 @@ Ext.define('portal.layer.downloader.wfs.WFSDownloader', {
                         boxLabel : 'Filter my download using the original bounds that were used to load the layer.',
                         name : 'wfs-download-radio',
                         inputValue : portal.layer.downloader.wfs.WFSDownloader.DOWNLOAD_ORIGINALLY_VISIBLE,
-                        checked : !isDifferentBBox && originallyVisibleBBox !== null,
-                        hidden : originallyVisibleBBox === null
+                        checked : !isDifferentBBox && !Ext.Object.isEmpty(originallyVisibleBBox),
+                        hidden : Ext.Object.isEmpty(originallyVisibleBBox)
                     },{
                         xtype : 'box',
                         autoEl : {
@@ -129,7 +132,7 @@ Ext.define('portal.layer.downloader.wfs.WFSDownloader', {
                         width : 18,
                         height : 21,
                         style : 'padding:3px 0px 0px 0px;',
-                        hidden : originallyVisibleBBox === null,
+                        hidden : Ext.Object.isEmpty(originallyVisibleBBox),
                         listeners : {
                             render : Ext.bind(this._configureImageClickHandlers, this, [originallyVisibleBBox], true)
                         }
@@ -137,7 +140,7 @@ Ext.define('portal.layer.downloader.wfs.WFSDownloader', {
                         boxLabel : 'Don\'t filter my download. Return all available data.',
                         name : 'wfs-download-radio',
                         inputValue : portal.layer.downloader.wfs.WFSDownloader.DOWNLOAD_ALL,
-                        checked : !isDifferentBBox && originallyVisibleBBox === null
+                        checked : !isDifferentBBox && Ext.Object.isEmpty(originallyVisibleBBox)
                     }]
                 }]
             }]


### PR DESCRIPTION
1. Fixes problem that downloads do not work unless layer has been added to map

Tested 'getParameters()' to make sure that downloads occur only when there are parameters to send to the service

2. Fixes problem that option to display "current visible map bounds" is usable, yet map has not been loaded

Problem is caused by 'currentlyVisibleBBox' and 'originallyVisibleBBox' being undefined, not 'null' when map has not been added, so the '=== null' tests etc. do not work, replaced with a more robust test



