### PR TITLE
AUS-2811 Fixed empty text showing if cmp is initially hidden

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/recordpanel/RecordPanel.js
@@ -108,6 +108,11 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
                 }
             });
         }
+        
+        this.on({
+            show: this.onComponentShow,
+            scope: this
+        });
 
         //If our store is already loaded - fill panel with existing contents
         if (this.store.getCount()) {
@@ -511,7 +516,8 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
     },
     
     /**
-     * Updates the empty text hidden/visible status depending on whether any records are showing.
+     * Updates the empty text hidden/visible status depending on whether any records are showing. Will
+     * ALWAYS show empty text if this component is hidden.
      */
     _updateEmptyText: function() {
         var visibleItems = 0;
@@ -533,6 +539,13 @@ Ext.define('portal.widgets.panel.recordpanel.RecordPanel', {
         this.down('#emptytext').setHidden(visibleItems !== 0);
     },
 
+    onComponentShow: function(recordPanel) {
+        //Update our empty text visibility if the component is shown. Empty text visibility
+        //does NOT properly work when the component is hidden hence we are forced to check this
+        //every time the component is returned from hiding - See AUS-2811
+        this._updateEmptyText();
+    },
+    
     /**
      * Handle updating renderers/tips for the modified fields
      */


### PR DESCRIPTION
If the record panel is initially hidden (eg another tab) the empty text will be updated to ALWAYS show irrespective of whether it should/should not. This is a quirk of the way we check for visibility. Rather than rejigging the whole checking mechanism with our own custom visbility flags, I've opted to recheck empty text when this component is made visible.

See https://jira.csiro.au/browse/AUS-2811