### PR TITLE
AUS-2788 New constructor allows use of CQL query

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/csw/CSWServiceItem.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/CSWServiceItem.java
@@ -63,6 +63,24 @@ public class CSWServiceItem {
         this.recordInformationUrl = recordInformationUrl;
         this.title = title;
     }
+    
+    /**
+     * Creates a new service item with NO role restrictions and a cqlText query, used to restrict the downloaded CSW records
+     * 
+     * @param id
+     *            Must be unique per service
+     * @param serviceUrl
+     * @param recordInformationUrl
+     * @param title
+     * @param cqlText
+     */
+    public CSWServiceItem(String id, String serviceUrl, String recordInformationUrl, String title, String cqlText) {
+        this.id = id;
+        this.serviceUrl = serviceUrl;
+        this.recordInformationUrl = recordInformationUrl;
+        this.title = title;
+        this.cqlText = cqlText;
+    }
 
     /**
      * Creates a new service item that is restricted to users with ANY of the specified roles


### PR DESCRIPTION
I have added a new constructor which allow the setting of 'cqlQuery', in addition to the normal set of parameters. 'cqlQuery' is already implemented within the 'CSWServiceItem' class.

This will be used to limit the number of CSW records downloaded from a service to save bandwidth and CPU time, only downloading the records that we need.