### PR TITLE
Vocabulary caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 target/
 .buildpath
 *.swp
+/bin/
+*.iml

--- a/src/main/java/org/auscope/portal/core/services/VocabularyCacheService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyCacheService.java
@@ -163,4 +163,8 @@ public class VocabularyCacheService {
         return vocabularyCache;
     }
 
+    public synchronized Map<String, String> getVocabularyCacheById(String vocabularyId) {
+        return vocabularyCache.get(vocabularyId);
+    }
+
 }

--- a/src/main/java/org/auscope/portal/core/services/VocabularyCacheService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyCacheService.java
@@ -1,0 +1,166 @@
+package org.auscope.portal.core.services;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.services.vocabs.VocabularyServiceItem;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.concurrent.Executor;
+
+public class VocabularyCacheService {
+
+    private final Log log = LogFactory.getLog(getClass());
+
+    protected List<VocabularyServiceItem> serviceList;
+    protected Executor executor;
+
+    protected Map<String, Map<String, String>> vocabularyCache;
+    protected boolean updateRunning;
+
+    public VocabularyCacheService(Executor executor,
+                                  ArrayList serviceList) {
+        this.executor = executor;
+        this.serviceList = serviceList;
+
+        this.vocabularyCache = new HashMap<String, Map<String, String>>();
+    }
+
+    /**
+     * @return
+     */
+    public boolean updateCache() {
+        if (!okToUpdate()) {
+            return false;
+        }
+
+        VocabularyCacheUpdateThread[] updateThreads = new VocabularyCacheUpdateThread[serviceList.size()];
+
+        for (int i = 0; i < updateThreads.length; i++) {
+            updateThreads[i] = new VocabularyCacheUpdateThread(this,
+                    updateThreads,
+                    serviceList.get(i),
+                    this.vocabularyCache);
+        }
+
+        for (VocabularyCacheUpdateThread thread : updateThreads) {
+            this.executor.execute(thread);
+        }
+
+        return true;
+    }
+
+    private synchronized boolean okToUpdate() {
+        if (this.updateRunning) {
+            return false;
+        }
+
+        this.updateRunning = true;
+        return true;
+    }
+
+    private synchronized void updateFinished(Map<String, Map<String, String>> vocabularyCache) {
+        this.updateRunning = false;
+
+        if (vocabularyCache != null) {
+            this.vocabularyCache = vocabularyCache;
+        }
+
+        int numberOfTerms = 0;
+        int numberOfVocabularies = this.vocabularyCache.size();
+
+        for (Entry<String, Map<String, String>> entry : this.vocabularyCache.entrySet()) {
+            numberOfTerms +=  entry.getValue().size();
+        }
+        log.info(String.format("Vocabulary cache updated! Cache now has '%1$d' unique vocabulary terms, from '%2$d' vocabulary services",
+                numberOfTerms, numberOfVocabularies));
+
+
+
+    }
+
+
+    private class VocabularyCacheUpdateThread extends Thread {
+        private final Log threadLog = LogFactory.getLog(getClass());
+
+        private VocabularyCacheService parent;
+        private VocabularyCacheUpdateThread[] siblings;
+        private VocabularyServiceItem serviceItem;
+
+        private Map<String, Map<String, String>> vocabularyCache;
+        private boolean finishedExecution;
+
+
+        public VocabularyCacheUpdateThread(VocabularyCacheService parent,
+                                           VocabularyCacheUpdateThread[] siblings,
+                                           VocabularyServiceItem serviceItem,
+                                           Map<String, Map<String, String>> vocabularyCache){
+            this.parent = parent;
+            this.siblings = siblings;
+            this.serviceItem = serviceItem;
+            this.vocabularyCache = vocabularyCache;
+        }
+
+        private boolean isFinishedExecution() {
+            synchronized (siblings) {
+                return finishedExecution;
+            }
+        }
+
+        private void setFinishedExecution(boolean finishedExecution) {
+            synchronized (siblings) {
+                this.finishedExecution = finishedExecution;
+            }
+        }
+
+        /**
+         *
+         */
+        @Override
+        public void run() {
+            try {
+                VocabularyService service = serviceItem.getVocabularyService();
+                Map<String,String> map = service.getAllRelevantConcepts();
+                synchronized (this.vocabularyCache){
+                    this.vocabularyCache.put(this.serviceItem.getId(), map);
+                }
+            }
+            catch (PortalServiceException | URISyntaxException e) {
+                threadLog.error(e.getStackTrace());
+
+            } finally {
+                attemptCleanup();
+            }
+        }
+
+        private void attemptCleanup() {
+            synchronized(siblings) {
+                this.setFinishedExecution(true);
+
+                boolean cleanupRequired = true;
+                for (VocabularyCacheUpdateThread sibling : siblings) {
+                    if (!sibling.isFinishedExecution()) {
+                        cleanupRequired = false;
+                        break;
+                    }
+                }
+
+                //Last thread to finish tells our parent we've terminated
+                if (cleanupRequired) {
+                    parent.updateFinished(vocabularyCache);
+                }
+            }
+        }
+
+    }
+
+    public synchronized Map<String, Map<String, String>> getVocabularyCache() {
+        return vocabularyCache;
+    }
+
+}

--- a/src/main/java/org/auscope/portal/core/services/VocabularyService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyService.java
@@ -1,0 +1,256 @@
+package org.auscope.portal.core.services;
+
+import com.hp.hpl.jena.rdf.model.*;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker;
+
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.View;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.Format;
+
+import org.auscope.portal.core.services.namespaces.VocabNamespaceContext;
+import org.auscope.portal.core.util.DOMUtil;
+import org.auscope.portal.core.util.FileIOUtil;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * A service class for interacting with a Linked Data API vocabulary service
+ *
+ * @author Josh Vote
+ *
+ */
+public class VocabularyService {
+    /** The class for making HTTP requests */
+    protected HttpServiceCaller httpServiceCaller;
+
+    /** The class for generating vocabulary requests */
+    protected VocabularyMethodMaker vocabularyMethodMaker;
+
+    /**
+     * The service URL in the form - http://host.name/path/to/service
+     *
+     * The URL will be appended with repository/command names and file formats
+     */
+    private String serviceUrl;
+
+    /**
+     * This service will request concepts in batches of this size. Defaults to 1000
+     */
+    private int pageSize = 1000;
+
+    public VocabularyService(HttpServiceCaller httpServiceCaller,
+                             VocabularyMethodMaker vocabularyMethodMaker, String serviceUrl) {
+        super();
+        this.httpServiceCaller = httpServiceCaller;
+        this.vocabularyMethodMaker = vocabularyMethodMaker;
+        this.serviceUrl = serviceUrl;
+    }
+
+    /**
+     * This service will request concepts in batches of this size. Defaults to 1000
+     * 
+     * @return
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * This service will request concepts in batches of this size. Defaults to 1000
+     * 
+     * @param pageSize
+     */
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    /**
+     * The service URL in the form - http://host.name/path/to/service
+     *
+     * The URL will be appended with repository/command names and file formats
+     * 
+     * @return
+     */
+    public String getServiceUrl() {
+        return serviceUrl;
+    }
+
+    /**
+     * Gets all descriptions for a given page (as described by a HttpMethod), appends the parsed values to the specified JENA model.
+     *
+     * Returns true if there is more data (pages) to request. false otherwise. Exceptions will be rethrown as PortalServiceException objects
+     *
+     * @param method
+     *            method to access to vocab service
+     * @param model
+     *            receives the response Descriptions
+     */
+    protected boolean requestPageOfConcepts(HttpRequestBase method, Model model) throws PortalServiceException {
+        boolean moreData = false;
+
+        try (InputStream inputStream  = httpServiceCaller.getMethodResponseAsStream(method)) {
+            // Parse the response into an XML document
+            Document document = null;
+            document = DOMUtil.buildDomFromStream(inputStream);
+
+            VocabNamespaceContext namespaceContext = new VocabNamespaceContext();
+            XPathExpression getDescriptionsExpression = DOMUtil.compileXPathExpr("rdf:RDF/descendant::rdf:Description", namespaceContext);
+            XPathExpression nextPageExpression = DOMUtil.compileXPathExpr("rdf:RDF/descendant::api:Page/xhv:next", namespaceContext);
+
+            Node nextPageNode = (Node) nextPageExpression.evaluate(document, XPathConstants.NODE);
+            if (nextPageNode != null) {
+                moreData = true;
+            }
+
+            NodeList allDescriptions = (NodeList) getDescriptionsExpression.evaluate(document, XPathConstants.NODESET);
+            for (int i = 0; i < allDescriptions.getLength(); i++) {
+                String rdf = DOMUtil.buildStringFromDom(allDescriptions.item(i), true);
+                model.read(new StringReader(rdf), null);
+            }
+
+        } catch (Exception e) {
+            throw new PortalServiceException(method, e);
+        } finally {
+            method.releaseConnection();
+        }
+
+        return moreData;
+    }
+
+    /**
+     * Gets all RDF concepts at the specified repository as a single JENA Model.
+     * The results will be requested page by page until the entire repository
+     * has been traversed.
+     *
+     * @return
+     * @throws PortalServiceException
+     * @throws URISyntaxException
+     */
+    public Model getAllConcepts() throws PortalServiceException, URISyntaxException {
+        Model model = ModelFactory.createDefaultModel();
+        int pageNumber = 0;
+        int ps = this.pageSize;
+
+        // Request each page in turn - put the results into Model
+        do {
+            HttpRequestBase method = vocabularyMethodMaker.getAllConcepts(serviceUrl, Format.Rdf, ps, pageNumber);
+            if (requestPageOfConcepts(method, model)) {
+                pageNumber++;
+            } else {
+                break;
+            }
+        } while (true);
+
+        return model;
+    }
+
+    /**
+     * Gets all RDF concepts in the specified scheme as a single JENA Model. The
+     * results will be requested page by page until the entire repository has
+     * been traversed.
+     *
+     * @return
+     * @throws PortalServiceException
+     * @throws URISyntaxException
+     */
+
+    public Model getAllConceptsInScheme(String inScheme, View view) throws URISyntaxException, PortalServiceException {
+        Model model = ModelFactory.createDefaultModel();
+        int pageNumber = 0;
+        int ps = this.pageSize;
+
+        do {
+            HttpRequestBase method = vocabularyMethodMaker.getAllConceptsInScheme(serviceUrl, inScheme,
+                    Format.Rdf, view, ps, pageNumber);
+            if (requestPageOfConcepts(method, model)) {
+                pageNumber++;
+            } else {
+                break;
+            }
+        } while (true);
+
+        return model;
+
+    }
+
+    /**
+     * Returns all the relevant concepts for this. By default returns
+     *
+     *
+     * @return
+     */
+    public Map<String,String> getAllRelevantConcepts() throws URISyntaxException, PortalServiceException {
+        Map<String, String> result = new HashMap<String, String>();
+
+        Model model = ModelFactory.createDefaultModel();
+        int pageNumber = 0;
+        int pageSize = this.getPageSize();
+
+        do {
+            HttpRequestBase method = vocabularyMethodMaker.getAllConcepts(getServiceUrl(), Format.Rdf, View.description, pageSize, pageNumber);
+            if (requestPageOfConcepts(method, model)) {
+                pageNumber++;
+            } else {
+                break;
+            }
+        } while (true);
+
+        Property prefLabelProperty = model.createProperty(VocabNamespaceContext.SKOS_NAMESPACE, "prefLabel");
+        ResIterator iterator = model.listResourcesWithProperty(prefLabelProperty);
+        while (iterator.hasNext()) {
+            Resource resource = iterator.next();
+            StmtIterator prefLabelIterator = resource.listProperties(prefLabelProperty);
+            while (prefLabelIterator.hasNext()) {
+                Statement prefLabelStatement = prefLabelIterator.next();
+                String prefLabel = prefLabelStatement.getString();
+
+                String urn = resource.getURI();
+                if (urn != null) {
+                    result.put(urn, prefLabel);
+                }
+            }
+        }
+        return result;
+    }
+
+
+    /**
+     * Makes a request to the configured SISSVoc service for a concept to describe the specified URI
+     * 
+     * @param resourceUri
+     *            The vocabulary resource to look for
+     * @return
+     * @throws PortalServiceException
+     */
+    @SuppressWarnings("resource")
+    public Resource getResourceByUri(String resourceUri) throws PortalServiceException {
+        InputStream inputStream = null;
+        HttpRequestBase method = null;
+        try {
+            method = vocabularyMethodMaker.getResourceByUri(serviceUrl, resourceUri, Format.Rdf);
+            inputStream = httpServiceCaller.getMethodResponseAsStream(method);
+            Model model = ModelFactory.createDefaultModel();
+            model.read(inputStream, null);
+
+            return model.getResource(resourceUri);
+        } catch (Exception e) {
+            throw new PortalServiceException(method, e);
+        } finally {
+            FileIOUtil.closeQuietly(inputStream);
+            if (method != null) {
+                method.releaseConnection();                
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/auscope/portal/core/services/methodmakers/VocabularyMethodMaker.java
+++ b/src/main/java/org/auscope/portal/core/services/methodmakers/VocabularyMethodMaker.java
@@ -1,0 +1,330 @@
+package org.auscope.portal.core.services.methodmakers;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.message.BasicNameValuePair;
+
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * A class for generating HTTP methods to communicate with a vocabulary
+ * service that uses the Linked Data API
+ *
+ * @author Josh Vote, Michael Sexton
+ *
+ */
+public class VocabularyMethodMaker extends AbstractMethodMaker {
+    /**
+     * The response format from the vocabulary service
+     */
+    public enum Format {
+        /**
+         * Request the response styled using HTML
+         */
+        Html,
+        /**
+         * Request the response styled using RDF XML
+         */
+        Rdf,
+        /**
+         * Request the response styled using JSON
+         */
+        Json,
+        /**
+         * Request the response styled using Turtle
+         * http://www.w3.org/TeamSubmission/turtle/
+         */
+        Ttl
+    }
+
+    public enum View {
+        basic,
+
+        concept,
+
+        description,
+
+        all
+    }
+
+    /**
+     * Utility method for building a SISSVoc GetMethod
+     *
+     * @param serviceUrl
+     *            The base URL
+     * @param command
+     *            The command to query
+     * @param format
+     *            The download format
+     * @param params
+     *            The list of params
+     * @return
+     * @throws URISyntaxException
+     */
+    protected HttpGet buildGetMethod(String serviceUrl, String command, Format format,
+            List<NameValuePair> params) throws URISyntaxException {
+        String requestUrl = this.urlPathConcat(serviceUrl, command);
+
+        if (format != null) {
+            switch (format) {
+            case Html:
+                requestUrl += ".html";
+                break;
+            case Rdf:
+                requestUrl += ".rdf";
+                break;
+            case Json:
+                requestUrl += ".json";
+                break;
+            case Ttl:
+                requestUrl += ".ttl";
+                break;
+            }
+        }
+
+        URIBuilder builder = new URIBuilder(requestUrl);
+
+        for (NameValuePair p : params) {
+            builder.setParameter(p.getName(), p.getValue());
+        }
+
+        HttpGet method = new HttpGet();
+        method.setURI(builder.build());
+
+        return method;
+    }
+
+    /**
+     * Appends elda params for paging to the specified list
+     *
+     * @param params
+     *            The list to append params to
+     * @param pageSize
+     * @param pageNumber
+     */
+    protected void appendPagingParams(List<NameValuePair> params, Integer pageSize, Integer pageNumber) {
+        if (pageSize != null) {
+            params.add(new BasicNameValuePair("_pageSize", pageSize.toString()));
+        }
+
+        if (pageNumber != null) {
+            params.add(new BasicNameValuePair("_page", pageNumber.toString()));
+        }
+    }
+
+    /**
+     * Appends the view parameter to the list, in the case where the vocabulary
+     * service presents a limited description for a vocabulary by default
+     * 
+     * @param params
+     *            The list to append params to
+     * @param view
+     *            The view parameter value to append
+     */
+    protected void appendViewParam(List<NameValuePair> params, String view) {
+        params.add(new BasicNameValuePair("_view", view));
+    }
+
+    /**
+     * Generates a method for requesting all concepts (as rdf:Descriptions) at
+     * the specified service
+     *
+     * The request supports rudimentary paging of the returned results
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param format
+     *            How the response should be structured.
+     * @param pageSize
+     *            [Optional] How many concepts should be returned per page
+     * @param pageNumber
+     *            [Optional] The page number to request (0 based)
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getAllConcepts(String serviceUrl, Format format, Integer pageSize,
+            Integer pageNumber) throws URISyntaxException {
+
+        return getAllConcepts(serviceUrl, format, null, pageSize, pageNumber);
+    }
+
+    /**
+     * Generates a method for requesting all concepts (as rdf:Descriptions) in
+     * the specified service
+     *
+     * The request supports rudimentary paging of the returned results
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param format
+     *            How the response should be structured.
+     * @param view
+     *            Type of view to be returned
+     * @param pageSize
+     *            [Optional] How many concepts should be returned per page
+     * @param pageNumber
+     *            [Optional] The page number to request (0 based)
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getAllConcepts(String serviceUrl, Format format, View view,
+            Integer pageSize, Integer pageNumber) throws URISyntaxException {
+
+        List<NameValuePair> params = new ArrayList<>();
+
+        appendPagingParams(params, pageSize, pageNumber);
+
+        if (view != null) {
+            appendViewParam(params, view.name());
+        }
+
+        return buildGetMethod(serviceUrl, "concept", format, params);
+    }
+
+    /**
+     * Generates a method for requesting all concepts (as rdf:Descriptions) in
+     * the specified service that below to the scheme requested
+     *
+     * The request supports rudimentary paging of the returned results
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param schemeUrl
+     *            The scheme the vocabulary is in
+     * @param format
+     *            How the response should be structured.
+     * @param pageSize
+     *            [Optional] How many concepts should be returned per page
+     * @param pageNumber
+     *            [Optional] The page number to request (0 based)
+     * @return
+     * @throws URISyntaxException
+     */
+
+    public HttpRequestBase getAllConceptsInScheme(String serviceUrl, String schemeUrl, Format format,
+            View view, Integer pageSize, Integer pageNumber) throws URISyntaxException {
+
+        List<NameValuePair> params = new ArrayList<>();
+
+        params.add(new BasicNameValuePair("inScheme", schemeUrl));
+        appendPagingParams(params, pageSize, pageNumber);
+        if (view != null) {
+            appendViewParam(params, view.name());
+        }
+        return buildGetMethod(serviceUrl, "concept", format, params);
+
+    }
+
+    /**
+     * Generates a method for requesting all concepts (as rdf:Descriptions) that
+     * match label in the specified service
+     *
+     * The request supports rudimentary paging of the returned results
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param format
+     *            How the response should be structured.
+     * @param label
+     *            The label to lookup
+     * @param pageSize
+     *            [Optional] How many concepts should be returned per page
+     * @param pageNumber
+     *            [Optional] The page number to request (0 based)
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getConceptsWithLabel(String serviceUrl, String label, Format format,
+            Integer pageSize, Integer pageNumber) throws URISyntaxException {
+        List<NameValuePair> params = new ArrayList<>();
+
+        appendPagingParams(params, pageSize, pageNumber);
+        params.add(new BasicNameValuePair("anylabel", label));
+
+        return buildGetMethod(serviceUrl, "concept", format, params);
+    }
+
+    /**
+     * Generates a method for the concept with matching URI from the specified
+     * service
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param format
+     *            How the response should be structured.
+     * @param conceptUri
+     *            The URI of the concept to lookup
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getResourceByUri(String serviceUrl, String conceptUri, Format format)
+            throws URISyntaxException {
+        List<NameValuePair> params = new ArrayList<>();
+        params.add(new BasicNameValuePair("uri", conceptUri));
+
+        return buildGetMethod(serviceUrl, "resource", format, params);
+    }
+
+    /**
+     * Generates a method for requesting all concepts (as rdf:Descriptions) that
+     * are broader than the specified concept as defined by skos:broader
+     *
+     * The request supports rudimentary paging of the returned results
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param format
+     *            How the response should be structured.
+     * @param baseConceptUri
+     *            The URI of a concept from which to base this request
+     * @param pageSize
+     *            [Optional] How many concepts should be returned per page
+     * @param pageNumber
+     *            [Optional] The page number to request (0 based)
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getBroaderConcepts(String serviceUrl, String baseConceptUri,
+            Format format, Integer pageSize, Integer pageNumber) throws URISyntaxException {
+        List<NameValuePair> params = new ArrayList<>();
+
+        appendPagingParams(params, pageSize, pageNumber);
+        params.add(new BasicNameValuePair("uri", baseConceptUri));
+
+        return buildGetMethod(serviceUrl,"concept/broader", format, params);
+    }
+
+    /**
+     * Generates a method for requesting all concepts (as rdf:Descriptions) that
+     * are narrower than the specified concept as defined by skos:narrower
+     *
+     * The request supports rudimentary paging of the returned results
+     *
+     * @param serviceUrl
+     *            The base URL of a vocabulary service
+     * @param format
+     *            How the response should be structured.
+     * @param baseConceptUri
+     *            The URI of a concept from which to base this request
+     * @param pageSize
+     *            [Optional] How many concepts should be returned per page
+     * @param pageNumber
+     *            [Optional] The page number to request (0 based)
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getNarrowerConcepts(String serviceUrl, String baseConceptUri,
+            Format format, Integer pageSize, Integer pageNumber) throws URISyntaxException {
+        List<NameValuePair> params = new ArrayList<>();
+
+        appendPagingParams(params, pageSize, pageNumber);
+        params.add(new BasicNameValuePair("uri", baseConceptUri));
+
+        return buildGetMethod(serviceUrl,"concept/narrower", format, params);
+    }
+
+}

--- a/src/main/java/org/auscope/portal/core/services/vocabs/VocabularyServiceItem.java
+++ b/src/main/java/org/auscope/portal/core/services/vocabs/VocabularyServiceItem.java
@@ -1,0 +1,46 @@
+package org.auscope.portal.core.services.vocabs;
+
+import org.auscope.portal.core.services.SISSVoc3Service;
+import org.auscope.portal.core.services.VocabularyService;
+
+/**
+ *
+ */
+public class VocabularyServiceItem {
+    private String id;
+    private String title;
+
+    private VocabularyService vocabularyService;
+
+    public VocabularyServiceItem(String id, String title, VocabularyService vocabularyService) {
+        this.id = id;
+        this.title = title;
+        this.vocabularyService = vocabularyService;
+    }
+
+
+
+    public String getId() { return id; }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public VocabularyService getVocabularyService() {
+        return vocabularyService;
+    }
+
+    public void setVocabularyService(VocabularyService vocabularyService) {
+        this.vocabularyService = vocabularyService;
+    }
+
+
+}

--- a/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_MoreData.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_MoreData.xml
@@ -1,0 +1,33 @@
+<rdf:RDF
+        xmlns:api="http://purl.org/linked-data/api/vocab#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:os="http://a9.com/-/spec/opensearch/1.1/"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+        xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#">
+    <api:Page rdf:about="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=2">
+        <api:page rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >2</api:page>
+        <api:items rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/commodity-code/gold">
+                <skos:prefLabel xml:lang="en">gold</skos:prefLabel>
+            </rdf:Description>
+        </api:items>
+        <os:startIndex rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >3</os:startIndex>
+        <dcterms:isPartOf>
+            <api:ListEndpoint rdf:about="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf">
+                <api:definition rdf:resource="http://52.63.163.95/cgi/sissvoc/meta/commodity-code/concept.rdf"/>
+                <dcterms:hasPart rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=2"/>
+            </api:ListEndpoint>
+        </dcterms:isPartOf>
+        <xhv:prev rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=1"/>
+        <api:definition rdf:resource="http://52.63.163.95/cgi/sissvoc/meta/commodity-code/concept.rdf"/>
+        <api:extendedMetadataVersion rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_metadata=all&amp;_pageSize=1&amp;_page=2"/>
+        <xhv:first rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=0"/>
+        <xhv:next rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=3"/>
+        <os:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >1</os:itemsPerPage>
+    </api:Page>
+</rdf:RDF>

--- a/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_NoMoreData.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_NoMoreData.xml
@@ -1,0 +1,32 @@
+<rdf:RDF
+        xmlns:api="http://purl.org/linked-data/api/vocab#"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:os="http://a9.com/-/spec/opensearch/1.1/"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+        xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#">
+    <api:Page rdf:about="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=176">
+        <api:items rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/commodity-code/uranium">
+                <skos:prefLabel xml:lang="en">uranium</skos:prefLabel>
+            </rdf:Description>
+        </api:items>
+        <api:definition rdf:resource="http://52.63.163.95/cgi/sissvoc/meta/commodity-code/concept.rdf"/>
+        <api:extendedMetadataVersion rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_metadata=all&amp;_pageSize=1&amp;_page=176"/>
+        <xhv:prev rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=175"/>
+        <dcterms:isPartOf>
+            <api:ListEndpoint rdf:about="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf">
+                <api:definition rdf:resource="http://52.63.163.95/cgi/sissvoc/meta/commodity-code/concept.rdf"/>
+                <dcterms:hasPart rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=176"/>
+            </api:ListEndpoint>
+        </dcterms:isPartOf>
+        <xhv:first rdf:resource="http://52.63.163.95/cgi/sissvoc/commodity-code/concept.rdf?_pageSize=1&amp;_page=0"/>
+        <os:startIndex rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >177</os:startIndex>
+        <os:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >1</os:itemsPerPage>
+        <api:page rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >176</api:page>
+    </api:Page>
+</rdf:RDF>

--- a/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/mineStatusConcepts_NoMoreData.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/mineStatusConcepts_NoMoreData.xml
@@ -1,0 +1,56 @@
+<rdf:RDF
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:xhv="http://www.w3.org/1999/xhtml/vocab#"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:os="http://a9.com/-/spec/opensearch/1.1/"
+        xmlns:api="http://purl.org/linked-data/api/vocab#"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+    <api:ListEndpoint rdf:about="http://vocabs.ga.gov.au/cgi/sissvoc/mine-status/concept.rdf">
+        <xhv:first rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mine-status/concept.rdf?_page=0"/>
+        <api:page rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >0</api:page>
+        <dcterms:hasPart rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mine-status/concept.rdf"/>
+        <dcterms:isPartOf rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mine-status/concept.rdf"/>
+        <api:definition rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/meta/mine-status/concept.rdf"/>
+        <os:startIndex rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >1</os:startIndex>
+        <api:items rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/operating">
+                <skos:prefLabel xml:lang="en">operating</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/under-development">
+                <skos:prefLabel xml:lang="en">under development</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/abandoned">
+                <skos:prefLabel xml:lang="en">abandoned</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/care-and-maintenance">
+                <skos:prefLabel xml:lang="en">care and maintenance</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/closed">
+                <skos:prefLabel xml:lang="en">closed</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/construction">
+                <skos:prefLabel xml:lang="en">construction</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/feasibility">
+                <skos:prefLabel xml:lang="en">feasibility</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/historic">
+                <skos:prefLabel xml:lang="en">historic</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/not-operating">
+                <skos:prefLabel xml:lang="en">not operating</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mine-status/operating-continuously">
+                <skos:prefLabel xml:lang="en">operating continuously</skos:prefLabel>
+            </rdf:Description>
+        </api:items>
+        <rdf:type rdf:resource="http://purl.org/linked-data/api/vocab#Page"/>
+        <xhv:next rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mine-status/concept.rdf?_page=1"/>
+        <api:extendedMetadataVersion rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mine-status/concept.rdf?_metadata=all"/>
+        <os:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+        >10</os:itemsPerPage>
+    </api:ListEndpoint>
+</rdf:RDF>

--- a/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/occurrenceType_ResourceRDF.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/occurrenceType_ResourceRDF.xml
@@ -1,0 +1,35 @@
+<rdf:RDF
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+        xmlns:api="http://purl.org/linked-data/api/vocab#"
+        xmlns:foaf="http://xmlns.com/foaf/0.1/">
+    <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type">
+        <skos:member>
+            <rdfs:Resource rdf:about="http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit">
+                <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
+                <dcterms:source xml:lang="en">This vocabulary, modified from Neuendorf et al., 2005 (AGI Glossary)</dcterms:source>
+                <skos:altLabel xml:lang="en">mineral deposit</skos:altLabel>
+                <skos:broader>
+                    <rdf:Description rdf:about="http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/occurrence">
+                        <skos:narrower rdf:resource="http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit"/>
+                    </rdf:Description>
+                </skos:broader>
+                <skos:definition xml:lang="en">A mass of naturally occurring material in the Earth that contains an anomalous concentration of some mineral or rock type that has some potential for human utilization, without regard to mode of origin. Typically is a single, connected, genetically related body of material.</skos:definition>
+                <skos:inScheme rdf:resource="http://resource.geosciml.org/classifierscheme/cgi/2016.01/mineral-occurrence-type"/>
+                <skos:notation rdf:datatype="http://resource.geosciml.org/classifier/cgi/LocalHierarchyKey"
+                >01.1</skos:notation>
+                <skos:prefLabel xml:lang="en">deposit</skos:prefLabel>
+                <foaf:isPrimaryTopicOf>
+                    <api:ItemEndpoint rdf:about="http://vocabs.ga.gov.au/cgi/sissvoc/mineral-occurrence-type/resource.rdf?uri=http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit">
+                        <foaf:primaryTopic rdf:resource="http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit"/>
+                        <rdf:type rdf:resource="http://purl.org/linked-data/api/vocab#Page"/>
+                        <api:extendedMetadataVersion rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mineral-occurrence-type/resource.rdf?_metadata=all&amp;uri=http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit"/>
+                        <api:definition rdf:resource="http://vocabs.ga.gov.au/cgi/sissvoc/mineral-occurrence-type/resource.rdf?uri=http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit"/>
+                    </api:ItemEndpoint>
+                </foaf:isPrimaryTopicOf>
+            </rdfs:Resource>
+        </skos:member>
+    </rdf:Description>
+</rdf:RDF>

--- a/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_MoreData.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_MoreData.xml
@@ -1,0 +1,552 @@
+<rdf:RDF
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:j.0="http://www.w3.org/1999/xhtml/vocab#"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:j.1="http://a9.com/-/spec/opensearch/1.1/"
+        xmlns:api="http://purl.org/linked-data/api/vocab#"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+    <api:Page
+            rdf:about="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=0">
+        <api:definition
+                rdf:resource="http://vocabs.ands.org.au/repository/api/lda/meta/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf"/>
+        <j.1:startIndex rdf:datatype="http://www.w3.org/2001/XMLSchema#long">1</j.1:startIndex>
+        <api:page rdf:datatype="http://www.w3.org/2001/XMLSchema#long">0</api:page>
+        <api:items rdf:parseType="Collection">
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Aalenian">
+                <skos:prefLabel xml:lang="nl">Aaleniën</skos:prefLabel>
+                <skos:prefLabel xml:lang="et">Aaleni</skos:prefLabel>
+                <skos:broader>
+                    <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/MiddleJurassic">
+                        <skos:prefLabel xml:lang="zh">中侏罗世</skos:prefLabel>
+                        <skos:prefLabel xml:lang="lt">Vidurinė Jura</skos:prefLabel>
+                        <skos:prefLabel xml:lang="et">Kesk-Juura</skos:prefLabel>
+                        <skos:prefLabel xml:lang="en">Middle Jurassic</skos:prefLabel>
+                        <skos:prefLabel xml:lang="fr">Jurassique moyen</skos:prefLabel>
+                        <skos:prefLabel xml:lang="bg">Средна Юра</skos:prefLabel>
+                        <skos:prefLabel xml:lang="fi">Keski-Jura</skos:prefLabel>
+                        <skos:narrower>
+                            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Callovian">
+                                <skos:prefLabel xml:lang="es">Calloviense</skos:prefLabel>
+                                <skos:prefLabel xml:lang="it">calloviano</skos:prefLabel>
+                                <skos:prefLabel xml:lang="hu">callovi</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sv">callov</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pl">Kelowej</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sk">kelovej</skos:prefLabel>
+                                <skos:prefLabel xml:lang="nl">Calloviën</skos:prefLabel>
+                                <skos:prefLabel xml:lang="lt">Kelovėjis</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fi">Callov</skos:prefLabel>
+                                <skos:prefLabel xml:lang="cs">Callov</skos:prefLabel>
+                                <skos:prefLabel xml:lang="en">Callovian</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pt">Caloviano</skos:prefLabel>
+                                <skos:prefLabel xml:lang="et">Callovi</skos:prefLabel>
+                                <skos:prefLabel xml:lang="de">Callovium</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sl">callovij</skos:prefLabel>
+                                <skos:prefLabel xml:lang="ja">カロビアン期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="bg">Калов</skos:prefLabel>
+                                <skos:prefLabel xml:lang="zh">卡洛夫期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="da">Callovien</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fr">Callovien</skos:prefLabel>
+                                <skos:prefLabel xml:lang="no">Callove</skos:prefLabel>
+                            </rdf:Description>
+                        </skos:narrower>
+                        <skos:prefLabel xml:lang="it">giurassico medio</skos:prefLabel>
+                        <skos:prefLabel xml:lang="no">Midtre jura</skos:prefLabel>
+                        <skos:prefLabel xml:lang="hu">középső-jura</skos:prefLabel>
+                        <skos:narrower rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/Aalenian"/>
+                        <skos:prefLabel xml:lang="sv">mellersta jura</skos:prefLabel>
+                        <skos:prefLabel xml:lang="pt">Jurássico Médio</skos:prefLabel>
+                        <skos:prefLabel xml:lang="ja">中期ジュラ紀</skos:prefLabel>
+                        <skos:notation rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode">
+                            a1.1.2.2.2
+                        </skos:notation>
+                        <skos:prefLabel xml:lang="de">Mittlerer Jura</skos:prefLabel>
+                        <skos:prefLabel xml:lang="es">Jurásico Medio</skos:prefLabel>
+                        <skos:prefLabel xml:lang="da">Mellem Jurassisk</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sl">srednja jura</skos:prefLabel>
+                        <skos:narrower>
+                            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Bathonian">
+                                <skos:prefLabel xml:lang="es">Bathoniense</skos:prefLabel>
+                                <skos:prefLabel xml:lang="it">bathoniano</skos:prefLabel>
+                                <skos:prefLabel xml:lang="da">Bathonien</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fr">Bathonien</skos:prefLabel>
+                                <skos:prefLabel xml:lang="nl">Barthoniën</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sv">bathon</skos:prefLabel>
+                                <skos:prefLabel xml:lang="ja">バソニアン期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="et">Bathoni</skos:prefLabel>
+                                <skos:prefLabel xml:lang="cs">Bathon</skos:prefLabel>
+                                <skos:prefLabel xml:lang="no">Bathon</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fi">Bathon</skos:prefLabel>
+                                <skos:prefLabel xml:lang="zh">巴通期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="bg">Бат</skos:prefLabel>
+                                <skos:prefLabel xml:lang="de">Bathonium</skos:prefLabel>
+                                <skos:prefLabel xml:lang="lt">Batonis</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pt">Batoniano</skos:prefLabel>
+                                <skos:prefLabel xml:lang="hu">bath</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sk">bath</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pl">Baton</skos:prefLabel>
+                                <skos:prefLabel xml:lang="en">Bathonian</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sl">bathonij</skos:prefLabel>
+                            </rdf:Description>
+                        </skos:narrower>
+                        <skos:prefLabel xml:lang="nl">Midden Jura</skos:prefLabel>
+                        <skos:prefLabel xml:lang="cs">Střední jura</skos:prefLabel>
+                        <skos:narrower>
+                            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Bajocian">
+                                <skos:prefLabel xml:lang="zh">巴柔期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pl">Bajos</skos:prefLabel>
+                                <skos:notation
+                                        rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                                >a1.1.2.2.2.3
+                                </skos:notation>
+                                <skos:prefLabel xml:lang="hu">bajoci</skos:prefLabel>
+                                <skos:prefLabel xml:lang="es">Bajociense</skos:prefLabel>
+                                <skos:prefLabel xml:lang="de">Bajocium</skos:prefLabel>
+                                <skos:prefLabel xml:lang="da">Bajocien</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fr">Bajocien</skos:prefLabel>
+                                <skos:prefLabel xml:lang="lt">Bajosis</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sk">bajok</skos:prefLabel>
+                                <skos:broader
+                                        rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/MiddleJurassic"/>
+                                <skos:prefLabel xml:lang="sv">bajoc</skos:prefLabel>
+                                <skos:prefLabel xml:lang="et">Bajoci</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sl">bajocij</skos:prefLabel>
+                                <skos:prefLabel xml:lang="nl">Bajociën</skos:prefLabel>
+                                <skos:prefLabel xml:lang="en">Bajocian</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pt">Bajociano</skos:prefLabel>
+                                <skos:prefLabel xml:lang="ja">バジョシアン期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="it">bajociano</skos:prefLabel>
+                                <skos:prefLabel xml:lang="cs">Bajok</skos:prefLabel>
+                                <skos:prefLabel xml:lang="bg">Байоѿ</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fi">Bajoc</skos:prefLabel>
+                                <skos:prefLabel xml:lang="no">Bajoc</skos:prefLabel>
+                            </rdf:Description>
+                        </skos:narrower>
+                        <skos:prefLabel xml:lang="sk">stredná jura</skos:prefLabel>
+                        <skos:broader>
+                            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Jurassic">
+                                <skos:prefLabel xml:lang="zh">侏罗纪</skos:prefLabel>
+                                <skos:narrower>
+                                    <rdf:Description
+                                            rdf:about="http://resource.geosciml.org/classifier/ics/ischart/LowerJurassic">
+                                        <skos:broader
+                                                rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/Jurassic"/>
+                                        <skos:prefLabel xml:lang="ja">前期ジュラ紀</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="fi">Varhais/Ala-Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="en">Early/Lower Jurassic</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="es">Jurásico Inferior</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sk">raná/odnSPá jura</skos:prefLabel>
+                                        <skos:narrower>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Sinemurian">
+                                                <skos:prefLabel xml:lang="de">Sinémurium</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sv">sinemur</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="es">Sinemuriense</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pl">Synemur</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Sinemur</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Sinemur</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Sinemur</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Sinémurien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="en">Sinemurian</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Синемур</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Sinemuriën</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">辛涅穆尔期</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">sinemuri</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Sinemiūris</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sl">sinemurij</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Sinemuriano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Sinemuri</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="it">sinemuriano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="da">Sinemurien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sk">sinemúr</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="ja">シネムール期</skos:prefLabel>
+                                            </rdf:Description>
+                                        </skos:narrower>
+                                        <skos:prefLabel xml:lang="da">Tidlig/Nedre Jurassisk</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="lt">Ankstyvoji/Apatinė Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="no">Tidlig/undre jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="nl">Vroeg/Onder Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="bg">Ранна/Долна Юра</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="et">Vara/Alam-Juura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="pt">Jurássico Inferior</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="zh">早侏罗世</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="de">Früher / Unterer Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="hu">kora/alsó-ura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="it">giurassico inferiore</skos:prefLabel>
+                                        <skos:notation
+                                                rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                                        >a1.1.2.2.3
+                                        </skos:notation>
+                                        <skos:prefLabel xml:lang="sl">zgodnja/odnjaSP kreda</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sv">äldre/undre jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="pl">Wczesna/Dolna Jura</skos:prefLabel>
+                                        <skos:narrower>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Toarcian">
+                                                <skos:prefLabel xml:lang="sv">toarc</skos:prefLabel>
+                                                <skos:broader
+                                                        rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/LowerJurassic"/>
+                                                <skos:prefLabel xml:lang="de">Toarcium</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="ja">トアルシアン期</skos:prefLabel>
+                                                <skos:notation
+                                                        rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                                                >a1.1.2.2.3.1
+                                                </skos:notation>
+                                                <skos:prefLabel xml:lang="en">Toarcian</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="es">Toarciense</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Toaris</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">托阿尔期</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Toark</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pl">Toark</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Toarci</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="it">toarciano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="da">Toarcien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Toarcien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Toarc</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Toarc</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sl">toarcij</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Тоар</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">toarci</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Toarciano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sk">toark</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Toarciën</skos:prefLabel>
+                                            </rdf:Description>
+                                        </skos:narrower>
+                                        <skos:prefLabel xml:lang="fr">Jurassique inférieur</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="cs">odnSPí jura</skos:prefLabel>
+                                        <skos:narrower>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Hettangian">
+                                                <skos:prefLabel xml:lang="pl">Hetang</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="en">Hettangian</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Hetangiano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Хетанж</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sl">hettangij</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Hettang</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Hettangi</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="es">Hettagiense</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Hettang</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Hettang</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Hettangiën</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sv">hettang</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="ja">ヘッタンギアン期</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="da">Hettangien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Hettangien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="de">Hettangium</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="it">hettangiano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">赫唐期</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">hettangi</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Hetangis</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sk">hetanž</skos:prefLabel>
+                                            </rdf:Description>
+                                        </skos:narrower>
+                                        <skos:narrower>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Pliensbachian">
+                                                <skos:prefLabel xml:lang="sk">pliensbach</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sv">pliensbach</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">pliensbachi</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Plynsbachis</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Pliensbaquiano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">普连斯巴奇期</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Плиинѿбах</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="ja">プリンスバッキアン期</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="es">Pliensbachiense</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Plienbach</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="de">Pliensbachium</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="en">Pliensbachian</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Pliensbachi</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Pliënsbachiën</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sl">pleinsbachij</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Pliensbach</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Pliensbach</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pl">Pliensbach</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="it">pliensbachiano</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="da">Pliensbachien</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Pliensbachien</skos:prefLabel>
+                                            </rdf:Description>
+                                        </skos:narrower>
+                                    </rdf:Description>
+                                </skos:narrower>
+                                <skos:prefLabel xml:lang="en">Jurassic</skos:prefLabel>
+                                <skos:prefLabel xml:lang="bg">Юра</skos:prefLabel>
+                                <skos:broader>
+                                    <rdf:Description
+                                            rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Mesozoic">
+                                        <skos:prefLabel xml:lang="da">Mesozoisk</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="pt">Mesozóico</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="fr">Mésozoïque</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="en">Mesozoic</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="it">mesozoico</skos:prefLabel>
+                                        <skos:notation
+                                                rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                                        >a1.1.2
+                                        </skos:notation>
+                                        <skos:prefLabel xml:lang="cs">Mezozoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="hu">mezozoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sk">mezozoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sv">mesozoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="ja">中生代</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="zh">中生代</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="es">Mesozoico</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="fi">Mesotsoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sl">mezozoik</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="et">Mesosoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="bg">Мезозой</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="lt">Mezozojus</skos:prefLabel>
+                                        <skos:narrower
+                                                rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/Jurassic"/>
+                                        <skos:broader>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Phanerozoic">
+                                                <skos:prefLabel xml:lang="es">Fanerozoico</skos:prefLabel>
+                                                <skos:narrower>
+                                                    <rdf:Description
+                                                            rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Paleozoic">
+                                                        <skos:prefLabel xml:lang="et">Paleosoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="it">paleozoico</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="pl">Paleozoik</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="en">Paleozoic</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="en-us">Paleozoic</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="es">Palozoico</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="ja">古生代</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="lt">Paleozojus</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="de">Paläozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="zh">古生代</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="no">Paleozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="cs">Paleozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="nl">Paleozoïcum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="fr">Paléozoïque</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="fi">Paleotsoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="pt">Paleozóico</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="sl">paleozoik</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="en-gb">Palaeozoic</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="hu">paleozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="sk">paleozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="sv">paleozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="bg">Палеозой</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="da">Palæozoisk</skos:prefLabel>
+                                                    </rdf:Description>
+                                                </skos:narrower>
+                                                <skos:prefLabel xml:lang="da">Phanerozoisk</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Fanerozoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Fanerozoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">fanerozoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Phanerozoïcum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sk">fanerozoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sv">fanerozoikum</skos:prefLabel>
+                                                <skos:narrower
+                                                        rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/Mesozoic"/>
+                                                <skos:prefLabel xml:lang="sl">fanerozoik</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Fanerozóico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Фанерозой</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Phanérozoïque</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="it">fanerozoico</skos:prefLabel>
+                                                <skos:notation
+                                                        rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                                                >a1.1
+                                                </skos:notation>
+                                                <skos:prefLabel xml:lang="ja">顕生代</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="de">Phanerozoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="en">Phanerozoic</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Fanerosoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Fanerozojus</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">显生宙</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Fanerotsoikum</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pl">Fanerozoik</skos:prefLabel>
+                                                <skos:narrower>
+                                                    <rdf:Description
+                                                            rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Cenozoic">
+                                                        <skos:prefLabel xml:lang="de">Känozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="sk">kenozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="sv">kenozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="fi">Kenotsoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="en">Cenozoic</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="en-us">Cenozoic</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="it">cenozoico</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="et">Kainosoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="lt">Cenozojus</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="pl">Kenozoik</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="ja">新生代</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="zh">新生代</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="fr">Cénozoïque</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="bg">пеозой</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="da">Kænozoisk</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="es">Cenozoico</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="pt">Cenozóico</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="nl">Kaenozoïcum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="hu">kainozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="cs">Kenozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="no">Kenozoikum</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="sl">kenozoik</skos:prefLabel>
+                                                        <skos:prefLabel xml:lang="en-gb">Cainozoic</skos:prefLabel>
+                                                    </rdf:Description>
+                                                </skos:narrower>
+                                            </rdf:Description>
+                                        </skos:broader>
+                                        <skos:prefLabel xml:lang="pl">Mezozoik</skos:prefLabel>
+                                        <skos:narrower>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Triassic">
+                                                <skos:prefLabel xml:lang="it">triassico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Триаѿ</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="en">Triassic</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="da">Triassisk</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Triias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">三叠纪</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sl">trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sv">trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sk">trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Triasas</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="de">Trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="es">Triásico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="ja">三畳紀</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Triásico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">triász</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Trias</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pl">Trias</skos:prefLabel>
+                                            </rdf:Description>
+                                        </skos:narrower>
+                                        <skos:prefLabel xml:lang="nl">Mesozoïcum</skos:prefLabel>
+                                        <skos:narrower>
+                                            <rdf:Description
+                                                    rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Cretaceous">
+                                                <skos:prefLabel xml:lang="da">Kridt</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="ja">白亜紀</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fr">Crétacé</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sk">krieda</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="nl">Krijt</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="lt">Kreida</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sl">kreda</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="it">cretacico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="zh">白垩纪</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="no">Kritt</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="bg">Креда</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="en">Cretaceous</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="de">Kreide</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="et">Kriit</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="fi">Liitu</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="sv">krita</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="es">Cretácico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pt">Cretácico</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="hu">kréta</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="cs">Křída</skos:prefLabel>
+                                                <skos:prefLabel xml:lang="pl">Kreda</skos:prefLabel>
+                                            </rdf:Description>
+                                        </skos:narrower>
+                                        <skos:prefLabel xml:lang="de">Mesozoikum</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="no">Mesozoikum</skos:prefLabel>
+                                    </rdf:Description>
+                                </skos:broader>
+                                <skos:prefLabel xml:lang="sk">jura, jurský</skos:prefLabel>
+                                <skos:prefLabel xml:lang="et">Juura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="ja">ジュラ紀</skos:prefLabel>
+                                <skos:prefLabel xml:lang="da">Jurassisk</skos:prefLabel>
+                                <skos:narrower
+                                        rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/MiddleJurassic"/>
+                                <skos:notation
+                                        rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                                >a1.1.2.2
+                                </skos:notation>
+                                <skos:prefLabel xml:lang="hu">jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="de">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fi">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="lt">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="nl">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pt">Jurássico</skos:prefLabel>
+                                <skos:prefLabel xml:lang="it">giurassico</skos:prefLabel>
+                                <skos:prefLabel xml:lang="no">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pl">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="cs">Jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sl">jura</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sv">jura</skos:prefLabel>
+                                <skos:narrower>
+                                    <rdf:Description
+                                            rdf:about="http://resource.geosciml.org/classifier/ics/ischart/UpperJurassic">
+                                        <skos:prefLabel xml:lang="sv">yngre/övre jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="en">Late/Upper Jurassic</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="zh">晚侏罗世</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sl">pozna/zgornja jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="cs">Svrchní jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="ja">後期ジュラ紀</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="et">Hilis/Ülem-Juura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="lt">Vėlyvoji/Viršutinė Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="it">giurassico superiore</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="no">Sen/øvre jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="sk">mladšia/vrchná jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="nl">Laat/Boven Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="pt">Jurássico Superior</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="fi">Myöhäis/Ylä-Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="bg">Къѿна/Горна Юра</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="es">Jurásico Superior</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="fr">Jurassique supérieur</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="hu">késő/felső-jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="pl">Późna/Górna Jura</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="da">Sen/Øvre Jurassisk</skos:prefLabel>
+                                        <skos:prefLabel xml:lang="de">Später/Oberer Jura</skos:prefLabel>
+                                    </rdf:Description>
+                                </skos:narrower>
+                                <skos:prefLabel xml:lang="es">Jurásico</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fr">Jurassique</skos:prefLabel>
+                            </rdf:Description>
+                        </skos:broader>
+                        <skos:prefLabel xml:lang="pl">Środkowa Jura</skos:prefLabel>
+                    </rdf:Description>
+                </skos:broader>
+                <skos:prefLabel xml:lang="sv">aalen</skos:prefLabel>
+                <skos:prefLabel xml:lang="ja">アーレニアン期</skos:prefLabel>
+                <skos:prefLabel xml:lang="lt">Alenis</skos:prefLabel>
+                <skos:prefLabel xml:lang="bg">пален</skos:prefLabel>
+                <skos:prefLabel xml:lang="en">Aalenian</skos:prefLabel>
+                <skos:prefLabel xml:lang="de">Aalénium</skos:prefLabel>
+                <skos:prefLabel xml:lang="cs">Aalen</skos:prefLabel>
+                <skos:prefLabel xml:lang="fi">Aalen</skos:prefLabel>
+                <skos:prefLabel xml:lang="no">Aalen</skos:prefLabel>
+                <skos:prefLabel xml:lang="da">Aalenien</skos:prefLabel>
+                <skos:prefLabel xml:lang="pl">Aalen</skos:prefLabel>
+                <skos:prefLabel xml:lang="it">aaleniano</skos:prefLabel>
+                <skos:prefLabel xml:lang="es">Aaleniense</skos:prefLabel>
+                <skos:notation rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode">a1.1.2.2.2.4</skos:notation>
+                <skos:prefLabel xml:lang="pt">Aaleniano</skos:prefLabel>
+                <skos:prefLabel xml:lang="hu">aaleni</skos:prefLabel>
+                <skos:prefLabel xml:lang="sl">aalenij</skos:prefLabel>
+                <skos:prefLabel xml:lang="sk">álen</skos:prefLabel>
+                <skos:prefLabel xml:lang="fr">Aalénien</skos:prefLabel>
+                <skos:prefLabel xml:lang="zh">阿连期</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/MiddleJurassic"/>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Jurassic"/>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Mesozoic"/>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Phanerozoic"/>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/BaseMiddleJurassic">
+                <skos:prefLabel xml:lang="en">Base of Middle Jurassic</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/BaseBajocian">
+                <skos:prefLabel xml:lang="en">Base of Bajocian</skos:prefLabel>
+            </rdf:Description>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Bajocian"/>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/LowerJurassic"/>
+            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Toarcian"/>
+        </api:items>
+        <dcterms:isPartOf>
+            <api:ListEndpoint
+                    rdf:about="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf">
+                <api:definition
+                        rdf:resource="http://vocabs.ands.org.au/repository/api/lda/meta/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf"/>
+                <dcterms:hasPart
+                        rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=0"/>
+            </api:ListEndpoint>
+        </dcterms:isPartOf>
+        <j.0:first
+                rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=0"/>
+        <api:extendedMetadataVersion
+                rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=0&amp;_metadata=all"/>
+        <j.1:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#long">10</j.1:itemsPerPage>
+        <j.0:next
+                rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=1"/>
+    </api:Page>
+</rdf:RDF>

--- a/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_NoMoreData.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_NoMoreData.xml
@@ -1,0 +1,107 @@
+<rdf:RDF
+        xmlns:dcterms="http://purl.org/dc/terms/"
+        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+        xmlns:j.0="http://www.w3.org/1999/xhtml/vocab#"
+        xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+        xmlns:j.1="http://a9.com/-/spec/opensearch/1.1/"
+        xmlns:api="http://purl.org/linked-data/api/vocab#"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+    <api:ListEndpoint rdf:about="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf">
+        <api:definition rdf:resource="http://vocabs.ands.org.au/repository/api/lda/meta/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf"/>
+        <dcterms:hasPart>
+            <api:Page rdf:about="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=29">
+                <j.1:itemsPerPage rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+                >10</j.1:itemsPerPage>
+                <api:definition rdf:resource="http://vocabs.ands.org.au/repository/api/lda/meta/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf"/>
+                <j.0:first rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=0"/>
+                <api:items rdf:parseType="Collection">
+                    <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Orosirian">
+                        <skos:broader>
+                            <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Paleoproterozoic">
+                                <skos:prefLabel xml:lang="sl">paleoproterozoik</skos:prefLabel>
+                                <skos:prefLabel xml:lang="ja">原生代前期</skos:prefLabel>
+                                <skos:prefLabel xml:lang="es">Paleoproterozoico</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pt">Paleoproterozóico</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fr">Paléoprotérozoïque</skos:prefLabel>
+                                <skos:prefLabel xml:lang="zh">古元古代</skos:prefLabel>
+                                <skos:prefLabel xml:lang="en-gb">Palaeoproterozoic</skos:prefLabel>
+                                <skos:prefLabel xml:lang="pl">Paleoproterozoik</skos:prefLabel>
+                                <skos:prefLabel xml:lang="no">Paleoproterozoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="cs">Paleoproterozoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="da">Palæoproterozoisk</skos:prefLabel>
+                                <skos:prefLabel xml:lang="hu">paleoproterozikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sk">paleoproterozoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="sv">paleoproterozoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="bg">Палеопротерозой</skos:prefLabel>
+                                <skos:prefLabel xml:lang="nl">paleoproterozoïcum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="it">paleoproterozoico</skos:prefLabel>
+                                <skos:prefLabel xml:lang="de">Paläoproteroizoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="fi">Paleoproterotsoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="en">Paleoproterozoic</skos:prefLabel>
+                                <skos:prefLabel xml:lang="et">Paleoproterosoikum</skos:prefLabel>
+                                <skos:prefLabel xml:lang="en-us">Paleoproterozoic</skos:prefLabel>
+                                <skos:prefLabel xml:lang="lt">Paleoproterozojus</skos:prefLabel>
+                            </rdf:Description>
+                        </skos:broader>
+                        <skos:prefLabel xml:lang="lt">Orosiris</skos:prefLabel>
+                        <skos:prefLabel xml:lang="zh">造山纪</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sl">orosijrij</skos:prefLabel>
+                        <skos:prefLabel xml:lang="hu">orosiri</skos:prefLabel>
+                        <skos:prefLabel xml:lang="da">Orosirien</skos:prefLabel>
+                        <skos:prefLabel xml:lang="fr">Orosirien</skos:prefLabel>
+                        <skos:prefLabel xml:lang="pt">Orosiriano</skos:prefLabel>
+                        <skos:prefLabel xml:lang="no">Orosirium</skos:prefLabel>
+                        <skos:prefLabel xml:lang="de">Orosirium</skos:prefLabel>
+                        <skos:prefLabel xml:lang="en">Orosirian</skos:prefLabel>
+                        <skos:prefLabel xml:lang="ja">オロシリアン紀</skos:prefLabel>
+                        <skos:prefLabel xml:lang="et">Orosir</skos:prefLabel>
+                        <skos:prefLabel xml:lang="fi">Orosir</skos:prefLabel>
+                        <skos:prefLabel xml:lang="pl">Orosir</skos:prefLabel>
+                        <skos:prefLabel xml:lang="cs">Orosir</skos:prefLabel>
+                        <skos:prefLabel xml:lang="bg">Ороѿир</skos:prefLabel>
+                        <skos:prefLabel xml:lang="it">orosiriano</skos:prefLabel>
+                        <skos:prefLabel xml:lang="nl">Orosiriën</skos:prefLabel>
+                        <skos:prefLabel xml:lang="es">Orosiriense</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sk">orosirium</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sv">orosirium</skos:prefLabel>
+                        <skos:notation rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                        >a2.1.3.2</skos:notation>
+                    </rdf:Description>
+                    <rdf:Description rdf:about="http://resource.geosciml.org/classifier/ics/ischart/Rhyacian">
+                        <skos:prefLabel xml:lang="et">Rhyac</skos:prefLabel>
+                        <skos:prefLabel xml:lang="nl">Rhyaciën</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sk">rhyacium</skos:prefLabel>
+                        <skos:prefLabel xml:lang="ja">リヤシアン紀</skos:prefLabel>
+                        <skos:prefLabel xml:lang="cs">Rhyak</skos:prefLabel>
+                        <skos:prefLabel xml:lang="fi">Ryak</skos:prefLabel>
+                        <skos:prefLabel xml:lang="it">rhyaciano</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sl">rhyacij</skos:prefLabel>
+                        <skos:prefLabel xml:lang="zh">层侵纪</skos:prefLabel>
+                        <skos:notation rdf:datatype="http://resource.geosciml.org/ontology/timescale/gts#EraCode"
+                        >a2.1.3.3</skos:notation>
+                        <skos:prefLabel xml:lang="es">Ryaciense</skos:prefLabel>
+                        <skos:prefLabel xml:lang="bg">Риац</skos:prefLabel>
+                        <skos:prefLabel xml:lang="da">Rhyacien</skos:prefLabel>
+                        <skos:prefLabel xml:lang="en">Rhyacian</skos:prefLabel>
+                        <skos:prefLabel xml:lang="fr">Rhyacien</skos:prefLabel>
+                        <skos:broader rdf:resource="http://resource.geosciml.org/classifier/ics/ischart/Paleoproterozoic"/>
+                        <skos:prefLabel xml:lang="no">Ryasium</skos:prefLabel>
+                        <skos:prefLabel xml:lang="pl">Riak</skos:prefLabel>
+                        <skos:prefLabel xml:lang="hu">rhyaci</skos:prefLabel>
+                        <skos:prefLabel xml:lang="lt">Riacis</skos:prefLabel>
+                        <skos:prefLabel xml:lang="sv">ryacium</skos:prefLabel>
+                        <skos:prefLabel xml:lang="pt">Riaciano</skos:prefLabel>
+                        <skos:prefLabel xml:lang="de">Rhyacium</skos:prefLabel>
+                    </rdf:Description>
+                </api:items>
+                <api:extendedMetadataVersion rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=29&amp;_metadata=all"/>
+                <api:page rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+                >29</api:page>
+                <j.0:prev rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf?_page=28"/>
+                <j.1:startIndex rdf:datatype="http://www.w3.org/2001/XMLSchema#long"
+                >291</j.1:startIndex>
+                <dcterms:isPartOf rdf:resource="http://vocabs.ands.org.au/repository/api/lda/csiro/international-chronostratigraphic-chart-2017/2017/concept.rdf"/>
+            </api:Page>
+        </dcterms:hasPart>
+    </api:ListEndpoint>
+</rdf:RDF>

--- a/src/test/java/org/auscope/portal/core/services/TestVocabularyCacheService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestVocabularyCacheService.java
@@ -1,0 +1,291 @@
+package org.auscope.portal.core.services;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import org.auscope.portal.core.server.http.HttpClientInputStream;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.Format;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.View;
+
+import org.auscope.portal.core.services.vocabs.VocabularyServiceItem;
+import org.auscope.portal.core.test.BasicThreadExecutor;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.core.test.ResourceUtil;
+import org.jmock.Expectations;
+import org.jmock.Sequence;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+public class TestVocabularyCacheService extends PortalTestClass {
+
+    private static final int CONCURRENT_THREADS_TO_RUN = 3;
+
+    static final int VOCABULARY_COUNT_TOTAL = 35;
+    static final int VOCABULARY_ERRORS_COUNT_TOTAL = 25;
+
+    private BasicThreadExecutor threadExecutor;
+
+    private VocabularyCacheService vocabularyCacheService;
+    private VocabularyMethodMaker mockMethodMaker1 = context.mock(VocabularyMethodMaker.class,"mockMethodMaker1");
+    private VocabularyMethodMaker mockMethodMaker2 = context.mock(VocabularyMethodMaker.class,"mockMethodMaker2");
+    private VocabularyMethodMaker mockMethodMaker3 = context.mock(VocabularyMethodMaker.class,"mockMethodMaker3");
+
+    private HttpRequestBase mockMethod1 = context.mock(HttpRequestBase.class,"method1");
+    private HttpRequestBase mockMethod2 = context.mock(HttpRequestBase.class,"method2");
+
+    private HttpRequestBase mockMethod3 = context.mock(HttpRequestBase.class,"method3");
+
+
+    private HttpServiceCaller mockServiceCaller = context.mock(HttpServiceCaller.class);
+    private ArrayList<VocabularyServiceItem> serviceList;
+
+
+    private static final String serviceUrlFormatString = "http://vocabservice.%1$s.url/";
+
+
+    @Before
+    public void setUp() throws Exception {
+
+        this.threadExecutor = new BasicThreadExecutor();
+
+        serviceList = new ArrayList<>(CONCURRENT_THREADS_TO_RUN);
+        VocabularyService vocabularyService1 = new VocabularyService(mockServiceCaller,mockMethodMaker1,String.format(
+                serviceUrlFormatString, 1));
+        VocabularyService vocabularyService2 = new VocabularyService(mockServiceCaller,mockMethodMaker2,String.format(
+                serviceUrlFormatString, 2));
+        VocabularyService vocabularyService3 = new VocabularyService(mockServiceCaller,mockMethodMaker3,String.format(
+                serviceUrlFormatString, 3));
+
+
+        serviceList.add(new VocabularyServiceItem(String.format("id:%1$s", 1), String.format("title:%1$s", 1), vocabularyService1));
+        serviceList.add(new VocabularyServiceItem(String.format("id:%1$s", 2), String.format("title:%1$s", 2), vocabularyService2));
+        serviceList.add(new VocabularyServiceItem(String.format("id:%1$s", 3), String.format("title:%1$s", 3), vocabularyService3));
+
+
+        this.vocabularyCacheService = new VocabularyCacheService(threadExecutor, serviceList);
+    }
+
+    @After
+    public void tearDown() {
+        this.threadExecutor = null;
+        this.vocabularyCacheService = null;
+    }
+
+    @Test
+    public void testMultiUpdate() throws IOException, URISyntaxException {
+        final String commodityVocabulary= ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_MoreData.xml");
+        final String noMorecommodityVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_NoMoreData.xml");
+        final String noMoreMineStatusVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/mineStatusConcepts_NoMoreData.xml");
+        final String timescaleVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_MoreData.xml");
+        final String noMoreTimescaleVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_NoMoreData.xml");
+
+        final Sequence t1Sequence = context.sequence("t1Sequence");
+        final Sequence t2Sequence = context.sequence("t2Sequence");
+        final Sequence t3Sequence = context.sequence("t3Sequence");
+
+        final int totalRequestsMade = CONCURRENT_THREADS_TO_RUN ;
+
+        try (final HttpClientInputStream t1r1 = new HttpClientInputStream(new ByteArrayInputStream(commodityVocabulary.getBytes()), null);
+             final HttpClientInputStream t1r2 = new HttpClientInputStream(new ByteArrayInputStream(noMorecommodityVocabulary.getBytes()), null);
+             final HttpClientInputStream t2r1 = new HttpClientInputStream(new ByteArrayInputStream(noMoreMineStatusVocabulary.getBytes()), null);
+             final HttpClientInputStream t3r1 = new HttpClientInputStream(new ByteArrayInputStream(timescaleVocabulary.getBytes()), null);
+             final HttpClientInputStream t3r2 = new HttpClientInputStream(
+                     new ByteArrayInputStream(noMoreTimescaleVocabulary.getBytes()), null)) {
+
+            context.checking(new Expectations() {
+                {
+
+                    oneOf(mockMethodMaker1).getAllConcepts(serviceList.get(0).getVocabularyService().getServiceUrl(), Format.Rdf,View.description, 1000, 0);
+                    inSequence(t1Sequence);
+                    will(returnValue(mockMethod1));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    inSequence(t1Sequence);
+                    will(returnValue(t1r1));
+
+                    oneOf(mockMethod1).releaseConnection();
+                    inSequence(t1Sequence);
+
+                    oneOf(mockMethodMaker1).getAllConcepts(serviceList.get(0).getVocabularyService().getServiceUrl(), Format.Rdf,View.description, 1000, 1);
+                    inSequence(t1Sequence);
+                    will(returnValue(mockMethod1));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    inSequence(t1Sequence);
+                    will(returnValue(t1r2));
+
+                    oneOf(mockMethod1).releaseConnection();
+                    inSequence(t1Sequence);
+
+                    oneOf(mockMethodMaker2).getAllConcepts(serviceList.get(1).getVocabularyService().getServiceUrl(), Format.Rdf,View.description, 1000, 0);
+                    inSequence(t2Sequence);
+                    will(returnValue(mockMethod2));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod2);
+                    inSequence(t2Sequence);
+                    will(returnValue(t2r1));
+
+
+                    oneOf(mockMethod2).releaseConnection();
+                    inSequence(t2Sequence);
+
+                    oneOf(mockMethodMaker3).getAllConcepts(serviceList.get(2).getVocabularyService().getServiceUrl(), Format.Rdf,View.description, 1000, 0);
+                    inSequence(t3Sequence);
+                    will(returnValue(mockMethod3));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod3);
+                    inSequence(t3Sequence);
+                    will(returnValue(t3r1));
+
+                    oneOf(mockMethod3).releaseConnection();
+                    inSequence(t3Sequence);
+
+                    oneOf(mockMethodMaker3).getAllConcepts(serviceList.get(2).getVocabularyService().getServiceUrl(), Format.Rdf,View.description, 1000, 1);
+                    inSequence(t3Sequence);
+                    will(returnValue(mockMethod3));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod3);
+                    inSequence(t3Sequence);
+                    will(returnValue(t3r2));
+
+                    oneOf(mockMethod3).releaseConnection();
+                    inSequence(t3Sequence);
+
+                }
+            });
+
+            Assert.assertTrue(this.vocabularyCacheService.updateCache());
+            try {
+                do {
+                    Thread.sleep(300);
+                } while (this.vocabularyCacheService.updateRunning);
+
+            } catch (InterruptedException e) {
+                Assert.fail("Test sleep interrupted. Test aborted.");
+            }
+            try {
+                threadExecutor.getExecutorService().shutdown();
+                threadExecutor.getExecutorService().awaitTermination(180, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                threadExecutor.getExecutorService().shutdownNow();
+                Assert.fail("Exception whilst waiting for update to finish " + e.getMessage());
+            }
+
+            Assert.assertEquals(totalRequestsMade, this.vocabularyCacheService.getVocabularyCache().size());
+            int numberOfTerms = 0;
+            for (Map.Entry<String, Map<String, String>> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
+                numberOfTerms +=  entry.getValue().size();
+            }
+            Assert.assertEquals(VOCABULARY_COUNT_TOTAL, numberOfTerms);
+            Assert.assertFalse(this.vocabularyCacheService.updateRunning);
+        }
+
+    }
+
+    @Test
+    public void testMultiUpdateWithErrors() throws IOException, URISyntaxException {
+        final String commodityVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_MoreData.xml");
+        final String noMorecommodityVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_NoMoreData.xml");
+        final String noMoreMineStatusVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/mineStatusConcepts_NoMoreData.xml");
+        final String timescaleVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_MoreData.xml");
+        final String noMoreTimescaleVocabulary = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_NoMoreData.xml");
+
+        final Sequence t1Sequence = context.sequence("t1Sequence");
+        final Sequence t2Sequence = context.sequence("t2Sequence");
+        final Sequence t3Sequence = context.sequence("t3Sequence");
+
+
+        try (final HttpClientInputStream t1r1 = new HttpClientInputStream(new ByteArrayInputStream(commodityVocabulary.getBytes()), null);
+             final HttpClientInputStream t1r2 = new HttpClientInputStream(new ByteArrayInputStream(noMorecommodityVocabulary.getBytes()), null);
+             final HttpClientInputStream t3r1 = new HttpClientInputStream(new ByteArrayInputStream(timescaleVocabulary.getBytes()), null);
+             final HttpClientInputStream t3r2 = new HttpClientInputStream(
+                     new ByteArrayInputStream(noMoreTimescaleVocabulary.getBytes()), null)) {
+
+            context.checking(new Expectations() {
+                {
+
+                    oneOf(mockMethodMaker1).getAllConcepts(serviceList.get(0).getVocabularyService().getServiceUrl(), Format.Rdf, View.description, 1000, 0);
+                    inSequence(t1Sequence);
+                    will(returnValue(mockMethod1));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    inSequence(t1Sequence);
+                    will(returnValue(t1r1));
+
+                    oneOf(mockMethod1).releaseConnection();
+                    inSequence(t1Sequence);
+
+                    oneOf(mockMethodMaker1).getAllConcepts(serviceList.get(0).getVocabularyService().getServiceUrl(), Format.Rdf, View.description, 1000, 1);
+                    inSequence(t1Sequence);
+                    will(returnValue(mockMethod1));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    inSequence(t1Sequence);
+                    will(returnValue(t1r2));
+
+                    oneOf(mockMethod1).releaseConnection();
+                    inSequence(t1Sequence);
+
+                    oneOf(mockMethodMaker2).getAllConcepts(serviceList.get(1).getVocabularyService().getServiceUrl(), Format.Rdf, View.description, 1000, 0);
+                    inSequence(t2Sequence);
+                    will(returnValue(mockMethod2));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod2);
+                    inSequence(t2Sequence);
+                    will(throwException(new Exception()));
+
+
+                    oneOf(mockMethod2).releaseConnection();
+                    inSequence(t2Sequence);
+
+                    oneOf(mockMethodMaker3).getAllConcepts(serviceList.get(2).getVocabularyService().getServiceUrl(), Format.Rdf, View.description, 1000, 0);
+                    inSequence(t3Sequence);
+                    will(returnValue(mockMethod3));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod3);
+                    inSequence(t3Sequence);
+                    will(returnValue(t3r1));
+
+                    oneOf(mockMethod3).releaseConnection();
+                    inSequence(t3Sequence);
+
+                    oneOf(mockMethodMaker3).getAllConcepts(serviceList.get(2).getVocabularyService().getServiceUrl(), Format.Rdf, View.description, 1000, 1);
+                    inSequence(t3Sequence);
+                    will(returnValue(mockMethod3));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod3);
+                    inSequence(t3Sequence);
+                    will(returnValue(t3r2));
+
+                    oneOf(mockMethod3).releaseConnection();
+                    inSequence(t3Sequence);
+
+                }
+            });
+
+            Assert.assertTrue(this.vocabularyCacheService.updateCache());
+            try {
+                do {
+                    Thread.sleep(300);
+                } while (this.vocabularyCacheService.updateRunning);
+
+            } catch (InterruptedException e) {
+                Assert.fail("Test sleep interrupted. Test aborted.");
+            }
+            try {
+                threadExecutor.getExecutorService().shutdown();
+                threadExecutor.getExecutorService().awaitTermination(180, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                threadExecutor.getExecutorService().shutdownNow();
+                Assert.fail("Exception whilst waiting for update to finish " + e.getMessage());
+            }
+
+            Assert.assertEquals(CONCURRENT_THREADS_TO_RUN - 1, this.vocabularyCacheService.getVocabularyCache().size());
+            int numberOfTerms = 0;
+            for (Map.Entry<String, Map<String, String>> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
+                numberOfTerms += entry.getValue().size();
+            }
+            Assert.assertEquals(VOCABULARY_ERRORS_COUNT_TOTAL, numberOfTerms);
+            Assert.assertFalse(this.vocabularyCacheService.updateRunning);
+        }
+    }
+}

--- a/src/test/java/org/auscope/portal/core/services/TestVocabularyService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestVocabularyService.java
@@ -1,0 +1,274 @@
+package org.auscope.portal.core.services;
+
+import com.google.common.collect.Lists;
+import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.Property;
+import com.hp.hpl.jena.rdf.model.Resource;
+import com.hp.hpl.jena.rdf.model.Statement;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.auscope.portal.core.server.http.HttpClientInputStream;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.Format;
+import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.View;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.core.test.ResourceUtil;
+import org.jmock.Expectations;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ConnectException;
+import java.net.URISyntaxException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class TestVocabularyService extends PortalTestClass {
+
+    private HttpRequestBase mockMethod1 = context.mock(HttpRequestBase.class, "mockMethod1");
+    private HttpRequestBase mockMethod2 = context.mock(HttpRequestBase.class, "mockMethod2");
+    private HttpServiceCaller mockServiceCaller = context.mock(HttpServiceCaller.class);
+    private VocabularyMethodMaker mockMethodMaker = context.mock(VocabularyMethodMaker.class);
+
+    private String serviceUrl = "http://example.org:8080/sissvoc/path";
+    private String schemeUrl = "http://example.org/classifier/repository/vocabulary-scheme";
+
+    private VocabularyService vocabularyService;
+
+    @Before
+    public void setUp() throws Exception {
+        vocabularyService = new VocabularyService(mockServiceCaller,mockMethodMaker,serviceUrl);
+        vocabularyService.setPageSize(50);
+    }
+
+    private static boolean containsResourceUri(List<Resource> list, String uri) {
+        for (Resource res : list) {
+            if (res.getURI().equals(uri)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Test
+    public void testGetAllConcepts() throws PortalServiceException, URISyntaxException, IOException {
+        try (final InputStream rs1 = new HttpClientInputStream(ResourceUtil.loadResourceAsStream(
+                "org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_MoreData.xml"), null);
+             final InputStream rs2 = new HttpClientInputStream(
+                     ResourceUtil.loadResourceAsStream(
+                             "org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_NoMoreData.xml"),
+                     null)) {
+
+            context.checking(new Expectations() {
+                {
+
+                    oneOf(mockMethodMaker).getAllConcepts(serviceUrl, Format.Rdf, vocabularyService.getPageSize(), 0);
+                    will(returnValue(mockMethod1));
+                    oneOf(mockMethodMaker).getAllConcepts(serviceUrl, Format.Rdf, vocabularyService.getPageSize(), 1);
+                    will(returnValue(mockMethod2));
+
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    will(returnValue(rs1));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod2);
+                    will(returnValue(rs2));
+
+                    oneOf(mockMethod1).releaseConnection();
+                    oneOf(mockMethod2).releaseConnection();
+                }
+            });
+
+            Model model = vocabularyService.getAllConcepts();
+            Assert.assertNotNull(model);
+            List<Resource> resources = Lists.newArrayList(model.listSubjects());
+            Assert.assertEquals(2, resources.size());
+            Assert.assertTrue(
+                    containsResourceUri(resources, "http://resource.geosciml.org/classifier/cgi/commodity-code/gold"));
+            Assert.assertTrue(
+                    containsResourceUri(resources, "http://resource.geosciml.org/classifier/cgi/commodity-code/uranium"));
+            Assert.assertFalse(
+                    containsResourceUri(resources, "http://resource.geosciml.org/classifier/cgi/commodity-code/not-a-commodity"));
+        }
+    }
+
+    /**
+     * Tests that when iterating a repository, a single failure is reported
+     * correctly
+     *
+     * @throws URISyntaxException
+     * @throws PortalServiceException
+     * @throws IOException
+     */
+    @Test(expected = PortalServiceException.class)
+    public void testGetAllDescriptionsCommsError() throws PortalServiceException, URISyntaxException, IOException {
+        // final String repository = "repository";
+
+        try (final HttpClientInputStream rs1 = new HttpClientInputStream(ResourceUtil.loadResourceAsStream(
+                "org/auscope/portal/core/test/responses/vocabulary/commodityConcepts_MoreData.xml"), null)) {
+
+            context.checking(new Expectations() {
+                {
+                    oneOf(mockMethodMaker).getAllConcepts(serviceUrl, Format.Rdf, vocabularyService.getPageSize(), 0);
+                    will(returnValue(mockMethod1));
+                    oneOf(mockMethodMaker).getAllConcepts(serviceUrl, Format.Rdf, vocabularyService.getPageSize(), 1);
+                    will(returnValue(mockMethod2));
+
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    will(returnValue(rs1));
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod2);
+                    will(throwException(new ConnectException("error")));
+
+                    oneOf(mockMethod1).releaseConnection();
+                    oneOf(mockMethod2).releaseConnection();
+                }
+            });
+
+            vocabularyService.getAllConcepts();
+        }
+    }
+
+    /**
+     * Tests that iterating a repository using a schemeUrl works as expected
+     *
+     * @throws URISyntaxException
+     * @throws PortalServiceException
+     * @throws IOException
+     */
+    @Test
+    public void testGetAllConceptsInScheme() throws IOException, URISyntaxException, PortalServiceException {
+        final InputStream rs1 = new HttpClientInputStream(ResourceUtil.loadResourceAsStream(
+                "org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_MoreData.xml"), null);
+        final InputStream rs2 = new HttpClientInputStream(ResourceUtil.loadResourceAsStream(
+                "org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_NoMoreData.xml"), null);
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mockMethodMaker).getAllConceptsInScheme(serviceUrl, schemeUrl, Format.Rdf, View.all,
+                        vocabularyService.getPageSize(), 0);
+                will(returnValue(mockMethod1));
+                oneOf(mockMethodMaker).getAllConceptsInScheme(serviceUrl, schemeUrl, Format.Rdf, View.all,
+                        vocabularyService.getPageSize(), 1);
+                will(returnValue(mockMethod2));
+
+                oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                will(returnValue(rs1));
+                oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod2);
+                will(returnValue(rs2));
+
+                oneOf(mockMethod1).releaseConnection();
+                oneOf(mockMethod2).releaseConnection();
+            }
+        });
+
+        Model model = vocabularyService.getAllConceptsInScheme(schemeUrl, View.all);
+        Assert.assertNotNull(model);
+        List<Resource> resources = Lists.newArrayList(model.listSubjects());
+        Assert.assertEquals(23, resources.size());
+        Assert.assertTrue(
+                containsResourceUri(resources, "http://resource.geosciml.org/classifier/ics/ischart/Orosirian"));
+        Assert.assertTrue(
+                containsResourceUri(resources, "http://resource.geosciml.org/classifier/ics/ischart/Rhyacian"));
+        Assert.assertFalse(
+                containsResourceUri(resources, "http://resource.geosciml.org/classifier/ics/ischart/Nonsensian"));
+
+    }
+
+    @Test(expected = PortalServiceException.class)
+    public void testGetAllConceptsInScheme_CommsError() throws IOException, URISyntaxException, PortalServiceException {
+        final HttpClientInputStream rs1 = new HttpClientInputStream(ResourceUtil.loadResourceAsStream(
+                "org/auscope/portal/core/test/responses/vocabulary/timescaleConcepts_MoreData.xml"), null);
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mockMethodMaker).getAllConceptsInScheme(serviceUrl, schemeUrl, Format.Rdf, View.all,
+                        vocabularyService.getPageSize(), 0);
+                will(returnValue(mockMethod1));
+                oneOf(mockMethodMaker).getAllConceptsInScheme(serviceUrl, schemeUrl, Format.Rdf, View.all,
+                        vocabularyService.getPageSize(), 1);
+                will(returnValue(mockMethod2));
+
+                oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                will(returnValue(rs1));
+                oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod2);
+                will(throwException(new ConnectException("error")));
+
+                oneOf(mockMethod1).releaseConnection();
+                oneOf(mockMethod2).releaseConnection();
+
+            }
+        });
+        vocabularyService.getAllConceptsInScheme(schemeUrl, View.all);
+    }
+
+    /**
+     * Tests that single resources are extracted correctly
+     *
+     * @throws PortalServiceException
+     * @throws IOException
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetResourceByUri() throws PortalServiceException, URISyntaxException, IOException {
+        final String uri = "http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit";
+
+        try (final HttpClientInputStream rs1 = new HttpClientInputStream(ResourceUtil.loadResourceAsStream(
+                "org/auscope/portal/core/test/responses/vocabulary/occurrenceType_ResourceRDF.xml"), null)) {
+
+            context.checking(new Expectations() {
+                {
+                    oneOf(mockMethodMaker).getResourceByUri(serviceUrl, uri, Format.Rdf);
+                    will(returnValue(mockMethod1));
+
+                    oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                    will(returnValue(rs1));
+
+                    oneOf(mockMethod1).releaseConnection();
+                }
+            });
+
+            Resource res = vocabularyService.getResourceByUri(uri);
+            Assert.assertNotNull(res);
+
+            Property skosDefn = res.getModel().createProperty("http://www.w3.org/2004/02/skos/core#", "definition");
+            List<Statement> matchingStatements = Lists.newArrayList(res.listProperties(skosDefn));
+
+            boolean foundEnglishDef = false;
+            for (Statement statement : matchingStatements) {
+                if (statement.getObject().asLiteral().getLanguage().equals("en")) {
+                    foundEnglishDef = true;
+                    Assert.assertEquals("A mass of naturally occurring material in the Earth that contains an anomalous concentration of some mineral or rock type that has some potential for human utilization, without regard to mode of origin. Typically is a single, connected, genetically related body of material.",
+                            statement.getObject().asLiteral().getString());
+                }
+            }
+            Assert.assertTrue("No English skos definition found!", foundEnglishDef);
+        }
+    }
+
+    /**
+     * Tests that getting a resource with a comms error fails gracefully
+     *
+     * @throws IOException
+     * @throws URISyntaxException
+     * @throws PortalServiceException
+     */
+    @Test(expected = PortalServiceException.class)
+    public void testGetConceptByUri_CommsError() throws URISyntaxException, IOException, PortalServiceException {
+        final String uri = "http://resource.geosciml.org/classifier/cgi/mineral-occurrence-type/deposit";
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mockMethodMaker).getResourceByUri(serviceUrl, uri, Format.Rdf);
+                will(returnValue(mockMethod1));
+
+                oneOf(mockServiceCaller).getMethodResponseAsStream(mockMethod1);
+                will(throwException(new ConnectException("err")));
+
+                oneOf(mockMethod1).releaseConnection();
+            }
+        });
+
+        vocabularyService.getResourceByUri(uri);
+    }
+}

--- a/src/test/java/org/auscope/portal/core/services/methodmakers/TestVocabularyMethodMaker.java
+++ b/src/test/java/org/auscope/portal/core/services/methodmakers/TestVocabularyMethodMaker.java
@@ -1,0 +1,170 @@
+package org.auscope.portal.core.services.methodmakers;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URISyntaxException;
+
+import static org.junit.Assert.*;
+
+public class TestVocabularyMethodMaker extends PortalTestClass {
+    VocabularyMethodMaker vocabularyMethodMaker;
+
+    @Before
+    public void setUp() throws Exception {
+        vocabularyMethodMaker = new VocabularyMethodMaker();
+    }
+
+
+    @Test
+    public void testOptionalParamErrors() throws URISyntaxException {
+        final String url = "http://example.org/vocab";
+        final String schemeUrl = "http://example.org/classifier/repository/vocabulary-scheme";
+
+        Assert.assertNotNull(vocabularyMethodMaker.getAllConcepts(url,null, null, null));
+        Assert.assertNotNull(vocabularyMethodMaker.getAllConceptsInScheme(url, schemeUrl, null, null, null, null));
+        Assert.assertNotNull(vocabularyMethodMaker.getConceptsWithLabel(url, "label", null, null, null));
+        Assert.assertNotNull(vocabularyMethodMaker.getResourceByUri(url, "uri", null));
+        Assert.assertNotNull(vocabularyMethodMaker.getBroaderConcepts(url,  "uri", null, null, null));
+        Assert.assertNotNull(vocabularyMethodMaker.getNarrowerConcepts(url,  "uri", null, null, null));
+    }
+
+    /**
+     * Ensures getAllConcepts encodes the method correctly
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetAllConcepts() throws URISyntaxException {
+        final String url = "http://sissvoc.example.org./";
+
+        final VocabularyMethodMaker.Format format = VocabularyMethodMaker.Format.Html;
+        final Integer pageSize = 23;
+        final Integer page = 2;
+
+        HttpRequestBase method = vocabularyMethodMaker.getAllConcepts(url, format, pageSize, page);
+        String queryString = method.getURI().getQuery();
+        String path = method.getURI().getPath();
+
+        Assert.assertEquals("/concept.html", path);
+        Assert.assertTrue(queryString.contains(String.format("_page=%1$s", page)));
+        Assert.assertTrue(queryString.contains(String.format("_pageSize=%1$s", pageSize)));
+    }
+
+    /**
+     * Ensures getAllConceptsInScheme encodes the method correctly
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetAllConceptsInScheme() throws URISyntaxException {
+        final String url = "http://sissvoc.example.org./";
+        final String schemeUrl = "http://example.org/classifier/repository/vocabulary-scheme";
+
+        final VocabularyMethodMaker.Format format = VocabularyMethodMaker.Format.Html;
+        final VocabularyMethodMaker.View view = VocabularyMethodMaker.View.basic;
+        final Integer pageSize = 23;
+        final Integer page = 2;
+
+        HttpRequestBase method = vocabularyMethodMaker.getAllConceptsInScheme(url, schemeUrl, format, view, pageSize, page);
+
+        String queryString = method.getURI().getQuery();
+        String path = method.getURI().getPath();
+
+        Assert.assertEquals("/concept.html", path);
+        Assert.assertTrue(queryString.contains(String.format("_page=%1$s", page)));
+        Assert.assertTrue(queryString.contains(String.format("_pageSize=%1$s", pageSize)));
+        Assert.assertTrue(queryString.contains(String.format("_view=%1$s", view.name())));
+    }
+
+    /**
+     * Ensures getAllConcepts encodes the method correctly
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetConceptsWithLabel() throws URISyntaxException {
+        final String url = "http://sissvoc.example.org./";
+        final String label = "label";
+        final VocabularyMethodMaker.Format format = VocabularyMethodMaker.Format.Ttl;
+        final Integer pageSize = 23;
+        final Integer page = 2;
+
+        HttpRequestBase method = vocabularyMethodMaker.getConceptsWithLabel(url, label, format, pageSize, page);
+        String queryString = method.getURI().getQuery();
+        String path = method.getURI().getPath();
+
+        Assert.assertEquals("/concept.ttl", path);
+        Assert.assertTrue(queryString.contains(String.format("_page=%1$s", page)));
+        Assert.assertTrue(queryString.contains(String.format("_pageSize=%1$s", pageSize)));
+        Assert.assertTrue(queryString.contains(String.format("anylabel=%1$s", label)));
+    }
+
+    /**
+     * Ensures getResourceByUri encodes the method correctly
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetConceptsByUri() throws URISyntaxException {
+        final String url = "http://sissvoc.example.org./";
+        final String uri = "uri";
+        final VocabularyMethodMaker.Format format = VocabularyMethodMaker.Format.Rdf;
+
+        HttpRequestBase method = vocabularyMethodMaker.getResourceByUri(url, uri, format);
+        String queryString = method.getURI().getQuery();
+        String path = method.getURI().getPath();
+
+        Assert.assertEquals("/resource.rdf", path);
+        Assert.assertTrue(queryString.contains(String.format("uri=%1$s", uri)));
+    }
+
+    /**
+     * Ensures getBroaderConcepts encodes the method correctly
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetBroaderConcepts() throws URISyntaxException {
+        final String url = "http://sissvoc.example.org./";
+        final String baseUri = "base-uri";
+        final VocabularyMethodMaker.Format format = VocabularyMethodMaker.Format.Json;
+        final Integer pageSize = 23;
+        final Integer page = 2;
+
+        HttpRequestBase method = vocabularyMethodMaker.getBroaderConcepts(url, baseUri, format, pageSize, page);
+        String queryString = method.getURI().getQuery();
+        String path = method.getURI().getPath();
+
+        Assert.assertEquals("/concept/broader.json", path);
+        Assert.assertTrue(queryString.contains(String.format("_page=%1$s", page)));
+        Assert.assertTrue(queryString.contains(String.format("_pageSize=%1$s", pageSize)));
+        Assert.assertTrue(queryString.contains(String.format("uri=%1$s", baseUri)));
+    }
+
+    /**
+     * Ensures testGetNarrowerConcepts encodes the method correctly
+     *
+     * @throws URISyntaxException
+     */
+    @Test
+    public void testGetNarrowerConcepts() throws URISyntaxException {
+        final String url = "http://sissvoc.example.org./";
+        final String baseUri = "base-uri";
+        final VocabularyMethodMaker.Format format = VocabularyMethodMaker.Format.Json;
+        final Integer pageSize = 23;
+        final Integer page = 2;
+
+        HttpRequestBase method = vocabularyMethodMaker.getNarrowerConcepts(url, baseUri, format, pageSize, page);
+        String queryString = method.getURI().getQuery();
+        String path = method.getURI().getPath();
+
+        Assert.assertEquals("/concept/narrower.json", path);
+        Assert.assertTrue(queryString.contains(String.format("_page=%1$s", page)));
+        Assert.assertTrue(queryString.contains(String.format("_pageSize=%1$s", pageSize)));
+        Assert.assertTrue(queryString.contains(String.format("uri=%1$s", baseUri)));
+    }
+}


### PR DESCRIPTION
We had a couple of vocabs that had latency problems, commodities (6 seconds) and timescales (14 seconds). To address this, we cache the vocabulary endpoints the same way we cache CSW endpoints, by wiring VocabularyServiceItems in a bean configuration, and making calls to each in independent threads.

The code here works the same as the CSW caching. There are a few new classes that are variations of the old SISSVoc classes - VocabularyService and VocabularyMethodMaker differ to their respective SISSVoc3Service and SISSVoc3Methodmaker. The latter are retained for backwards compatibility, the two new ones are added to drop the 'repository' concept as it no longer really makes sense in light of using multiple vocab APIs (AusGIN uses three separate APIs). Furthermore the timescales repository looks like "csiro/international-chronostratigraphic-chart/2017" which is the same for all RVA vocabs. In my view, the syntax for regular SISSVoc and the RVA implementation differs enough to make the 'repository' field meaningless.

If necessary, I can change the code to drop the new service/methodmaker and use the old ones, but I thought I'd put in the work to separate the two.

Here is the the AusGIN portal code that makes use of these changes

https://github.com/GeoscienceAustralia/geoscience-portal/pull/321/files