### PR TITLE
Changed the way WMS and WFS metadata records are merged

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/CSWCacheService.java
+++ b/src/main/java/org/auscope/portal/core/services/CSWCacheService.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.Executor;
 
 import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
@@ -513,26 +514,67 @@ public class CSWCacheService {
                     for (CSWRecord record : cswRecordMap.values()) {
                         boolean recordMerged = false;
 
-                        //Firstly we may possibly merge this
-                        //record into an existing record IF particular keywords
-                        //are present. In this case, record will be discarded (its contents
-                        //already found their way into an existing record)
-                        //Hence we need to perform this step first
-                        for (String keyword : record.getDescriptiveKeywords()) {
-                            if (keyword == null || keyword.isEmpty()) {
-                                continue;
-                            }
+                        // We will merge WMS or WFS records into an existing record if the endpoint urls and
+                        // layer names match. In this case, this record will be discarded after its
+                        // content has been merged.
 
-                            //If we have an 'association keyword', look for existing records
-                            //to merge this record's contents in to.
-                            if (keyword.startsWith(KEYWORD_MERGE_PREFIX)) {
-                                Set<CSWRecord> existingRecs = newKeywordCache.get(keyword);
-                                if (existingRecs != null && !existingRecs.isEmpty()) {
-                                    mergeRecords(endpoint, existingRecs.iterator().next(), record, newKeywordCache, newKeywordByEndpointCache);
-                                    recordMerged = true;
+                        // Loop through new records looking for candidates to merge
+                        for (AbstractCSWOnlineResource wXSOnlineRes : record
+                                .getOnlineResourcesByType(OnlineResourceType.WFS, OnlineResourceType.WMS)) {
+
+                            // Skip null or empty urls and layernames
+                            if (wXSOnlineRes.getLinkage() == null
+                                    || StringUtils.isEmpty(wXSOnlineRes.getLinkage().toString())
+                                    || StringUtils.isEmpty(record.getLayerName()))
+                                continue;
+                            String recURL = wXSOnlineRes.getLinkage().toString();
+                            // trim interface name from url for comparison
+                            recURL = StringUtils.substring(recURL, 0, recURL.lastIndexOf('/'));
+
+                            // loop through existing records
+                            for (CSWRecord existingRec : newRecordCache) {
+                                // loop through online resources of each record
+                                for (AbstractCSWOnlineResource existingRes : existingRec
+                                        .getOnlineResourcesByType(OnlineResourceType.WFS, OnlineResourceType.WMS)) {
+                                    // Skip null or empty urls and layernames
+                                    if (existingRes.getLinkage() == null
+                                            || StringUtils.isEmpty(existingRes.getLinkage().toString())
+                                            || StringUtils.isEmpty(existingRec.getLayerName()))
+                                        continue;
+
+                                    String existingURL = existingRes.getLinkage().toString();
+                                    String existingRecLayerName = existingRec.getLayerName();
+
+                                    // trim interface name from url for comparison
+                                    existingURL = StringUtils.substring(existingURL, 0, existingURL.lastIndexOf('/'));
+                                    String recLayerName = record.getLayerName();
+
+                                    // MapServer uses layer names without namespaces in WMS getcaps. So, if either
+                                    // the new or existing record's layername doesn't include a namepaces then we
+                                    // trim all namespaces for comparison.
+                                    if (!existingRecLayerName.contains(":") || !recLayerName.contains(":")) {
+                                        recLayerName = recLayerName.substring(recLayerName.indexOf(':') + 1,
+                                                recLayerName.length());
+                                        existingRecLayerName = existingRecLayerName.substring(
+                                                existingRecLayerName.indexOf(':') + 1, existingRecLayerName.length());
+                                    }
+                                    // compare Layer Names and URLs
+                                    if (recLayerName.equals(existingRecLayerName) && recURL.equals(existingURL)) {
+                                        threadLog.debug("Merging CSW records " + record.getRecordInfoUrl() + " and "
+                                                + existingRec.getRecordInfoUrl());
+                                        mergeRecords(endpoint, existingRec, record, newKeywordCache,
+                                                newKeywordByEndpointCache);
+                                        recordMerged = true;
+                                        break;
+                                    }
                                 }
+                                if (recordMerged == true)
+                                    break;
                             }
+                            if (recordMerged == true)
+                                break;
                         }
+
 
                         //If the record was NOT merged into an existing record we then update the record cache
                         if (!recordMerged) {


### PR DESCRIPTION
Changed the way WMS and WFS metadata records that represent the same data are merged.  In the past a special keyword "association" was required to merge.  Now any layers with the same name from the same server/path will automatically be merged.