### PR TITLE
JClouds Keystone v3 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -489,7 +489,7 @@
         <dependency>
             <groupId>org.apache.jclouds</groupId>
             <artifactId>jclouds-all</artifactId>
-            <version>2.0.3-SHADED</version>
+            <version>2.1.2-SHADED</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
@@ -521,12 +521,12 @@
         <dependency>
           <groupId>org.pacesys</groupId>
           <artifactId>openstack4j-core</artifactId>
-          <version>2.0.3</version>
+          <version>3.2.0</version>
         </dependency>
         <dependency>
           <groupId>org.pacesys.openstack4j.connectors</groupId>
           <artifactId>openstack4j-httpclient</artifactId>
-          <version>2.0.3</version>
+          <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
@@ -36,6 +36,7 @@ import org.jclouds.openstack.nova.v2_0.compute.options.NovaTemplateOptions;
 import org.jclouds.openstack.nova.v2_0.domain.Image;
 import org.jclouds.openstack.nova.v2_0.features.ImageApi;
 import org.openstack4j.api.OSClient.OSClientV3;
+import org.openstack4j.model.common.Identifier;
 import org.openstack4j.openstack.OSFactory;
 
 import com.shaded.google.common.base.Predicate;
@@ -151,10 +152,11 @@ public class CloudComputeServiceNectar extends CloudComputeService {
     @SuppressWarnings("unchecked")
     public CloudComputeServiceNectar(String endpoint, String accessKey, String secretKey, String apiVersion) {
         super(ProviderType.NovaKeystone, endpoint, apiVersion);
+        this.endpoint = endpoint;
         this.accessKey = accessKey;
         this.secretKey = secretKey;
         
-        String[] accessParts = this.accessKey.split(":");        
+        String[] accessParts = this.accessKey.split(":");
         String projectName = accessParts[0];
         String userName = accessParts[1];
         String typeString = "openstack-nova";
@@ -163,13 +165,7 @@ public class CloudComputeServiceNectar extends CloudComputeService {
         overrides.put(KeystoneProperties.KEYSTONE_VERSION, "3");
         overrides.put(KeystoneProperties.SCOPE, "project:" + projectName);
         
-        // Logging
-        //Iterable<Module> modules = ImmutableSet.<Module>of(new SLF4JLoggingModule());        
-
         this.builder = ContextBuilder.newBuilder(typeString)
-                //.endpoint(endpoint)
-            	//.credentials("default:" + userName, secretKey)
-            	//.modules(modules)
                 .overrides(overrides);
         
         if(accessKey!=null && secretKey!=null)
@@ -190,7 +186,7 @@ public class CloudComputeServiceNectar extends CloudComputeService {
         if(!regions.isEmpty())
             region = regions.iterator().next();
         
-        this.imageApi = novaApi.getImageApi(region);        
+        this.imageApi = novaApi.getImageApi(region);
         this.context = builder.buildView(ComputeServiceContext.class);
         this.computeService = this.context.getComputeService();
         this.terminateFilter = Predicates.and(not(TERMINATED), not(RUNNING), inGroup(getGroupName()));
@@ -367,11 +363,13 @@ public class CloudComputeServiceNectar extends CloudComputeService {
         try {
             String[] accessParts = this.accessKey.split(":");
             String[] idParts = computeInstanceId.split("/");
+            
             //JClouds has no support (currently) for tailing server console output. Our current workaround
             //is to offload this to openstack4j.
             OSClientV3 os = OSFactory.builderV3()
             		.endpoint(endpoint)
-                    .credentials("default:" + accessParts[1], secretKey)
+            		.credentials(accessParts[1], secretKey, Identifier.byName("Default"))
+                    .scopeToProject(Identifier.byName(accessParts[0]), Identifier.byName("Default"))
                     .authenticate();
             return os.compute().servers().getConsoleOutput(idParts[1], numLines);
         } catch (Exception ex) {

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -221,14 +221,13 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
         properties.setProperty("jclouds.relax-hostname", relaxHostName ? "true" : "false");
         properties.setProperty("jclouds.strip-expect-header", stripExpectHeader ? "true" : "false");
 
-        
+        // Keystone v3 will require a few extra properties
         if(this.getEndpoint().contains("keystone") && this.getEndpoint().contains("v3")) {
-        	String[] accessParts = this.getAccessKey().split(":");
+            String[] accessParts = this.getAccessKey().split(":");
             String projectName = accessParts[0];
             properties.put(KeystoneProperties.KEYSTONE_VERSION, "3");
-        	properties.put(KeystoneProperties.SCOPE, "project:" + projectName);
+            properties.put(KeystoneProperties.SCOPE, "project:" + projectName);
         }
-
         
         Class<? extends BlobStoreContext> targetClass = BlobStoreContext.class;
         if (getRegionName() != null) {
@@ -240,7 +239,7 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
         }
 
         if(! TextUtil.isNullOrEmpty(arn)) {
-        	ContextBuilder builder = ContextBuilder.newBuilder("sts");
+            ContextBuilder builder = ContextBuilder.newBuilder("sts");
         	
             if(  (! TextUtil.isNullOrEmpty(getAccessKey())) && 
             		(! TextUtil.isNullOrEmpty(getSecretKey()))) {
@@ -259,7 +258,6 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
             }
 
             try (STSApi api = builder.buildApi(STSApi.class)) {
-            	
                 AssumeRoleOptions assumeRoleOptions = new AssumeRoleOptions().durationSeconds(3600)
                         .externalId(clientSecret);
                 final UserAndSessionCredentials credentials = api.assumeRole(arn, "vgl", assumeRoleOptions);
@@ -292,22 +290,22 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
             if(  (! TextUtil.isNullOrEmpty(getAccessKey())) && 
             		(! TextUtil.isNullOrEmpty(getSecretKey()))) {
             	if(! TextUtil.isNullOrEmpty(getSessionKey())) {
-            		SessionCredentials credentials = SessionCredentials.builder()
-            			    .accessKeyId(getAccessKey())
-            			    .secretAccessKey(getSecretKey())
-            			    .sessionToken(getSessionKey())
-            			    .build();
+                    SessionCredentials credentials = SessionCredentials.builder()
+                            .accessKeyId(getAccessKey())
+                            .secretAccessKey(getSecretKey())
+                            .sessionToken(getSessionKey())
+                            .build();
 
-            		builder.credentialsSupplier(Suppliers.ofInstance(credentials));
+                    builder.credentialsSupplier(Suppliers.ofInstance(credentials));
             	} else {
-            		String accessKey = getAccessKey();
-            		String secretKey = getSecretKey();
-            		if(this.getEndpoint().contains("keystone") && this.getEndpoint().contains("v3")) {
-                    	properties.put(KeystoneProperties.KEYSTONE_VERSION, "3");
-                    	String[] accessParts = this.getAccessKey().split(":");
+                    String accessKey = getAccessKey();
+                    String secretKey = getSecretKey();
+                    if(this.getEndpoint().contains("keystone") && this.getEndpoint().contains("v3")) {
+                        properties.put(KeystoneProperties.KEYSTONE_VERSION, "3");
+                        String[] accessParts = this.getAccessKey().split(":");
                         accessKey = "default:" + accessParts[1];
-            		}
-            		builder.credentials(accessKey, secretKey);
+                    }
+                    builder.credentials(accessKey, secretKey);
             	}
             }
             

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -481,8 +481,6 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
         String arn = job.getProperty(CloudJob.PROPERTY_STS_ARN);
         String clientSecret = job.getProperty(CloudJob.PROPERTY_CLIENT_SECRET);
         
-        System.out.println("uploadJobFiles: size: " + files.length + ", arn="+arn+", clientSecret=" + clientSecret);
-
         try {
             BlobStore bs = getBlobStore(arn, clientSecret);
 

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -413,6 +413,8 @@ public class TestCloudStorageService extends PortalTestClass {
     public void testStsRequired() throws PortalServiceException {
         CloudStorageServiceJClouds stsService = new CloudStorageServiceJClouds();
         stsService.setStsRequirement(STSRequirement.Mandatory);
+        stsService.setEndpoint("https://keystone.rc.nectar.org.au:5000/v3");
+        stsService.setAccessKey("Project:User");
         stsService.getBlobStoreContext(null, null);
     }
 


### PR DESCRIPTION
* Upgraded shaded JClouds to 2.1.2 for Keystone v3 compatibility.
* Updated cloud compute service and storage to use Keystone v3.