### PR TITLE
AUS-2827 "Hiding" online resources from known bad hosts

### DIFF
--- a/src/main/webapp/portal-core/js/portal/widgets/panel/FilterPanel.js
+++ b/src/main/webapp/portal-core/js/portal/widgets/panel/FilterPanel.js
@@ -326,7 +326,7 @@ Ext.define('portal.widgets.panel.FilterPanel', {
             layer.get('source').containsNagiosFailures()) {
             var failingHosts = layer.get('source').get('nagiosFailingHosts');
             
-            var message = 'Please be aware that some of the services underpinning this layer have recently been reported as being unstable. Some aspects of this layer may fail to load successfully. The hosts reported to be experiencing problems are:<br><ul>';
+            var message = 'Please be aware that some of the services underpinning this layer have recently been reported as being unstable. The unstable hosts will be not be queried. The hosts reported to be experiencing problems are:<br><ul>';
             Ext.each(failingHosts, function(host) {
                 message += '<li><b>' + host + '</b></li>';
             });


### PR DESCRIPTION
Made the widely used function getAllOnlineResources in Layer.js return only OR's that are NOT failing according to Nagios. 

Updated the warning message when adding layers to properly reflect this.