### PR TITLE
AUS 2846: Update version of saxon library to enable Uni of Melbourne MSCL borehole plots to work again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.auscope.portal</groupId>
     <artifactId>portal-core</artifactId>
     <packaging>jar</packaging>
-    <version>1.6.0</version>
+    <version>1.7.0-SNAPSHOT</version>
     <name>Portal-Core</name>
     <description>Core functionality common to various AuScope portals.</description>
     <url>http://portal.auscope.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -396,8 +396,8 @@
         </dependency>
         <dependency>
             <groupId>net.sf.saxon</groupId>
-            <artifactId>saxon-xom</artifactId>
-            <version>8.7</version>
+            <artifactId>Saxon-HE</artifactId>
+            <version>9.7.0-18</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -482,18 +482,6 @@
             <groupId>edu.ucar</groupId>
             <artifactId>netcdf</artifactId>
             <version>4.2</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.saxon</groupId>
-            <artifactId>saxon-xpath</artifactId>
-            <version>8.7</version>
-            <optional>false</optional>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.saxon</groupId>
-            <artifactId>saxon-dom</artifactId>
-            <version>8.7</version>
             <optional>false</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update version of saxon library to enable Uni of Melbourne MSCL borehole plots to work again
I have re-tested AuScope functionality that uses saxon to check that there are no side-effects: e.g. IRIS, QLD Mineral Tenements, borehole counting, Yilgarn specimen chemical data, pressure DB observations etc. 