### PR TITLE
added serviceGroup filter parameter to nagios configuration

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/controllers/BaseCSWController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/BaseCSWController.java
@@ -127,9 +127,9 @@ public abstract class BaseCSWController extends BasePortalController {
             viewKnownLayer.put("cswRecords", viewMappedRecords);
             viewKnownLayer.put("relatedRecords", viewRelatedRecords);
 
-            if (nagiosService != null && kl.getNagiosHostGroup() != null) {
+            if (nagiosService != null && (kl.getNagiosHostGroup() != null || kl.getNagiosServiceGroup() != null)) {
                 try {
-                    Map<String, List<ServiceStatusResponse>> response = nagiosService.getStatuses(kl.getNagiosHostGroup());
+                    Map<String, List<ServiceStatusResponse>> response = nagiosService.getStatuses(kl.getNagiosHostGroup(),kl.getNagiosServiceGroup());
                     List<String> failingHosts = new ArrayList<String>();
                     for (Entry<String, List<ServiceStatusResponse>> entry : response.entrySet()) {
                         for (ServiceStatusResponse status : entry.getValue()) {

--- a/src/main/java/org/auscope/portal/core/services/Nagios4CachedService.java
+++ b/src/main/java/org/auscope/portal/core/services/Nagios4CachedService.java
@@ -46,7 +46,7 @@ public class Nagios4CachedService extends Nagios4Service {
      * @see Nagios4Service.getStatuses
      */
     @Override
-    public synchronized Map<String, List<ServiceStatusResponse>> getStatuses(String hostGroup) throws PortalServiceException {
+    public synchronized Map<String, List<ServiceStatusResponse>> getStatuses(String hostGroup, String serviceGroup) throws PortalServiceException {
         CacheEntry cacheEntry = cache.get(hostGroup);
 
         if (cacheEntry != null) {
@@ -64,7 +64,7 @@ public class Nagios4CachedService extends Nagios4Service {
         // but I feel that's over engineering it
         Map<String, List<ServiceStatusResponse>> response = null;
         try{
-        	response = super.getStatuses(hostGroup);
+        	response = super.getStatuses(hostGroup,serviceGroup);
         } catch(PortalServiceException pse){
         	cacheEntry = new CacheEntry(new Date(), pse); // This could potentially recycle the CacheEntry objects instead
             cache.put(hostGroup, cacheEntry);

--- a/src/main/java/org/auscope/portal/core/services/Nagios4Service.java
+++ b/src/main/java/org/auscope/portal/core/services/Nagios4Service.java
@@ -60,17 +60,18 @@ public class Nagios4Service {
     /**
      * Gets a (possibly filtered) view of all services, keyed by their host name.
      * @param hostGroup If not null, results will be filtered to services belonging to this host group
+     * @param serviceGroup If not null, results will be filtered to services belonging to this service group
      * @param hostName
      * @return
      * @throws PortalServiceException
      */
-    public Map<String, List<ServiceStatusResponse>> getStatuses(String hostGroup) throws PortalServiceException {
+    public Map<String, List<ServiceStatusResponse>> getStatuses(String hostGroup, String serviceGroup) throws PortalServiceException {
 
         //Make our request
         HttpRequestBase method = null;
         String responseString = null;
         try {
-            method = methodMaker.statusServiceListJSON(serviceUrl, hostGroup, null);
+            method = methodMaker.statusServiceListJSON(serviceUrl, hostGroup, serviceGroup, null);
             responseString = serviceCaller.getMethodResponseAsString(method, generateCredentials());
         } catch (Exception ex) {
             throw new PortalServiceException(method, "Unable to access remote Nagios4 service", ex);

--- a/src/main/java/org/auscope/portal/core/services/methodmakers/Nagios4MethodMaker.java
+++ b/src/main/java/org/auscope/portal/core/services/methodmakers/Nagios4MethodMaker.java
@@ -17,11 +17,12 @@ public class Nagios4MethodMaker extends AbstractMethodMaker {
      * Generates a servicelist query for status information that can be optionally filtered
      * @param serviceUrl The base Nagios 4 URL
      * @param hostGroup If not null, will filter all services to those within the named host group
+     * @param serviceGroup If not null, will filter all services to those within the named service group
      * @param hostName If not null, will filter all services to those belonging to the named host
      * @return
      * @throws URISyntaxException
      */
-    public HttpRequestBase statusServiceListJSON(String serviceUrl, String hostGroup, String hostName) throws URISyntaxException {
+    public HttpRequestBase statusServiceListJSON(String serviceUrl, String hostGroup, String serviceGroup, String hostName) throws URISyntaxException {
         String queryUrl = urlPathConcat(serviceUrl, "cgi-bin/statusjson.cgi");
 
         URIBuilder builder = new URIBuilder(queryUrl);
@@ -29,6 +30,9 @@ public class Nagios4MethodMaker extends AbstractMethodMaker {
         builder.addParameter("formatoptions", "enumerate");
         if (StringUtils.isNotEmpty(hostGroup)) {
             builder.addParameter("hostgroup", hostGroup);
+        }
+        if (StringUtils.isNotEmpty(serviceGroup)) {
+            builder.addParameter("servicegroup", serviceGroup);
         }
         if (StringUtils.isNotEmpty(hostName)) {
             builder.addParameter("hostname", hostName);

--- a/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
+++ b/src/main/java/org/auscope/portal/core/view/knownlayer/KnownLayer.java
@@ -83,6 +83,9 @@ public class KnownLayer implements Serializable {
     /** If specified, the name/id of a Nagios host group whose status reflects the availability of this known layer */
     private String nagiosHostGroup;
 
+    /** If specified, the name/id of a Nagios host group whose status reflects the availability of this known layer */
+    private String nagiosServiceGroup;
+
     private FilterCollection filterCollection;
     /**
      * Creates a new KnownLayer
@@ -400,6 +403,14 @@ public class KnownLayer implements Serializable {
 
     public void setNagiosHostGroup(String nagiosHostGroup) {
         this.nagiosHostGroup = nagiosHostGroup;
+    }
+
+    public String getNagiosServiceGroup() {
+        return nagiosServiceGroup;
+    }
+
+    public void setNagiosServiceGroup(String nagiosServiceGroup) {
+        this.nagiosServiceGroup = nagiosServiceGroup;
     }
 
     /* (non-Javadoc)

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestBaseCSWController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestBaseCSWController.java
@@ -102,9 +102,9 @@ public class TestBaseCSWController extends PortalTestClass {
         hg2Response.put("host.name.4", Arrays.asList(new ServiceStatusResponse(Status.critical, "hg2.serv3"), new ServiceStatusResponse(Status.critical, "hg2.serv4")));
 
         context.checking(new Expectations() {{
-            oneOf(mockNagiosService).getStatuses("hg1");will(returnValue(hg1Response));
-            oneOf(mockNagiosService).getStatuses("hg2");will(returnValue(hg2Response));
-            oneOf(mockNagiosService).getStatuses("hg4");will(throwException(new PortalServiceException("hg4 error")));
+            oneOf(mockNagiosService).getStatuses("hg1", null);will(returnValue(hg1Response));
+            oneOf(mockNagiosService).getStatuses("hg2", null);will(returnValue(hg2Response));
+            oneOf(mockNagiosService).getStatuses("hg4", null);will(throwException(new PortalServiceException("hg4 error")));
         }});
 
         ModelAndView mav = baseController.generateKnownLayerResponse(knownLayers, mockNagiosService);

--- a/src/test/java/org/auscope/portal/core/services/TestNagios4Service.java
+++ b/src/test/java/org/auscope/portal/core/services/TestNagios4Service.java
@@ -53,11 +53,12 @@ public class TestNagios4Service extends PortalTestClass {
     @Test
     public void testSuccessfulResponsePassword() throws Exception {
         final String hostGroup = "foo";
+        final String serviceGroup = "bar";
         final String responseString = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/nagios/nagios4-status-servicelist-success.json");
 
         context.checking(new Expectations() {
             {
-                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, null);
+                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, serviceGroup, null);
                 will(returnValue(mockMethod));
 
                 oneOf(mockServiceCaller).getMethodResponseAsString(with(mockMethod), with(any(CredentialsProvider.class)));
@@ -69,18 +70,19 @@ public class TestNagios4Service extends PortalTestClass {
         service.setPassword(password);
 
         //Do main result parsing in testSuccessfulResponseNoPassword
-        Map<String, List<ServiceStatusResponse>> result = service.getStatuses(hostGroup);
+        Map<String, List<ServiceStatusResponse>> result = service.getStatuses(hostGroup, serviceGroup);
         Assert.assertNotNull(result);
     }
 
     @Test
     public void testSuccessfulResponseNoPassword() throws Exception {
         final String hostGroup = "foo";
+        final String serviceGroup = "bar";
         final String responseString = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/nagios/nagios4-status-servicelist-success.json");
 
         context.checking(new Expectations() {
             {
-                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, null);
+                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, serviceGroup, null);
                 will(returnValue(mockMethod));
 
                 oneOf(mockServiceCaller).getMethodResponseAsString(mockMethod, (CredentialsProvider) null);
@@ -88,7 +90,7 @@ public class TestNagios4Service extends PortalTestClass {
             }
         });
 
-        Map<String, List<ServiceStatusResponse>> result = service.getStatuses(hostGroup);
+        Map<String, List<ServiceStatusResponse>> result = service.getStatuses(hostGroup, serviceGroup);
         Assert.assertNotNull(result);
         Assert.assertEquals(2, result.size());
 
@@ -113,10 +115,11 @@ public class TestNagios4Service extends PortalTestClass {
     @Test(expected=PortalServiceException.class)
     public void testConnectionError() throws Exception {
         final String hostGroup = "foo";
+        final String serviceGroup = "bar";
 
         context.checking(new Expectations() {
             {
-                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, null);
+                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, serviceGroup, null);
                 will(returnValue(mockMethod));
 
                 oneOf(mockServiceCaller).getMethodResponseAsString(mockMethod, (CredentialsProvider)null);
@@ -124,17 +127,18 @@ public class TestNagios4Service extends PortalTestClass {
             }
         });
 
-        service.getStatuses(hostGroup);
+        service.getStatuses(hostGroup, serviceGroup);
     }
 
     @Test(expected=PortalServiceException.class)
     public void testFailureResponse() throws Exception {
         final String hostGroup = "foo";
+        final String serviceGroup = "bar";
         final String responseString = ResourceUtil.loadResourceAsString("org/auscope/portal/core/test/responses/nagios/nagios4-status-servicelist-failure.json");
 
         context.checking(new Expectations() {
             {
-                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, null);
+                oneOf(mockMethodMaker).statusServiceListJSON(serviceUrl, hostGroup, serviceGroup, null);
                 will(returnValue(mockMethod));
 
                 oneOf(mockServiceCaller).getMethodResponseAsString(mockMethod, (CredentialsProvider) null);
@@ -142,6 +146,6 @@ public class TestNagios4Service extends PortalTestClass {
             }
         });
 
-        service.getStatuses(hostGroup);
+        service.getStatuses(hostGroup, serviceGroup);
     }
 }


### PR DESCRIPTION
added serviceGroup filter parameter to nagios configuration to enable more control over the nagios checks which are required to pass for a layer to be considered functional.  This enables detection of partial outages to allow functional layers to continue to be used even when others on the same server are not working.

Also, a minor jena package update for security.