### PR TITLE
AUS-2790 Rename URL because catalogue has moved

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/CSWMetadataPanel.js
@@ -25,7 +25,7 @@ Ext.define('portal.widgets.panel.CSWMetadataPanel', {
 
         if (typeof(cfg.extraItems) === 'undefined') {
 
-            if (source.indexOf('eos-test.ga.gov.au') !== -1 || source.indexOf('eos.ga.gov.au') !== -1) {
+            if (source.indexOf('ecat-test.ga.gov.au') !== -1 || source.indexOf('ecat.ga.gov.au') !== -1) {
                 this.extraItems = {
                         xtype : 'displayfield',
                         fieldLabel : 'Notes',


### PR DESCRIPTION
European Space Agency InSAR catalogue has moved to a new URL.
This just updates the code in line with that change.