### PR TITLE
Added AuScope snapshot repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -317,7 +317,7 @@
         </repository>
         <!-- This is for AuScope specific snapshot builds of packages that arent in Maven central -->
         <repository>
-            <id>cgsrv8.arrc.csiro.au</id>
+            <id>cgsrv8.arrc.csiro.au-snapshots</id>
             <name>AuScope Nexus - PortalRepo</name>
             <url>http://cgsrv8.arrc.csiro.au/nexus/content/groups/PortalSnapshot/</url>
         </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
         <repository>
             <id>cgsrv8.arrc.csiro.au-snapshots</id>
             <name>AuScope Nexus - PortalRepo</name>
-            <url>http://cgsrv8.arrc.csiro.au/nexus/content/groups/PortalSnapshot/</url>
+            <url>https://cgsrv8.arrc.csiro.au/nexus/content/repositories/PortalSnapshot/</url>
         </repository>
     </repositories>
     <!-- Dependencies -->

--- a/pom.xml
+++ b/pom.xml
@@ -315,6 +315,12 @@
             <name>AuScope Nexus - PortalRepo</name>
             <url>http://cgsrv8.arrc.csiro.au/nexus/content/groups/PortalRepository/</url>
         </repository>
+        <!-- This is for AuScope specific snapshot builds of packages that arent in Maven central -->
+        <repository>
+            <id>cgsrv8.arrc.csiro.au</id>
+            <name>AuScope Nexus - PortalRepo</name>
+            <url>http://cgsrv8.arrc.csiro.au/nexus/content/groups/PortalSnapshot/</url>
+        </repository>
     </repositories>
     <!-- Dependencies -->
     <dependencies>


### PR DESCRIPTION
We currently depend on the snapshot grouping of repositories in the AuScope nexus instance. This ensures that they are referenced correctly