### PR TITLE
Cache Jena model for vocabularies instead of key-value pairs of preflabel and URI

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/VocabularyFilterService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyFilterService.java
@@ -10,7 +10,8 @@ import org.springframework.stereotype.Service;
 import java.util.*;
 
 /**
- * Service class that handles filtering of
+ * Service class that handles filtering of JENA models that are cached by the {@link VocabularyCacheService}.
+ * Filters are either selectors on resources or properties, and also find narrower relationships with specified resources
  */
 public class VocabularyFilterService {
 

--- a/src/main/java/org/auscope/portal/core/services/VocabularyFilterService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyFilterService.java
@@ -1,0 +1,232 @@
+package org.auscope.portal.core.services;
+
+import com.hp.hpl.jena.rdf.model.*;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.auscope.portal.core.services.VocabularyCacheService;
+import org.auscope.portal.core.services.namespaces.VocabNamespaceContext;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+/**
+ * Service class that handles filtering of
+ */
+public class VocabularyFilterService {
+
+    private final Log log = LogFactory.getLog(getClass());
+
+    private VocabularyCacheService vocabularyCacheService;
+
+
+    public VocabularyFilterService(VocabularyCacheService vocabularyCacheService) {
+        this.vocabularyCacheService = vocabularyCacheService;
+    }
+
+
+    /**
+     * Returns key-value pairs of vocabulary terms for the specified cache ID, filtered by
+     * the queries listed in the selectors.
+     *
+     * @param vocabularyId Cache ID of vocabulary model
+     * @param selectors List of selectors used to query the model
+     * @return
+     */
+    public Map<String, String> getFilteredVocabularyById(String vocabularyId, Selector... selectors) {
+        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+
+        Model filteredModel = ModelFactory.createDefaultModel();
+        for (Selector selector : selectors) {
+            StmtIterator stmtIterator = filterModel(model, selector).listStatements();
+            while (stmtIterator.hasNext()) {
+                Statement statement = stmtIterator.next();
+                Selector resourceSelector = new SimpleSelector(statement.getSubject(), null, (RDFNode) null);
+                filteredModel.add(model.listStatements(resourceSelector));
+            }
+
+        }
+
+        return getLabeledVocabulary(filteredModel);
+    }
+
+
+    /**
+     * Returns key-value pairs of vocabulary terms for the specified cache ID.
+     *
+     * @param vocabularyId Cache ID of vocabulary model
+     * @return
+     */
+    public Map<String, String> getVocabularyById(String vocabularyId) {
+        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+
+        return getLabeledVocabulary(model);
+    }
+
+
+    /**
+     * Returns key-value pairs of vocabulary terms for model. Pairs are prefLabel and URI.
+     *
+     * @param model The model to transform into URI and prefLabels.
+     * @return
+     */
+    private Map<String, String> getLabeledVocabulary(Model model) {
+        Map<String, String> result = new HashMap<>();
+
+        if (model != null) {
+            Property prefLabelProperty = model.createProperty(VocabNamespaceContext.SKOS_NAMESPACE, "prefLabel");
+
+            ResIterator iterator = model.listResourcesWithProperty(prefLabelProperty);
+            while (iterator.hasNext()) {
+                Resource res = iterator.next();
+                StmtIterator prefLabelIt = res.listProperties(prefLabelProperty);
+                while (prefLabelIt.hasNext()) {
+                    Statement prefLabelStatement = prefLabelIt.next();
+                    String prefLabel = prefLabelStatement.getString();
+
+                    String urn = res.getURI();
+                    if (urn != null) {
+                        result.put(urn, prefLabel);
+                    }
+
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Returns set of all narrower URIs, narrower and narrowerTransitive, for given cache ID and URI.
+     * If no narrowerTransitive found, it recursively follows the narrower relationships through the model.
+     *
+     * @param vocabularyId  Cache ID of vocabulary model
+     * @param uri Vocabulary URI to find narrower terms
+     * @return
+     */
+    public Set<String> getAllNarrower(String vocabularyId, String uri) {
+        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+        Set<String> result = new HashSet<>();
+        result.add(uri);
+        Set<String> narrowerTransitive = getNarrowerTransitive(model, uri);
+        if (result.addAll(narrowerTransitive)) {
+            result.addAll(getNarrower(model, uri));
+        } else {
+            result.addAll(getNarrowRecursive(model, uri));
+        }
+        return result;
+    }
+
+    public Set<String> getNarrowRecursive(String vocabularyId, String uri) {
+        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+        return getNarrowRecursive(model, uri);
+    }
+
+    /**
+     * Recursive narrower query through the model for the given cache ID and URI
+     *
+     * @param model Cache ID of vocabulary model
+     * @param uri Vocabulary URI to find narrower terms
+     * @return Set of URIs
+     */
+    private Set<String> getNarrowRecursive(Model model, String uri) {
+        Set<String> result = new HashSet<>();
+
+        Set<String> narrower = getNarrower(model, uri);
+
+        result.addAll(narrower);
+        for (String narrowUri : narrower) {
+            result.addAll(getNarrowRecursive(model, narrowUri));
+        }
+        return result;
+    }
+
+
+    /**
+     * Narrower concepts for the given URI and vocabualry ID.
+     *
+     * @param vocabularyId The vocabulary ID.
+     * @param uri Vocabulary URI to find narrower terms
+     * @return
+     */
+    public Set<String> getNarrower(String vocabularyId, String uri) {
+        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+        return getNarrower(model, uri);
+    }
+
+    /**
+     * Narrower concepts for the given URI and model.
+     *
+     * @param model The vocabulary model
+     * @param uri Vocabulary URI to find narrower terms
+     * @return Set of URIs
+     */
+    private Set<String> getNarrower(Model model, String uri) {
+        Property property = model.createProperty(VocabNamespaceContext.SKOS_NAMESPACE, "narrower");
+        Resource resource = model.getResource(uri);
+        Selector selector = new SimpleSelector(resource, property, (RDFNode) null);
+        Model filteredModel = filterModel(model, selector);
+        return getSubjectUris(filteredModel);
+    }
+
+
+    /**
+     * Narrower concepts for the given URI and vocabulary ID.
+     *
+     * @param vocabularyId The vocabulary ID.
+     * @param uri Vocabulary URI to find narrower terms
+     * @return
+     */
+    public Set<String> getNarrowerTransitive(String vocabularyId, String uri) {
+        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+        return getNarrowerTransitive(model, uri);
+    }
+
+    /**
+     * Narrower Transitive concepts for the given URI and voabualry model
+     *
+     * @param model The vocabulary model
+     * @param uri Vocabulary URI to find narrower terms
+     * @return Set of URIs
+     */
+    private Set<String> getNarrowerTransitive(Model model, String uri) {
+        Property property = model.createProperty(VocabNamespaceContext.SKOS_NAMESPACE, "narrowerTransitive");
+        Resource resource = model.getResource(uri);
+        Selector selector = new SimpleSelector(resource, property, (RDFNode) null);
+        Model filteredModel = filterModel(model, selector);
+        return getSubjectUris(filteredModel);
+    }
+
+    /** Returns all subject resource URIs for the given model
+     *
+     * @param model
+     * @return Set of URIs
+     */
+    private Set<String> getSubjectUris(Model model) {
+        Set<String> result = new HashSet<>();
+        if (model != null) {
+            StmtIterator stmtIterator = model.listStatements();
+            while (stmtIterator.hasNext()) {
+                Statement statement = stmtIterator.next();
+                String uri = statement.getResource().getURI();
+                result.add(uri);
+            }
+        }
+        return result;
+    }
+
+
+    /**
+     * Filters a model by the given selector
+     *
+     * @param model Model to filter
+     * @param selector Query for the model to filter on
+     * @return New filtered model
+     */
+    private Model filterModel(Model model, Selector selector) {
+        Model filteredModel = ModelFactory.createDefaultModel();
+        if (model != null) {
+            StmtIterator stmtIterator = model.listStatements(selector);
+            filteredModel.add(stmtIterator);
+        }
+        return filteredModel;
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/VocabularyFilterService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyFilterService.java
@@ -27,14 +27,19 @@ public class VocabularyFilterService {
 
     /**
      * Returns key-value pairs of vocabulary terms for the specified cache ID, filtered by
-     * the queries listed in the selectors.
+     * the queries listed in the selectors. If there are no selectors in the call then it returns
+     * the vocabulary for the unfiltered model.
      *
      * @param vocabularyId Cache ID of vocabulary model
      * @param selectors List of selectors used to query the model
      * @return
      */
-    public Map<String, String> getFilteredVocabularyById(String vocabularyId, Selector... selectors) {
+    public Map<String, String> getVocabularyById(String vocabularyId, Selector... selectors) {
         Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
+
+        if (selectors == null || selectors.length == 0) {
+            return  getLabeledVocabulary(model);
+        }
 
         Model filteredModel = ModelFactory.createDefaultModel();
         for (Selector selector : selectors) {
@@ -49,20 +54,6 @@ public class VocabularyFilterService {
 
         return getLabeledVocabulary(filteredModel);
     }
-
-
-    /**
-     * Returns key-value pairs of vocabulary terms for the specified cache ID.
-     *
-     * @param vocabularyId Cache ID of vocabulary model
-     * @return
-     */
-    public Map<String, String> getVocabularyById(String vocabularyId) {
-        Model model = this.vocabularyCacheService.getVocabularyCacheById(vocabularyId);
-
-        return getLabeledVocabulary(model);
-    }
-
 
     /**
      * Returns key-value pairs of vocabulary terms for model. Pairs are prefLabel and URI.

--- a/src/main/java/org/auscope/portal/core/services/VocabularyService.java
+++ b/src/main/java/org/auscope/portal/core/services/VocabularyService.java
@@ -184,26 +184,15 @@ public class VocabularyService {
     }
 
     /**
-     * Returns all the relevant concepts for this. By default returns
+     * Returns all the relevant concepts for the given vocabulary
      *
      *
      * @return
      */
-    public Map<String,String> getAllRelevantConcepts() throws URISyntaxException, PortalServiceException {
+    public Map<String, String> getAllRelevantConcepts() throws URISyntaxException, PortalServiceException {
         Map<String, String> result = new HashMap<String, String>();
 
-        Model model = ModelFactory.createDefaultModel();
-        int pageNumber = 0;
-        int pageSize = this.getPageSize();
-
-        do {
-            HttpRequestBase method = vocabularyMethodMaker.getAllConcepts(getServiceUrl(), Format.Rdf, View.description, pageSize, pageNumber);
-            if (requestPageOfConcepts(method, model)) {
-                pageNumber++;
-            } else {
-                break;
-            }
-        } while (true);
+        Model model = getModel();
 
         Property prefLabelProperty = model.createProperty(VocabNamespaceContext.SKOS_NAMESPACE, "prefLabel");
         ResIterator iterator = model.listResourcesWithProperty(prefLabelProperty);
@@ -221,6 +210,30 @@ public class VocabularyService {
             }
         }
         return result;
+    }
+
+    /**
+     * @return Returns full Jena model of the vocabulary
+     *
+     * @throws URISyntaxException
+     * @throws PortalServiceException
+     */
+    public Model getModel() throws URISyntaxException, PortalServiceException {
+
+        Model model = ModelFactory.createDefaultModel();
+        int pageNumber = 0;
+        int pageSize = this.getPageSize();
+
+        do {
+            HttpRequestBase method = vocabularyMethodMaker.getAllConcepts(getServiceUrl(), Format.Rdf, View.description, pageSize, pageNumber);
+            if (requestPageOfConcepts(method, model)) {
+                pageNumber++;
+            } else {
+                break;
+            }
+        } while (true);
+
+        return model;
     }
 
 

--- a/src/main/java/org/auscope/portal/core/services/methodmakers/VocabularyMethodMaker.java
+++ b/src/main/java/org/auscope/portal/core/services/methodmakers/VocabularyMethodMaker.java
@@ -14,7 +14,7 @@ import java.util.List;
  * A class for generating HTTP methods to communicate with a vocabulary
  * service that uses the Linked Data API
  *
- * @author Josh Vote, Michael Sexton
+ * @author Josh Vote
  *
  */
 public class VocabularyMethodMaker extends AbstractMethodMaker {
@@ -116,6 +116,7 @@ public class VocabularyMethodMaker extends AbstractMethodMaker {
         }
     }
 
+
     /**
      * Appends the view parameter to the list, in the case where the vocabulary
      * service presents a limited description for a vocabulary by default
@@ -181,6 +182,7 @@ public class VocabularyMethodMaker extends AbstractMethodMaker {
         if (view != null) {
             appendViewParam(params, view.name());
         }
+        params.add(new BasicNameValuePair("_lang", "en"));
 
         return buildGetMethod(serviceUrl, "concept", format, params);
     }
@@ -299,6 +301,25 @@ public class VocabularyMethodMaker extends AbstractMethodMaker {
     }
 
     /**
+     * @param serviceUrl
+     * @param baseConceptUri
+     * @param format
+     * @param pageSize
+     * @param pageNumber
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getBroaderTransitiveConcepts(String serviceUrl, String baseConceptUri,
+                                              Format format, Integer pageSize, Integer pageNumber) throws URISyntaxException {
+        List<NameValuePair> params = new ArrayList<>();
+
+        appendPagingParams(params, pageSize, pageNumber);
+        params.add(new BasicNameValuePair("uri", baseConceptUri));
+
+        return buildGetMethod(serviceUrl,"concept/broaderTransitive", format, params);
+    }
+
+    /**
      * Generates a method for requesting all concepts (as rdf:Descriptions) that
      * are narrower than the specified concept as defined by skos:narrower
      *
@@ -327,4 +348,24 @@ public class VocabularyMethodMaker extends AbstractMethodMaker {
         return buildGetMethod(serviceUrl,"concept/narrower", format, params);
     }
 
+
+    /**
+     * @param serviceUrl
+     * @param baseConceptUri
+     * @param format
+     * @param pageSize
+     * @param pageNumber
+     * @return
+     * @throws URISyntaxException
+     */
+    public HttpRequestBase getNarrowerTransitiveConcepts(String serviceUrl, String baseConceptUri,
+                                               Format format, View view, Integer pageSize, Integer pageNumber) throws URISyntaxException {
+        List<NameValuePair> params = new ArrayList<>();
+
+        appendPagingParams(params, pageSize, pageNumber);
+        params.add(new BasicNameValuePair("uri", baseConceptUri));
+
+
+        return buildGetMethod(serviceUrl,"concept/narrowerTransitive", format, params);
+    }
 }

--- a/src/test/java/org/auscope/portal/core/services/TestVocabularyCacheService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestVocabularyCacheService.java
@@ -1,5 +1,6 @@
 package org.auscope.portal.core.services;
 
+import com.hp.hpl.jena.rdf.model.Model;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.server.http.HttpClientInputStream;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
@@ -177,7 +178,7 @@ public class TestVocabularyCacheService extends PortalTestClass {
 
             Assert.assertEquals(totalRequestsMade, this.vocabularyCacheService.getVocabularyCache().size());
             int numberOfTerms = 0;
-            for (Map.Entry<String, Map<String, String>> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
+            for (Map.Entry<String, Model> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
                 numberOfTerms +=  entry.getValue().size();
             }
             Assert.assertEquals(VOCABULARY_COUNT_TOTAL, numberOfTerms);
@@ -281,7 +282,7 @@ public class TestVocabularyCacheService extends PortalTestClass {
 
             Assert.assertEquals(CONCURRENT_THREADS_TO_RUN - 1, this.vocabularyCacheService.getVocabularyCache().size());
             int numberOfTerms = 0;
-            for (Map.Entry<String, Map<String, String>> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
+            for (Map.Entry<String, Model> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
                 numberOfTerms += entry.getValue().size();
             }
             Assert.assertEquals(VOCABULARY_ERRORS_COUNT_TOTAL, numberOfTerms);

--- a/src/test/java/org/auscope/portal/core/services/TestVocabularyCacheService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestVocabularyCacheService.java
@@ -1,6 +1,6 @@
 package org.auscope.portal.core.services;
 
-import com.hp.hpl.jena.rdf.model.Model;
+import com.hp.hpl.jena.rdf.model.*;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.server.http.HttpClientInputStream;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
@@ -8,6 +8,7 @@ import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker;
 import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.Format;
 import org.auscope.portal.core.services.methodmakers.VocabularyMethodMaker.View;
 
+import org.auscope.portal.core.services.namespaces.VocabNamespaceContext;
 import org.auscope.portal.core.services.vocabs.VocabularyServiceItem;
 import org.auscope.portal.core.test.BasicThreadExecutor;
 import org.auscope.portal.core.test.PortalTestClass;
@@ -30,8 +31,8 @@ public class TestVocabularyCacheService extends PortalTestClass {
 
     private static final int CONCURRENT_THREADS_TO_RUN = 3;
 
-    static final int VOCABULARY_COUNT_TOTAL = 35;
-    static final int VOCABULARY_ERRORS_COUNT_TOTAL = 25;
+    static final int VOCABULARY_COUNT_TOTAL = 461;
+    static final int VOCABULARY_ERRORS_COUNT_TOTAL = 451;
 
     private BasicThreadExecutor threadExecutor;
 
@@ -176,11 +177,17 @@ public class TestVocabularyCacheService extends PortalTestClass {
                 Assert.fail("Exception whilst waiting for update to finish " + e.getMessage());
             }
 
-            Assert.assertEquals(totalRequestsMade, this.vocabularyCacheService.getVocabularyCache().size());
-            int numberOfTerms = 0;
-            for (Map.Entry<String, Model> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
-                numberOfTerms +=  entry.getValue().size();
+            Map<String, Model> cache = this.vocabularyCacheService.getVocabularyCache();
+            Selector selector = new SimpleSelector(null, ResourceFactory.createProperty("http://www.w3.org/2004/02/skos/core#prefLabel"), (RDFNode) null);
+
+
+            Assert.assertEquals(totalRequestsMade, cache.size());
+            int numberOfTerms =0;
+            for (Map.Entry<String, Model> entry: cache.entrySet() ) {
+                StmtIterator statements = entry.getValue().listStatements(selector);
+                numberOfTerms += statements.toList().size();
             }
+
             Assert.assertEquals(VOCABULARY_COUNT_TOTAL, numberOfTerms);
             Assert.assertFalse(this.vocabularyCacheService.updateRunning);
         }
@@ -280,10 +287,15 @@ public class TestVocabularyCacheService extends PortalTestClass {
                 Assert.fail("Exception whilst waiting for update to finish " + e.getMessage());
             }
 
-            Assert.assertEquals(CONCURRENT_THREADS_TO_RUN - 1, this.vocabularyCacheService.getVocabularyCache().size());
-            int numberOfTerms = 0;
-            for (Map.Entry<String, Model> entry : this.vocabularyCacheService.vocabularyCache.entrySet()) {
-                numberOfTerms += entry.getValue().size();
+            Map<String, Model> cache = this.vocabularyCacheService.getVocabularyCache();
+            Selector selector = new SimpleSelector(null, ResourceFactory.createProperty("http://www.w3.org/2004/02/skos/core#prefLabel"), (RDFNode) null);
+
+
+            Assert.assertEquals(CONCURRENT_THREADS_TO_RUN - 1, cache.size());
+            int numberOfTerms =0;
+            for (Map.Entry<String, Model> entry: cache.entrySet() ) {
+                StmtIterator statements = entry.getValue().listStatements(selector);
+                numberOfTerms += statements.toList().size();
             }
             Assert.assertEquals(VOCABULARY_ERRORS_COUNT_TOTAL, numberOfTerms);
             Assert.assertFalse(this.vocabularyCacheService.updateRunning);

--- a/src/test/java/org/auscope/portal/core/services/TestVocabularyFilterService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestVocabularyFilterService.java
@@ -1,0 +1,194 @@
+package org.auscope.portal.core.services;
+
+import com.hp.hpl.jena.rdf.model.*;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.jmock.Expectations;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.validation.constraints.AssertTrue;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class TestVocabularyFilterService extends PortalTestClass {
+
+    private VocabularyCacheService mockCacheService;
+    private Model mockModel1;
+    private Model mockModel2;
+    private String mockVocabularyCacheId = "vocabularyCacheId";
+
+    private Property mockDefaultProperty;
+
+
+    private VocabularyFilterService vocabularyFilterService;
+
+    @Before
+    public void setUp() throws Exception {
+
+
+        Resource mockResource = ResourceFactory.createResource("http://www.example.org/vocab/resource");
+        Resource mockNarrowResource1 = ResourceFactory.createResource("http://www.example.org/vocab/narrow");
+        Resource mockNarrowResource2 = ResourceFactory.createResource("http://www.example.org/vocab/narrow2");
+        Resource mockNarrowTransitiveResource1 = ResourceFactory.createResource("http://www.example.org/vocab/narrowTransitive1");
+        Resource mockNarrowTransitiveResource2 = ResourceFactory.createResource("http://www.example.org/vocab/narrowTransitive2");
+        Resource mockNarrowTransitiveResource3 = ResourceFactory.createResource("http://www.example.org/vocab/narrowTransitive3");
+        Resource mockNarrowTransitiveResource4 = ResourceFactory.createResource("http://www.example.org/vocab/narrowTransitive4");
+
+
+        mockDefaultProperty = ResourceFactory.createProperty("http://example.org/property");
+        Property mockPrefLabelProperty = ResourceFactory.createProperty("http://www.w3.org/2004/02/skos/core#prefLabel");
+        Property mockNarrowerProperty =ResourceFactory.createProperty("http://www.w3.org/2004/02/skos/core#narrower");
+        Property mockNarrowerTransitiveProperty = ResourceFactory.createProperty("http://www.w3.org/2004/02/skos/core#narrowerTransitive");
+
+        // Model 1 has narrow and narrowerTransitive relationships
+
+        mockModel1 = ModelFactory.createDefaultModel();
+
+        Statement mockLanguageProperty = mockModel1.createStatement(mockResource, mockDefaultProperty, "example", "en");
+        Statement mockPrefLabelStatement = mockModel1.createStatement(mockResource, mockPrefLabelProperty, "prefLabel");
+
+        Statement mockNarrowerStatement1 = mockModel1.createStatement(mockResource, mockNarrowerProperty, mockNarrowResource1);
+        Statement mockNarrowerStatement2 = mockModel1.createStatement(mockResource, mockNarrowerProperty, mockNarrowResource2);
+        Statement mockNarrowerTransitiveStatement1 = mockModel1.createStatement(mockResource, mockNarrowerTransitiveProperty, mockNarrowTransitiveResource1);
+        Statement mockNarrowerTransitiveStatement2 = mockModel1.createStatement(mockResource, mockNarrowerTransitiveProperty, mockNarrowTransitiveResource2);
+        Statement mockNarrowerTransitiveStatement3 = mockModel1.createStatement(mockResource, mockNarrowerTransitiveProperty, mockNarrowTransitiveResource3);
+        Statement mockNarrowerTransitiveStatement4 = mockModel1.createStatement(mockResource, mockNarrowerTransitiveProperty, mockNarrowTransitiveResource4);
+
+        Statement[] statements1 = {mockLanguageProperty, mockPrefLabelStatement, mockNarrowerStatement1, mockNarrowerStatement2,
+                mockNarrowerTransitiveStatement1, mockNarrowerTransitiveStatement2, mockNarrowerTransitiveStatement3, mockNarrowerTransitiveStatement4};
+
+        mockModel1.add(statements1);
+
+        // Model 2 has only narrower relationships which are defined recursively.
+
+        mockModel2 = ModelFactory.createDefaultModel();
+
+        mockLanguageProperty = mockModel2.createStatement(mockResource, mockDefaultProperty, "example", "en");
+
+        mockPrefLabelStatement = mockModel2.createStatement(mockResource, mockPrefLabelProperty, "prefLabel");
+        mockNarrowerStatement1 = mockModel2.createStatement(mockResource, mockNarrowerProperty, mockNarrowResource1);
+        mockNarrowerStatement2 = mockModel2.createStatement(mockResource, mockNarrowerProperty, mockNarrowResource2);
+        Statement mockNarrowerRecursiveStatement1 = mockModel2.createStatement(mockNarrowResource1, mockNarrowerProperty, mockNarrowTransitiveResource1);
+        Statement mockNarrowerRecursiveStatement2 = mockModel2.createStatement(mockNarrowResource1, mockNarrowerProperty, mockNarrowTransitiveResource2);
+        Statement mockNarrowerRecursiveStatement3 = mockModel2.createStatement(mockNarrowResource2, mockNarrowerProperty, mockNarrowTransitiveResource3);
+        Statement mockNarrowerRecursiveStatement4 = mockModel2.createStatement(mockNarrowResource2, mockNarrowerProperty, mockNarrowTransitiveResource4);
+
+        Statement[] statements2 = {mockLanguageProperty, mockPrefLabelStatement, mockNarrowerStatement1, mockNarrowerStatement2,
+                mockNarrowerRecursiveStatement1, mockNarrowerRecursiveStatement2, mockNarrowerRecursiveStatement3, mockNarrowerRecursiveStatement4};
+
+        mockModel2.add(statements2);
+
+
+        mockCacheService = context.mock(VocabularyCacheService.class);
+
+
+        vocabularyFilterService = new VocabularyFilterService(mockCacheService);
+    }
+
+    @Test
+    public void testGetFilteredVocabularyById() {
+
+        Selector mockSelector = new SimpleSelector(null, mockDefaultProperty, "example", "en");
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel1));
+            }
+        });
+
+        Map<String, String> values = vocabularyFilterService.getFilteredVocabularyById(mockVocabularyCacheId, mockSelector);
+
+        Assert.assertEquals(1, values.size());
+    }
+
+    @Test
+    public void testGetVocabularyById() {
+
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel1));
+            }
+        });
+
+        Map<String, String> values = vocabularyFilterService.getVocabularyById(mockVocabularyCacheId);
+
+        Assert.assertEquals(1, values.size());
+    }
+
+    @Test
+    public void testGetAllNarrowerWithTransitive() {
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel1));
+            }
+        });
+
+        Set<String> values = vocabularyFilterService.getAllNarrower(mockVocabularyCacheId, "http://www.example.org/vocab/resource");
+
+        Assert.assertEquals(7, values.size());
+    }
+
+    @Test
+    public void testGetAllNarrowerWithRecursive() {
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel1));
+            }
+        });
+
+        Set<String> values = vocabularyFilterService.getAllNarrower(mockVocabularyCacheId, "http://www.example.org/vocab/resource");
+
+        Assert.assertEquals(7, values.size());
+    }
+
+    @Test
+    public void testGetNarrowerRecursive() {
+
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel2));
+            }
+        });
+
+        Set<String> values = vocabularyFilterService.getNarrowRecursive(mockVocabularyCacheId, "http://www.example.org/vocab/resource");
+
+        Assert.assertEquals(6, values.size());
+    }
+
+    @Test
+    public void testGetNarrower() {
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel1));
+            }
+        });
+
+        Set<String> values = vocabularyFilterService.getNarrower(mockVocabularyCacheId, "http://www.example.org/vocab/resource");
+
+        Assert.assertEquals(2, values.size());
+    }
+
+    @Test
+    public void testGetNarrowerTransitive() {
+        context.checking(new Expectations() {
+            {
+                oneOf(mockCacheService).getVocabularyCacheById(mockVocabularyCacheId);
+                will(returnValue(mockModel1));
+            }
+        });
+
+        Set<String> values = vocabularyFilterService.getNarrowerTransitive(mockVocabularyCacheId, "http://www.example.org/vocab/resource");
+
+        Assert.assertEquals(4, values.size());
+    }
+}

--- a/src/test/java/org/auscope/portal/core/services/TestVocabularyFilterService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestVocabularyFilterService.java
@@ -100,7 +100,7 @@ public class TestVocabularyFilterService extends PortalTestClass {
             }
         });
 
-        Map<String, String> values = vocabularyFilterService.getFilteredVocabularyById(mockVocabularyCacheId, mockSelector);
+        Map<String, String> values = vocabularyFilterService.getVocabularyById(mockVocabularyCacheId, mockSelector);
 
         Assert.assertEquals(1, values.size());
     }


### PR DESCRIPTION
This is to improve performance of SLD queries where vocabulary terms have narrower and narrowerTransitive relationships.

The Jena model is cached fully instead of filtering for prefLabel relationships and storing as key-value pairs. 

The VocabularyFilterService is a new service class that allows querying and transform for the cached models.