### PR TITLE
Check job object exists before attepting to delete it

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -499,7 +499,10 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
         try {
             BlobStore bs = getBlobStore(arn, clientSecret);
-            bs.deleteDirectory(getBucket(job), jobToBaseKey(job));
+            String bucket = getBucket(job);
+            String baseKey = jobToBaseKey(job);
+            if(bs.blobExists(bucket, baseKey))
+                bs.deleteDirectory(bucket, baseKey);
         } catch (Exception ex) {
             log.error("Error in removing job files or storage key.", ex);
             throw new PortalServiceException(

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -349,6 +349,8 @@ public class TestCloudStorageService extends PortalTestClass {
             {
                 allowing(mockBlobStoreContext).getBlobStore();
                 will(returnValue(mockBlobStore));
+                oneOf(mockBlobStore).blobExists(bucket, jobStorageBaseKey);
+                will(returnValue(true));
                 oneOf(mockBlobStore).deleteDirectory(bucket, jobStorageBaseKey);
                 oneOf(mockBlobStoreContext).close();
             }


### PR DESCRIPTION
VGL was hanging for a minute or 2 whilst attempting to clean up job files it couldn't find, so I've added a simple check in the underlying CloudStorageServiceJClouds.deleteJobFiles method that ensures the requested object is there before attempting to delete it.