### PR TITLE
Add WCS GetCapabilities v1.0.0 request/response

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/controllers/BaseCSWController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/BaseCSWController.java
@@ -1,13 +1,11 @@
 package org.auscope.portal.core.server.controllers;
 
-import java.net.URL;
 import java.util.*;
 import java.util.Map.Entry;
 
 import org.auscope.portal.core.services.Nagios4CachedService;
 import org.auscope.portal.core.services.PortalServiceException;
 import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
-import org.auscope.portal.core.services.responses.csw.CSWOnlineResourceImpl;
 import org.auscope.portal.core.services.responses.csw.CSWRecord;
 import org.auscope.portal.core.services.responses.nagios.ServiceStatusResponse;
 import org.auscope.portal.core.services.responses.nagios.ServiceStatusResponse.Status;

--- a/src/main/java/org/auscope/portal/core/server/controllers/WCSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WCSController.java
@@ -21,6 +21,7 @@ import org.auscope.portal.core.services.PortalServiceException;
 import org.auscope.portal.core.services.WCSService;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicBoundingBox;
 import org.auscope.portal.core.services.responses.wcs.DescribeCoverageRecord;
+import org.auscope.portal.core.services.responses.wcs.GetCapabilitiesRecord_1_0_0;
 import org.auscope.portal.core.services.responses.wcs.Resolution;
 import org.auscope.portal.core.services.responses.wcs.TimeConstraint;
 import org.auscope.portal.core.util.FileIOUtil;
@@ -335,10 +336,12 @@ public class WCSController extends BasePortalController {
      * @return
      */
     @RequestMapping("/describeCoverage.do")
-    public ModelAndView describeCoverage(String serviceUrl, String layerName) {
+    public ModelAndView describeCoverage(
+    		@RequestParam("serviceUrl") final String serviceUrl,
+    		@RequestParam("coverageName") final String coverageName) {
         DescribeCoverageRecord[] records = null;
         try {
-            records = wcsService.describeCoverage(serviceUrl, layerName);
+            records = wcsService.describeCoverage(serviceUrl, coverageName);
         } catch (Exception ex) {
             logger.error("Error describing coverage", ex);
             return generateJSONResponseMAV(false, null,
@@ -347,4 +350,25 @@ public class WCSController extends BasePortalController {
 
         return generateJSONResponseMAV(true, records, "");
     }
+    
+    /**
+     * Returns a WCS GetCapabilitiesRecord (v1.0.0) response.
+     * 
+     * @param serviceUrl the link the the GetCapabilities service.
+     * @return a WCS {@link GetCapabilitiesRecord_1_0_0} response as JSON.
+     */
+    @RequestMapping("/getWCSCapabilities.do")
+    public ModelAndView getCapabilities(
+    		@RequestParam("serviceUrl") final String serviceUrl) {
+    	GetCapabilitiesRecord_1_0_0 getCap = null;
+    	try {
+    		getCap = wcsService.getWcsCapabilities(serviceUrl);
+    	} catch(Exception ex) {
+    		logger.error("Error getting capabilities" , ex);
+    		return generateJSONResponseMAV(false, null,
+                    "Error occured whilst communicating to remote service: " + ex.getMessage());
+    	}
+    	return generateJSONResponseMAV(true, getCap, "");
+    }
+    
 }

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/CoverageOfferingBrief.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/CoverageOfferingBrief.java
@@ -1,0 +1,123 @@
+package org.auscope.portal.core.services.responses.wcs;
+
+import java.io.Serializable;
+import java.text.ParseException;
+
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+
+import org.auscope.portal.core.services.namespaces.WCSNamespaceContext;
+import org.auscope.portal.core.util.DOMUtil;
+import org.w3c.dom.DOMException;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class CoverageOfferingBrief implements Serializable {
+
+	private static final long serialVersionUID = 1545107506827553704L;
+	
+	private String name;
+	private String description;
+	private String label;
+	private SimpleEnvelope lonLatEnvelope;
+	private SimpleTimePosition[] timePositions;
+
+	public CoverageOfferingBrief(String name, String description, String label, SimpleEnvelope lonLatEnvelope,
+			SimpleTimePosition[] timePositions) {
+		this.name = name;
+		this.description = description;
+		this.label = label;
+		this.lonLatEnvelope = lonLatEnvelope;
+		this.timePositions = timePositions;
+	}
+	
+	/**
+	 * Construct a CoverageOfferingBrief from an XML CoverageOfferingBrief DOM Node
+	 * 
+	 * @param node the XML node
+	 * @throws XPathExpressionException
+	 * @throws ParseException 
+	 * @throws DOMException 
+	 */
+	public CoverageOfferingBrief(Node node) throws XPathExpressionException, DOMException, ParseException {
+		WCSNamespaceContext nc = new WCSNamespaceContext();
+		Node tempNode = null;
+		NodeList tempNodeList = null;
+        
+        tempNode = (Node)DOMUtil.compileXPathExpr("name").evaluate(node, XPathConstants.NODE);
+        name = getTextContentOrEmptyString(tempNode);
+        
+		tempNode = (Node)DOMUtil.compileXPathExpr("description").evaluate(node, XPathConstants.NODE);
+        description = getTextContentOrEmptyString(tempNode);
+
+        tempNode = (Node)DOMUtil.compileXPathExpr("label").evaluate(node, XPathConstants.NODE);
+        label = getTextContentOrEmptyString(tempNode);
+        
+        //Parse our spatial domain (currently only looking at lonLatEvelope)
+        tempNode = (Node) DOMUtil.compileXPathExpr("lonLatEnvelope").evaluate(node, XPathConstants.NODE);
+        if (tempNode != null) {
+            lonLatEnvelope = new SimpleEnvelope(tempNode, nc);
+            tempNodeList = (NodeList)DOMUtil.compileXPathExpr("gml:timePosition", nc).evaluate(tempNode, XPathConstants.NODESET);
+            timePositions = new SimpleTimePosition[tempNodeList.getLength()];
+            for (int i = 0; i < tempNodeList.getLength(); i++) {
+                timePositions[i] = new SimpleTimePosition(tempNodeList.item(i));
+            }
+        }
+	}
+	
+	/**
+     * Gets the text content or empty string.
+     *
+     * @param node
+     *            the node
+     * @return the text content or empty string
+     */
+    private static String getTextContentOrEmptyString(Node node) {
+        if (node != null) {
+            return node.getTextContent();
+        } else {
+            return "";
+        }
+    }
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public SimpleEnvelope getLonLatEnvelope() {
+		return lonLatEnvelope;
+	}
+
+	public void setLonLatEnvelope(SimpleEnvelope lonLatEnvelope) {
+		this.lonLatEnvelope = lonLatEnvelope;
+	}
+
+	public SimpleTimePosition[] getTimePositions() {
+		return timePositions;
+	}
+
+	public void setTimePositions(SimpleTimePosition[] timePositions) {
+		this.timePositions = timePositions;
+	}
+
+}

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/GetCapabilitiesRecord_1_0_0.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/GetCapabilitiesRecord_1_0_0.java
@@ -1,0 +1,128 @@
+package org.auscope.portal.core.services.responses.wcs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.auscope.portal.core.util.DOMUtil;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+/**
+ * Minimal response object for a WCS GetCapabilities request.
+ * 
+ * @author woo392
+ *
+ */
+public class GetCapabilitiesRecord_1_0_0 {
+	
+	private final Log log = LogFactory.getLog(getClass());
+	
+	// WCS Capabilities Map<capability_type, url> where capability_type = GetCapabilities, GetCoverage, DescribeCoverage etc.
+	Map<String, String> capabilities;
+	
+	// CoverageOfferingBriefs
+	CoverageOfferingBrief[] coverageOfferingBriefs;
+	
+	
+	private static final String EXTRACT_CAPABILITY_REQUESTS_EXPRESSION = "/WCS_Capabilities/Capability/Request";
+	// This expression is relative to the previous expression
+	private static final String EXTRACT_CAPABILITY_REQUEST_ONLINE_RESOURCES_EXPRESSION = "DCPType/HTTP/Get/OnlineResource/@href";
+	private static final String EXTRACT_COVERAGE_OFFERING_BRIEFS_EXPRESSION = "/WCS_Capabilities/ContentMetadata/CoverageOfferingBrief";
+	
+
+	public GetCapabilitiesRecord_1_0_0(InputStream inXml) throws SAXException, IOException, ParserConfigurationException {
+		try {
+			Document doc = DOMUtil.buildDomFromStream(inXml, false);
+			this.capabilities = getCapabilityRequests(doc);
+			this.coverageOfferingBriefs = getCoverageBriefs(doc);
+		} catch(SAXException e) {
+			log.error("Parsing error: " + e.getMessage());
+            throw e;
+		} catch(IOException e) {
+			log.error("IO error: " + e.getMessage());
+            throw e;
+		} catch (ParserConfigurationException e) {
+			log.error("Parser configuration error: " + e.getMessage());
+            throw e;
+		}
+	}
+	
+	/**
+	 * Parse WCS GetCapabilities XML document for capability requests.
+	 * 
+	 * @param doc the WCS GetCapabilities XML document
+	 * @return a Map of the capability requests <String(request), String(URL)>
+	 */
+	private Map<String, String> getCapabilityRequests(Document doc) {
+		Map<String, String> capabilityRequests = new HashMap<String, String>();
+        try {
+        	XPathFactory xpFactory = XPathFactory.newInstance();
+        	XPath xp = xpFactory.newXPath();
+        	NodeList requestNodes = (NodeList)xp.evaluate(EXTRACT_CAPABILITY_REQUESTS_EXPRESSION, doc, XPathConstants.NODE);
+        	for (int i = 0; i < requestNodes.getLength(); i++) {
+        		if(!requestNodes.item(i).getNodeName().toLowerCase().equals("#text")) {
+		        	String requestUrl = xp.evaluate(EXTRACT_CAPABILITY_REQUEST_ONLINE_RESOURCES_EXPRESSION, requestNodes.item(i));
+		        	capabilityRequests.put(requestNodes.item(i).getNodeName(), requestUrl);
+        		}
+        	}
+        } catch (XPathExpressionException e) {
+            log.error("GetCapabilities get capability requests xml parsing error: " + e.getMessage());
+        }
+        return capabilityRequests;
+    }
+	
+	/**
+	 * 
+	 * @param doc
+	 * @return
+	 */
+	private CoverageOfferingBrief[] getCoverageBriefs(Document doc) {
+		ArrayList<CoverageOfferingBrief> coverageOfferingsList = new ArrayList<CoverageOfferingBrief>();
+		try {
+			XPathFactory xpFactory = XPathFactory.newInstance();
+        	XPath xp = xpFactory.newXPath();
+        	NodeList requestNodes = (NodeList)xp.evaluate(EXTRACT_COVERAGE_OFFERING_BRIEFS_EXPRESSION, doc, XPathConstants.NODESET);
+        	for (int i = 0; i < requestNodes.getLength(); i++) {
+        		CoverageOfferingBrief cob = new CoverageOfferingBrief(requestNodes.item(i));
+        		coverageOfferingsList.add(cob);
+        	}
+		} catch(XPathExpressionException e) {
+			log.error("GetCapabilities get coverage offering briefs xml parsing error: " + e.getMessage());
+		} catch(ParseException pe) {
+			log.error("GetCapabilities get coverage offering parsing error: " + pe.getMessage());
+		}
+		CoverageOfferingBrief[] coverageOfferings = new CoverageOfferingBrief[coverageOfferingsList.size()];
+		coverageOfferings = coverageOfferingsList.toArray(coverageOfferings);
+		return coverageOfferings;
+	}
+	
+	public Map<String, String> getCapabilities() {
+		return capabilities;
+	}
+
+	public void setCapabilities(Map<String, String> capabilities) {
+		this.capabilities = capabilities;
+	}
+
+	public CoverageOfferingBrief[] getCoverageOfferingBriefs() {
+		return coverageOfferingBriefs;
+	}
+
+	public void setCoverageOfferingBriefs(CoverageOfferingBrief[] coverageOfferingBriefs) {
+		this.coverageOfferingBriefs = coverageOfferingBriefs;
+	}
+
+}

--- a/src/main/java/org/auscope/portal/core/services/responses/wcs/SimpleTimePosition.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/wcs/SimpleTimePosition.java
@@ -10,7 +10,8 @@ import org.w3c.dom.DOMException;
 import org.w3c.dom.Node;
 
 /**
- * Represents a simplified instance of the <gml:timePosition> element from a WCS DescribeCoverage response
+ * Represents a simplified instance of the <gml:timePosition> element from a
+ * WCS DescribeCoverage or GetCapabilities response
  * 
  * @author vot002
  *
@@ -31,11 +32,15 @@ public class SimpleTimePosition implements TemporalDomain {
     }
 
     public SimpleTimePosition(Node node) throws DOMException, ParseException {
-        DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-        df.setTimeZone(TimeZone.getTimeZone("GMT")); // assumption - Make everything GMT
-
-        timePosition = df.parse(node.getTextContent());
-
+        DateFormat df1 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+        df1.setTimeZone(TimeZone.getTimeZone("GMT")); // assumption - Make everything GMT
+        DateFormat df2 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+        df2.setTimeZone(TimeZone.getTimeZone("GMT")); // assumption - Make everything GMT
+        try {
+        	timePosition = df1.parse(node.getTextContent());
+        } catch(ParseException e) {
+        	timePosition = df2.parse(node.getTextContent());
+        }
         type = node.getLocalName();
     }
 }

--- a/src/main/resources/org/auscope/portal/core/test/responses/wcs/GetCapabilitiesResponse1.xml
+++ b/src/main/resources/org/auscope/portal/core/test/responses/wcs/GetCapabilitiesResponse1.xml
@@ -1,0 +1,88 @@
+<WCS_Capabilities xmlns="http://www.opengis.net/wcs"
+	xmlns:gml="http://www.opengis.net/gml"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://www.opengis.net/wcs http://schemas.opengis.net/wcs/1.0.0/wcsCapabilities.xsd"
+	version="1.0.0">
+	<Service>
+		<name>test_wcs_service</name>
+		<label>Test WCS Service</label>
+		<fees>NONE</fees>
+		<accessConstraints>NONE</accessConstraints>
+	</Service>
+	<Capability>
+		<Request>
+			<GetCapabilities>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource
+								xlink:href="http://test.org.au/ows/dea" />
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetCapabilities>
+			<DescribeCoverage>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource
+								xlink:href="http://test.org.au/ows/dea" />
+						</Get>
+					</HTTP>
+				</DCPType>
+			</DescribeCoverage>
+			<GetCoverage>
+				<DCPType>
+					<HTTP>
+						<Get>
+							<OnlineResource
+								xlink:href="http://test.org.au/ows/dea" />
+						</Get>
+					</HTTP>
+				</DCPType>
+			</GetCoverage>
+		</Request>
+		<Exception>
+			<Format>application/vnd.ogc.se_xml</Format>
+		</Exception>
+	</Capability>
+	<ContentMetadata>
+		<CoverageOfferingBrief>
+			<description>This is coverage offering 1</description>
+			<name>coverage_offering_1</name>
+			<label>Coverage Offering 1</label>
+			<lonLatEnvelope
+				srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
+				<gml:pos>-180.0 -90.0</gml:pos>
+				<gml:pos>180.0 90.0</gml:pos>
+				<gml:timePosition>1986-08-15T00:00:00.000Z</gml:timePosition>
+				<gml:timePosition>2019-09-16T00:00:00.000Z</gml:timePosition>
+			</lonLatEnvelope>
+		</CoverageOfferingBrief>
+		<CoverageOfferingBrief>
+			<description>This is coverage offering 2</description>
+			<name>coverage_offering_2</name>
+			<label>Coverage Offering 2</label>
+			<lonLatEnvelope
+				srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
+				<gml:pos>-180.0 -90.0</gml:pos>
+				<gml:pos>180.0 90.0</gml:pos>
+				<gml:timePosition>1986-08-15T00:00:00.000Z</gml:timePosition>
+				<gml:timePosition>2019-09-16T00:00:00.000Z</gml:timePosition>
+			</lonLatEnvelope>
+		</CoverageOfferingBrief>
+		<CoverageOfferingBrief>
+			<description>This is coverage offering 3</description>
+			<name>coverage_offering_3</name>
+			<label>Coverage Offering 3</label>
+			<lonLatEnvelope
+				srsName="urn:ogc:def:crs:OGC:1.3:CRS84">
+				<gml:pos>-180.0 -90.0</gml:pos>
+				<gml:pos>180.0 90.0</gml:pos>
+				<gml:timePosition>2016-10-31T23:59:59.000Z</gml:timePosition>
+				<gml:timePosition>2016-10-31T23:59:59.000Z</gml:timePosition>
+			</lonLatEnvelope>
+		</CoverageOfferingBrief>
+	</ContentMetadata>
+</WCS_Capabilities>

--- a/src/test/java/org/auscope/portal/core/services/responses/wcs/TestGetCapabilities.java
+++ b/src/test/java/org/auscope/portal/core/services/responses/wcs/TestGetCapabilities.java
@@ -1,0 +1,65 @@
+package org.auscope.portal.core.services.responses.wcs;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.text.ParseException;
+import java.util.Calendar;
+import java.util.Map;
+import java.util.TimeZone;
+
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPathExpressionException;
+
+import org.auscope.portal.core.services.responses.ows.OWSException;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.core.test.ResourceUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.w3c.dom.DOMException;
+import org.xml.sax.SAXException;
+
+
+public class TestGetCapabilities extends PortalTestClass {
+
+    @Test
+    public void parseTest1() throws IOException, ParserConfigurationException, SAXException, XPathExpressionException, DOMException, OWSException, ParseException {
+        final InputStream xmlStream = ResourceUtil
+                .loadResourceAsStream("org/auscope/portal/core/test/responses/wcs/GetCapabilitiesResponse1.xml");
+        GetCapabilitiesRecord_1_0_0 getCapRecord = new GetCapabilitiesRecord_1_0_0(xmlStream);
+        
+        Map<String, String> capabilities = getCapRecord.getCapabilities();
+        CoverageOfferingBrief[] coverageOfferings = getCapRecord.getCoverageOfferingBriefs();
+
+        Assert.assertNotNull(capabilities);
+        Assert.assertEquals(3, capabilities.size());
+        Assert.assertNotNull(coverageOfferings);
+        Assert.assertEquals(3, coverageOfferings.length);
+        
+        CoverageOfferingBrief cob = coverageOfferings[0];
+        Assert.assertEquals("coverage_offering_1", cob.getName());
+        Assert.assertEquals("This is coverage offering 1", cob.getDescription());
+        Assert.assertEquals("Coverage Offering 1", cob.getLabel());
+        
+        SimpleEnvelope envelope = cob.getLonLatEnvelope();
+        Assert.assertNotNull(envelope);
+        Assert.assertEquals("urn:ogc:def:crs:OGC:1.3:CRS84", envelope.getSrsName());
+        Assert.assertEquals(180.0, envelope.getEastBoundLongitude(), 0.000001);
+        Assert.assertEquals(-180.0, envelope.getWestBoundLongitude(), 0.000001);
+        Assert.assertEquals(90.0, envelope.getNorthBoundLatitude(), 0.000001);
+        Assert.assertEquals(-90.0, envelope.getSouthBoundLatitude(), 0.000001);
+        
+        SimpleTimePosition[] timePositions = cob.getTimePositions();
+        Assert.assertNotNull(timePositions);
+        Assert.assertEquals(2, timePositions.length);
+        SimpleTimePosition tp0 = timePositions[0];
+        SimpleTimePosition tp1 = timePositions[1];
+
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("GMT"));
+        cal.set(1986, 7, 15, 0, 0, 0);
+        Assert.assertEquals(cal.getTime().toString(), tp0.getTimePosition().toString());        
+        cal.set(2019, 8, 16, 0, 0, 0);
+        Assert.assertEquals(cal.getTime().toString(), tp1.getTimePosition().toString());
+    }
+
+}


### PR DESCRIPTION
* Added request to return minimal implementation of WCS GetCapabilities v1.0.0, currently returning capabilities map and CoverageOfferingBrief objects.
* Fixed missing RequestParameters in DescribeCoverage endpoint.
* Added a second date/time pattern to SimpleTimePosition so that date/times can specify milliseconds.