### PR TITLE
Update to 3rd party libraries and switch to new CSIRO maven repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,9 +311,9 @@
         </repository>
         <!-- This is for AuScope specific builds of packages that arent in Maven central -->
         <repository>
-            <id>cgsrv8.arrc.csiro.au</id>
-            <name>AuScope Nexus - PortalRepo</name>
-            <url>https://cgsrv8.arrc.csiro.au/nexus/repository/PortalRepository/</url>
+            <id>cgmaven.it.csiro.au</id>
+            <name>AuScope Nexus - New PortalRepo</name>
+            <url>https://cgmaven.it.csiro.au/nexus/repository/PortalRepository/</url>
         </repository>
         <!-- This is for AuScope specific snapshot builds of packages that arent in Maven central -->
         
@@ -333,7 +333,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.10.48</version>
+            <version>1.11.277</version>
         </dependency>
         <dependency>
             <groupId>taglibs</groupId>
@@ -477,7 +477,8 @@
         <dependency>
             <groupId>edu.ucar</groupId>
             <artifactId>netcdf</artifactId>
-            <version>4.2</version>
+            <version>4.3.16</version>
+        <!--     <version>4.3.22</version>  -->
             <optional>false</optional>
         </dependency>
         <dependency>


### PR DESCRIPTION
Update to newer versions of 3rd party libraries as old versions no longer available through any of the maven repositories we use.

Also changed to new CSIRO repository as old one does no longer work with current versions of Java 8 or 9 (due to weak certificate which Java refuses to work with)