### PR TITLE
Use stored base key when listing job files

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -431,7 +431,7 @@ public class CloudStorageServiceJClouds extends CloudStorageService {
 
         try {
             BlobStore bs = getBlobStore(arn, clientSecret);
-            String baseKey = generateBaseKey(job);
+            String baseKey = jobToBaseKey(job);
 
             String bucketName = getBucket(job);
 


### PR DESCRIPTION
Use base key stored with job info when listing job files instead of constructing the base key anew each time. Currently fails if the hostname changes (e.g. if running in a docker container that is recreated or if replicated across multiple hosts behind a proxy).

Fixes the bug in https://jira.csiro.au/browse/AUS-3274, but not the potential for s3 bucket proliferation or leaking private hostnames into user AWS accounts.