### PR TITLE
VGLOPS-20 Fixed endless loading on WCS Querier

### DIFF
--- a/src/main/webapp/portal-core/js/portal/layer/querier/coverage/WCSQuerier.js
+++ b/src/main/webapp/portal-core/js/portal/layer/querier/coverage/WCSQuerier.js
@@ -52,11 +52,12 @@ Ext.define('portal.layer.querier.coverage.WCSQuerier', {
             },
             scope : this,
             callback : function(success, data, message) {
-                if(success){
-                    if (!data) { //LJ: AUS-2598 ASTER mask hanging when server is down.
-                        callback(this, [this._generateErrorComponent('There was a problem when looking up the point')], queryTarget);
-                        return;
-                    }                    
+                if (!success || !data) { //LJ: AUS-2598 ASTER mask hanging when server is down.
+                    callback(this, [this._generateErrorComponent('There was a problem when looking up the coverage: ' + message)], queryTarget);
+                    return;
+                }
+                
+                if(success) {
                     var record = data[0];
                     var spatialFunc=function(item) {
                         var s = '';
@@ -118,7 +119,7 @@ Ext.define('portal.layer.querier.coverage.WCSQuerier', {
                             },{
                                 xtype : 'displayfield',
                                 fieldLabel : 'WMS URLs',
-                                value : options.params.layerName + '-' + options.params.serviceUrl
+                                value : queryTarget.get('onlineResource').get('name') + '-' + queryTarget.get('onlineResource').get('url')
                             },{
                                 xtype : 'displayfield',
                                 fieldLabel : 'Spatial Domain',

--- a/src/main/webapp/portal-core/js/portal/util/Ajax.js
+++ b/src/main/webapp/portal-core/js/portal/util/Ajax.js
@@ -35,13 +35,19 @@ Ext.define('portal.util.Ajax', {
             return;
         }
         
+        var responseObj = null;
         try {
-            var responseObj = Ext.JSON.decode(response.responseText);
-            callback(responseObj.success === true, responseObj.data, responseObj.msg, responseObj.debugInfo);
-            return;
+            responseObj = Ext.JSON.decode(response.responseText);
         } catch(err) {
             console.log('ERROR parsing Ajax response:', err);
             callback(false, undefined, undefined, undefined);
+            return;
+        }
+        
+        try {
+            callback(responseObj.success === true, responseObj.data, responseObj.msg, responseObj.debugInfo);
+        } catch(err) {
+            console.log('ERROR calling user callback:', err);
             return;
         }
     },


### PR DESCRIPTION
Two main fixes:
* Errors thrown from Ajax callback no longer cause the Ajax callback to be refired
* Fixed JS error when loading WCS querier popup