### PR TITLE
Fix breaking test, thread sleep not long enough

### DIFF
--- a/src/test/java/org/auscope/portal/core/services/TestCSWCacheService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestCSWCacheService.java
@@ -292,7 +292,10 @@ public class TestCSWCacheService extends PortalTestClass {
             // Start our updating and wait for our threads to finish
             Assert.assertTrue(this.cswCacheService.updateCache());
             try {
-                Thread.sleep(3000);
+                do {
+                Thread.sleep(300);
+                } while (this.cswCacheService.updateRunning);
+
             } catch (InterruptedException e) {
                 Assert.fail("Test sleep interrupted. Test aborted.");
             }


### PR DESCRIPTION
On some machines, the thread sleep is not long enough and the cache process isn't finished before we test it. 