### PR TITLE
AUS-2789 Make sure portal doesn't display csw metadata records as reg…

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/KnownLayerService.java
+++ b/src/main/java/org/auscope/portal/core/services/KnownLayerService.java
@@ -108,7 +108,11 @@ public class KnownLayerService {
                         mappedRecordIDs.put(record.getFileIdentifier(), null);
                         break;
                     default:
-                        break;
+                        // Ignore metadata CSW records - they have no named online resources and no geographic element BBOXes
+                        // To ignore we must add it to the mapped record ids, so it does not get counted as an unmapped record
+                        if (!record.hasNamedOnlineResources() && !record.hasGeographicElements()) {
+                            mappedRecordIDs.put(record.getFileIdentifier(), null);
+                        }
                     }
                 } catch (PortalServiceException e) {
                     logger.error("Expecting data to line up", e);

--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWRecord.java
@@ -215,6 +215,24 @@ public class CSWRecord {
     public AbstractCSWOnlineResource[] getOnlineResources() {
         return onlineResources;
     }
+    
+    /**
+     * Check for an online resource with a name
+     *
+     * @return true if there exists an online resource with a name 
+     */
+    public boolean hasNamedOnlineResources() {
+        boolean hasName = false;
+        if (onlineResources != null) {
+            for (int i=0; i<onlineResources.length; i++) {
+                if (!onlineResources[i].getName().equals("")) {
+                    hasName = true;
+                    break;
+                }
+            }
+        }
+        return hasName;
+    }
 
     /**
      * Gets the resource provider.
@@ -251,6 +269,15 @@ public class CSWRecord {
      */
     public CSWGeographicElement[] getCSWGeographicElements() {
         return cswGeographicElements;
+    }
+    
+    /**
+     * Checks if there are any BBOXes for this record
+     *
+     * @return true if there are any BBOXes in the geographic elements
+     */
+    public boolean hasGeographicElements() {
+        return (cswGeographicElements!=null && cswGeographicElements.length>0);
     }
 
     /**

--- a/src/test/java/org/auscope/portal/core/services/TestKnownLayerService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestKnownLayerService.java
@@ -151,6 +151,13 @@ public class TestKnownLayerService extends PortalTestClass {
                 will(returnValue(RelationType.NotRelated));
                 oneOf(mockSelector3).isRelatedRecord(cswRecordList.get(2));
                 will(returnValue(RelationType.NotRelated));
+
+                allowing(cswRecordList.get(0)).hasNamedOnlineResources();
+                will(returnValue(true));
+                allowing(cswRecordList.get(1)).hasNamedOnlineResources();
+                will(returnValue(true));
+                allowing(cswRecordList.get(2)).hasNamedOnlineResources();
+                will(returnValue(true));
             }
         });
 
@@ -209,6 +216,13 @@ public class TestKnownLayerService extends PortalTestClass {
                 will(returnValue(RelationType.NotRelated));
                 oneOf(mockSelector3).isRelatedRecord(cswRecordList.get(2));
                 will(returnValue(RelationType.NotRelated));
+
+                allowing(cswRecordList.get(0)).hasNamedOnlineResources();
+                will(returnValue(true));
+                allowing(cswRecordList.get(1)).hasNamedOnlineResources();
+                will(returnValue(true));
+                allowing(cswRecordList.get(2)).hasNamedOnlineResources();
+                will(returnValue(true));
             }
         });
 
@@ -219,5 +233,72 @@ public class TestKnownLayerService extends PortalTestClass {
         // Assert
         Assert.assertEquals(1, groups.size());
         Assert.assertTrue(groups.get(0).getKnownLayer() instanceof FakeKnownLayerChild);
+    }
+    
+    @Test
+    public void groupKnownLayerRecords_avoids_metadatacsw_records() {
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getRecordCache();
+                will(returnValue(cswRecordList));
+
+                oneOf(mockSelector1).isRelatedRecord(cswRecordList.get(0));
+                will(returnValue(RelationType.NotRelated));
+                oneOf(mockSelector1).isRelatedRecord(cswRecordList.get(1));
+                will(returnValue(RelationType.NotRelated));
+                oneOf(mockSelector1).isRelatedRecord(cswRecordList.get(2));
+                will(returnValue(RelationType.NotRelated));
+
+                oneOf(mockSelector2).isRelatedRecord(cswRecordList.get(0));
+                will(returnValue(RelationType.NotRelated));
+                oneOf(mockSelector2).isRelatedRecord(cswRecordList.get(1));
+                will(returnValue(RelationType.NotRelated));
+                oneOf(mockSelector2).isRelatedRecord(cswRecordList.get(2));
+                will(returnValue(RelationType.NotRelated));
+
+                oneOf(mockSelector3).isRelatedRecord(cswRecordList.get(0));
+                will(returnValue(RelationType.NotRelated));
+                oneOf(mockSelector3).isRelatedRecord(cswRecordList.get(1));
+                will(returnValue(RelationType.NotRelated));
+                oneOf(mockSelector3).isRelatedRecord(cswRecordList.get(2));
+                will(returnValue(RelationType.NotRelated));
+
+                allowing(cswRecordList.get(0)).hasNamedOnlineResources();
+                will(returnValue(false));
+                allowing(cswRecordList.get(0)).hasGeographicElements();
+                will(returnValue(false));
+                allowing(cswRecordList.get(1)).hasNamedOnlineResources();
+                will(returnValue(true));
+                allowing(cswRecordList.get(1)).hasGeographicElements();
+                will(returnValue(false));
+                allowing(cswRecordList.get(2)).hasNamedOnlineResources();
+                will(returnValue(false));
+                allowing(cswRecordList.get(2)).hasGeographicElements();
+                will(returnValue(true));
+            }
+        });
+
+        // Start execution
+        KnownLayerGrouping grouping = knownLayerService.groupKnownLayerRecords();
+
+        // Test the results
+        Assert.assertNotNull(grouping);
+        Assert.assertNotNull(grouping.getKnownLayers());
+        Assert.assertNotNull(grouping.getOriginalRecordSet());
+        Assert.assertNotNull(grouping.getUnmappedRecords());
+
+        List<KnownLayerAndRecords> groups = grouping.getKnownLayers();
+        Assert.assertEquals(2, groups.size());
+        Assert.assertEquals(0, groups.get(0).getBelongingRecords().size());
+        Assert.assertEquals(0, groups.get(0).getRelatedRecords().size());
+        Assert.assertEquals(0, groups.get(1).getBelongingRecords().size());
+        Assert.assertEquals(0, groups.get(1).getRelatedRecords().size());
+
+        List<CSWRecord> unmappedCSWList = grouping.getUnmappedRecords();
+        Assert.assertEquals(2, unmappedCSWList.size());
+
+        assertListContentsSame(cswRecordList, grouping.getOriginalRecordSet());
+        Assert.assertEquals(cswRecordList.get(1), unmappedCSWList.get(0));
+        Assert.assertEquals(cswRecordList.get(2), unmappedCSWList.get(1));
     }
 }


### PR DESCRIPTION
…istered layers.

This fix makes sure that unusable csw metadata records are not added to the list of unmapped CSW records. 
The list of unmapped CSW records will appear in the "Registered" tab on the left hand panel in Auscope website. Thus this removes almost all of the unusable reports from the "Registered" tab. 
