### PR TITLE
AWS session tokens and shaded JClouds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.auscope.portal</groupId>
     <artifactId>portal-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.1.0-VGL-SNAPSHOT</version>
     <name>Portal-Core</name>
     <description>Core functionality common to various AuScope portals.</description>
     <url>http://portal.auscope.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
+            <version>4.5.5</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -488,7 +488,7 @@
         <dependency>
             <groupId>org.apache.jclouds</groupId>
             <artifactId>jclouds-all</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.3-SHADED</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -299,14 +299,14 @@
     </reporting>
     <repositories>
         <repository>
+            <id>dcdp-deps</id>
+            <name>AuScope Nexus - New PortalRepo</name>
+            <url>https://cgmaven.it.csiro.au/nexus/repository/dcdp-deps/</url>
+        </repository>
+        <repository>
             <id>osgeo</id>
             <name>Open Source Geospatial Foundation Repository</name>
             <url>http://download.osgeo.org/webdav/geotools</url>
-        </repository>
-        <repository>
-            <id>geotoolkit</id>
-            <name>Geo Toolkit Repository</name>
-            <url>http://maven.geotoolkit.org/</url>
         </repository>
         <repository>
             <id>apache-releases</id>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>org.auscope.portal</groupId>
     <artifactId>portal-core</artifactId>
     <packaging>jar</packaging>
-    <version>2.1.0-VGL-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <name>Portal-Core</name>
     <description>Core functionality common to various AuScope portals.</description>
     <url>http://portal.auscope.org</url>
@@ -44,7 +44,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
+	
     <!-- Build Configuration -->
     <organization>
         <name>AuScope</name>

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -191,7 +191,11 @@ public class CloudComputeServiceAws extends CloudComputeService {
         } else if (stsRequirement == STSRequirement.Mandatory) {
             throw new PortalServiceException("AWS cross account authorization required, but not configured");
         } else if (!TextUtil.isAnyNullOrEmpty(devAccessKey, devSecretKey)) {
-            return new BasicAWSCredentials(devAccessKey, devSecretKey);
+        	if(!TextUtil.isAnyNullOrEmpty(devSessionKey)) {
+        		return new BasicSessionCredentials(devAccessKey, devSecretKey, devSessionKey);
+        	} else {
+        		return new BasicAWSCredentials(devAccessKey, devSecretKey);
+        	}
         }
         return null;
     }
@@ -261,7 +265,8 @@ public class CloudComputeServiceAws extends CloudComputeService {
                 .withInstanceInitiatedShutdownBehavior("terminate").withUserData(userDataString);
 
         String instanceProfileArn = job.getProperty(CloudJob.PROPERTY_S3_ROLE);
-        if (!TextUtil.isNullOrEmpty(instanceProfileArn)) {
+        if ( (stsRequirement != STSRequirement.ForceNone) && 
+        		(!TextUtil.isNullOrEmpty(instanceProfileArn))) {
             IamInstanceProfileSpecification iamInstanceProfile = new IamInstanceProfileSpecification()
                     .withArn(instanceProfileArn);
             runInstancesRequest = runInstancesRequest.withIamInstanceProfile(iamInstanceProfile);

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceAws.java
@@ -72,6 +72,24 @@ public class CloudComputeServiceAws extends CloudComputeService {
 
     private STSRequirement stsRequirement  = STSRequirement.Permissable;
 
+	private String devSessionKey;
+
+    /**
+     * Creates a new instance with the specified credentials (no endpoint
+     * specified - ensure provider type has a fixed endpoint)
+     *
+     * @param accessKey
+     *            The Compute Access key (user name)
+     * @param secretKey
+     *            The Compute Secret key (password)
+     * @param sessionKey
+     *            The Compute Session key (password)
+     *
+     */
+    public CloudComputeServiceAws(String accessKey, String secretKey, String sessionKey) {
+        this(null, accessKey, secretKey, null, sessionKey);
+    }
+
     /**
      * Creates a new instance with the specified credentials (no endpoint
      * specified - ensure provider type has a fixed endpoint)
@@ -83,7 +101,7 @@ public class CloudComputeServiceAws extends CloudComputeService {
      *
      */
     public CloudComputeServiceAws(String accessKey, String secretKey) {
-        this(null, accessKey, secretKey, null);
+        this(null, accessKey, secretKey, null, null);
     }
 
     private static String getJaxpImplementationInfo(String componentName, Class<?> componentClass) {
@@ -104,10 +122,11 @@ public class CloudComputeServiceAws extends CloudComputeService {
      * @param apiVersion
      *            The API version
      */
-    public CloudComputeServiceAws(String endpoint, String accessKey, String secretKey, String apiVersion) {
+    public CloudComputeServiceAws(String endpoint, String accessKey, String secretKey, String apiVersion, String sessionKey) {
         super(ProviderType.AWSEc2, endpoint, apiVersion);
         this.devAccessKey = accessKey;
         this.devSecretKey = secretKey;
+        this.devSessionKey = sessionKey;
 
         logger.debug(
                 getJaxpImplementationInfo("DocumentBuilderFactory", DocumentBuilderFactory.newInstance().getClass()));
@@ -146,7 +165,13 @@ public class CloudComputeServiceAws extends CloudComputeService {
             AWSSecurityTokenServiceClient stsClient;
 
             if (!TextUtil.isAnyNullOrEmpty(devAccessKey, devSecretKey)) {
-                BasicAWSCredentials awsCredentials = new BasicAWSCredentials(devAccessKey, devSecretKey);
+            	AWSCredentials awsCredentials;
+                
+                if(!TextUtil.isAnyNullOrEmpty(devSessionKey)) {
+                	awsCredentials = new BasicSessionCredentials(devAccessKey, devSecretKey, devSessionKey);                
+                } else {
+                	awsCredentials = new BasicAWSCredentials(devAccessKey, devSecretKey);
+                }
                 stsClient = new AWSSecurityTokenServiceClient(awsCredentials);
             } else {
                 stsClient = new AWSSecurityTokenServiceClient();

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
@@ -1,6 +1,6 @@
 package org.auscope.portal.core.services.cloud;
 
-import static com.google.common.base.Predicates.not;
+import static com.shaded.google.common.base.Predicates.not;
 import static org.jclouds.compute.predicates.NodePredicates.RUNNING;
 import static org.jclouds.compute.predicates.NodePredicates.TERMINATED;
 import static org.jclouds.compute.predicates.NodePredicates.inGroup;
@@ -37,8 +37,10 @@ import org.jclouds.openstack.nova.v2_0.features.ImageApi;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.openstack.OSFactory;
 
-import com.google.common.base.Predicate;
-import com.google.common.base.Predicates;
+import com.shaded.google.common.base.Predicate;
+import com.shaded.google.common.base.Predicates;
+
+
 
 /**
  * Service class wrapper for interacting with a remote cloud compute service using CloudJob objects.

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageService.java
@@ -106,7 +106,18 @@ public abstract class CloudStorageService {
     /** Password credentials for accessing the storage service */
     private String secretKey;
 
-    /** The bucket name used when no bucket is specified */
+    /** Session token for accessing the storage service */
+    private String sessionKey;
+    
+    public String getSessionKey() {
+		return sessionKey;
+	}
+
+	public void setSessionKey(String sessionKey) {
+		this.sessionKey = sessionKey;
+	}
+
+	/** The bucket name used when no bucket is specified */
     public static final String DEFAULT_BUCKET = "vgl";
 
     /**

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -229,7 +229,8 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
 
         if(! TextUtil.isNullOrEmpty(arn)) {
             ContextBuilder builder = ContextBuilder.newBuilder("sts");
-            if(getAccessKey()!=null && getSecretKey()!=null) {
+            if(  (! TextUtil.isNullOrEmpty(getAccessKey())) && 
+            		(! TextUtil.isNullOrEmpty(getSecretKey()))) {
             	if(! TextUtil.isNullOrEmpty(getSessionKey())) {
             		SessionCredentials credentials = SessionCredentials.builder()
             			    .accessKeyId(getAccessKey())
@@ -273,7 +274,9 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
 
             ContextBuilder builder = ContextBuilder.newBuilder(getProvider()).overrides(properties);
 
-            if (getAccessKey() != null && getSecretKey() != null) {
+//            if (getAccessKey() != null && getSecretKey() != null) {
+            if(  (! TextUtil.isNullOrEmpty(getAccessKey())) && 
+            		(! TextUtil.isNullOrEmpty(getSecretKey()))) {
             	if(! TextUtil.isNullOrEmpty(getSessionKey())) {
             		SessionCredentials credentials = SessionCredentials.builder()
             			    .accessKeyId(getAccessKey())

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -273,9 +273,20 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
 
             ContextBuilder builder = ContextBuilder.newBuilder(getProvider()).overrides(properties);
 
-            if (getAccessKey() != null && getSecretKey() != null)
-                builder.credentials(getAccessKey(), getSecretKey());
+            if (getAccessKey() != null && getSecretKey() != null) {
+            	if(! TextUtil.isNullOrEmpty(getSessionKey())) {
+            		SessionCredentials credentials = SessionCredentials.builder()
+            			    .accessKeyId(getAccessKey())
+            			    .secretAccessKey(getSecretKey())
+            			    .sessionToken(getSessionKey())
+            			    .build();
 
+            		builder.credentialsSupplier(Suppliers.ofInstance(credentials));
+            	} else {
+            		builder.credentials(getAccessKey(), getSecretKey());
+            	}
+            }
+            
             if (this.getEndpoint() != null) {
                 builder.endpoint(this.getEndpoint());
             }

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -33,8 +33,9 @@ import org.jclouds.sts.STSApi;
 import org.jclouds.sts.domain.UserAndSessionCredentials;
 import org.jclouds.sts.options.AssumeRoleOptions;
 
-import com.google.common.base.Supplier;
-import com.google.common.io.Files;
+import com.shaded.google.common.base.Supplier;
+import com.shaded.google.common.io.Files;
+
 
 /**
  * Service for providing storage of objects (blobs) in a cloud using the JClouds library

--- a/src/main/java/org/auscope/portal/core/services/csw/CSWServiceItem.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/CSWServiceItem.java
@@ -26,6 +26,13 @@ public class CSWServiceItem {
     private boolean hideFromCatalogue = false;
 
     /**
+     * No arg constructor necessary for binding
+     */
+    public CSWServiceItem() {
+    	super();
+    }
+    
+    /**
      * Creates a new service item with NO role restrictions
      * 
      * @param id
@@ -108,6 +115,15 @@ public class CSWServiceItem {
     public String getServiceUrl() {
         return this.serviceUrl;
     }
+    
+    /**
+     * Set service URL
+     * 
+     * @param serviceUrl
+     */
+    public void setServiceUrl(String serviceUrl) {
+    	this.serviceUrl = serviceUrl;
+    }
 
     /**
      * The list of roles that a user must have at least one of to be authorised to see records from the CSW Service
@@ -119,6 +135,15 @@ public class CSWServiceItem {
     public String[] getRestrictedRoleList() {
         return this.restrictedRoleList;
     }
+    
+    /**
+     * Set restriced role list
+     * 
+     * @param restrictedRoleList
+     */
+    public void setRestrictedRoleList(String[] restrictedRoleList) {
+    	this.restrictedRoleList = restrictedRoleList;
+    }
 
     /**
      * Gets the descriptive title of this service item
@@ -128,6 +153,15 @@ public class CSWServiceItem {
     public String getTitle() {
         return this.title;
     }
+    
+    /**
+     * Set title
+     * 
+     * @param title
+     */
+    public void setTitle(String title) {
+    	this.title = title;
+    }
 
     /**
      * Gets the unique ID of this service item
@@ -136,6 +170,15 @@ public class CSWServiceItem {
      */
     public String getId() {
         return this.id;
+    }
+    
+    /**
+     * Set ID
+     * 
+     * @param id
+     */
+    public void setId(String id) {
+    	this.id = id;
     }
 
     /**
@@ -166,6 +209,15 @@ public class CSWServiceItem {
      */
     public String getRecordInformationUrl() {
         return recordInformationUrl;
+    }
+    
+    /**
+     * Set record information URL
+     * 
+     * @param recordInformationUrl
+     */
+    public void setRecordInformationUrl(String recordInformationUrl) {
+    	this.recordInformationUrl = recordInformationUrl;
     }
 
     @Override
@@ -307,6 +359,11 @@ public class CSWServiceItem {
         return this.noCache;
     }
 
+    /**
+     * Get default constraints
+     * 
+     * @return
+     */
     public String[] getDefaultConstraints() {
         return this.defaultConstraints;
     }

--- a/src/main/java/org/auscope/portal/core/services/responses/csw/CSWGetRecordResponse.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/csw/CSWGetRecordResponse.java
@@ -72,7 +72,7 @@ public class CSWGetRecordResponse {
         XPathExpression exprNextRecord = DOMUtil.compileXPathExpr(
                 "/csw:GetRecordsResponse/csw:SearchResults/@nextRecord", nc);
         XPathExpression exprRecordMetadata = DOMUtil.compileXPathExpr(
-                "/csw:GetRecordsResponse/csw:SearchResults/gmd:MD_Metadata", nc);
+                "/csw:GetRecordsResponse/csw:SearchResults/(gmd:MD_Metadata|gmi:MI_Metadata)", nc);
 
         Node node = (Node) exprRecordsMatched.evaluate(getRecordResponse, XPathConstants.NODE);
         if (node != null) {

--- a/src/test/java/org/auscope/portal/core/services/cloud/MockCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/MockCloudStorageService.java
@@ -14,7 +14,7 @@ public class MockCloudStorageService extends CloudStorageServiceJClouds {
     private BlobStoreContext mockBlobStoreContext;
 
     public MockCloudStorageService(BlobStoreContext mockBlobStoreContext) {
-        super(null,null,null);
+        super();
         this.mockBlobStoreContext=mockBlobStoreContext;
     }
 

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
@@ -24,7 +24,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Predicate;
+import com.shaded.google.common.base.Predicate;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableSet;
 

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -411,7 +411,7 @@ public class TestCloudStorageService extends PortalTestClass {
 
     @Test(expected=PortalServiceException.class)
     public void testStsRequired() throws PortalServiceException {
-        CloudStorageServiceJClouds stsService = new CloudStorageServiceJClouds("dummy1", "dummy2", "dummy3");
+        CloudStorageServiceJClouds stsService = new CloudStorageServiceJClouds();
         stsService.setStsRequirement(STSRequirement.Mandatory);
         stsService.getBlobStoreContext(null, null);
     }

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -33,7 +33,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.google.common.io.ByteSource;
+import com.shaded.google.common.io.ByteSource;
+
 
 public class TestCloudStorageService extends PortalTestClass {
     private final String bucket = "bucket-name";


### PR DESCRIPTION
* Added support for AWS session tokens.
* Now uses a shaded version of JClouds (was needed due to GeoDEVL project's use of Spring Boot that requires a later version of Google GSON that is incompatible with the one needed by JClouds).
* Support for both MD_Metadata and MI_Metadata.
* Added missing getters/setters and a no argument constructor to CSWServiceItem to allow data binding.