### PR TITLE
Merge VGL CSW search functionality into portal-core

### DIFF
--- a/src/main/java/org/auscope/portal/core/configuration/ServiceConfiguration.java
+++ b/src/main/java/org/auscope/portal/core/configuration/ServiceConfiguration.java
@@ -2,6 +2,10 @@ package org.auscope.portal.core.configuration;
 
 import java.util.List;
 
+import org.springframework.stereotype.Component;
+
+
+@Component
 public class ServiceConfiguration {
 
     List<ServiceConfigurationItem> serviceConfigurationItems;

--- a/src/main/java/org/auscope/portal/core/server/controllers/CSWCacheController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/CSWCacheController.java
@@ -1,0 +1,92 @@
+package org.auscope.portal.core.server.controllers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.auscope.portal.core.server.controllers.BaseCSWController;
+import org.auscope.portal.core.services.CSWCacheService;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.view.ViewCSWRecordFactory;
+import org.auscope.portal.core.view.ViewKnownLayerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * @version $Id: CSWCacheController.java 1863 2011-08-08 07:55:42Z JoshVote $
+ */
+@Controller
+public class CSWCacheController extends BaseCSWController {
+    private CSWCacheService cswService;
+
+    /**
+     * Constructor
+     * @param
+     */
+    @Autowired
+    public CSWCacheController(CSWCacheService cswService,
+                         ViewCSWRecordFactory viewCSWRecordFactory,
+                         ViewKnownLayerFactory viewKnownLayerFactory) {
+
+        super(viewCSWRecordFactory, viewKnownLayerFactory);
+        this.cswService = cswService;
+
+        cswService.updateCache();
+    }
+
+    /**
+     * This controller method returns a representation of each and every CSWRecord from the internal cache
+     * @throws Exception
+     */
+    @RequestMapping("/getCSWRecords.do")
+    public ModelAndView getCSWRecords() {
+        List<CSWRecord> records = null;
+        try {
+            records = this.cswService.getRecordCache();
+        } catch (Exception e) {
+            log.error(String.format("error getting data records: %1$s", e));
+            log.debug("Exception:", e);
+            return generateJSONResponseMAV(false, new CSWRecord[] {}, "Error getting data records");
+        }
+        return generateJSONResponseMAV(records.toArray(new CSWRecord[records.size()]));
+    }
+
+    /**
+     * This controller method is for forcing the internal cache of CSWRecords to invalidate and update.
+     * @return
+     */
+    @RequestMapping("/updateCSWCache.do")
+    public ModelAndView updateCSWCache() {
+        try {
+            this.cswService.updateCache();
+            return generateJSONResponseMAV(true);
+        } catch (Exception e) {
+            log.warn(String.format("Error updating CSW cache: %1$s", e));
+            log.debug("Exception:", e);
+            return generateJSONResponseMAV(false);
+        }
+    }
+
+    /**
+     * Requests every keyword as cached by
+     * @return
+     */
+    @RequestMapping("/getCSWKeywords.do")
+    public ModelAndView getCSWKeywords() {
+        Map<String, Set<CSWRecord>> keywords = this.cswService.getKeywordCache();
+
+        List<ModelMap> response = new ArrayList<>();
+        for (String keyword : keywords.keySet()) {
+            ModelMap modelMap = new ModelMap();
+            modelMap.put("keyword", keyword);
+            modelMap.put("count", keywords.get(keyword).size());
+            response.add(modelMap);
+        }
+
+        return generateJSONResponseMAV(true, response, "");
+    }
+}

--- a/src/main/java/org/auscope/portal/core/server/controllers/CSWSearchController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/CSWSearchController.java
@@ -1,0 +1,360 @@
+package org.auscope.portal.core.server.controllers;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
+import org.auscope.portal.core.server.controllers.BaseCSWController;
+import org.auscope.portal.core.services.CSWCacheService;
+import org.auscope.portal.core.services.CSWFilterService;
+import org.auscope.portal.core.services.LocalCSWFilterService;
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.WMSService;
+import org.auscope.portal.core.services.csw.CSWServiceItem;
+import org.auscope.portal.core.services.csw.SearchFacet;
+import org.auscope.portal.core.services.csw.SearchFacet.Comparison;
+import org.auscope.portal.core.services.methodmakers.filter.FilterBoundingBox;
+import org.auscope.portal.core.services.methodmakers.filter.csw.CSWGetDataRecordsFilter;
+import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
+import org.auscope.portal.core.services.responses.csw.CSWGetRecordResponse;
+import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource.OnlineResourceType;
+import org.auscope.portal.core.services.responses.csw.CSWOnlineResourceImpl;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.services.responses.search.FacetedMultiSearchResponse;
+import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord;
+import org.auscope.portal.core.services.responses.wms.GetCapabilitiesWMSLayerRecord;
+import org.auscope.portal.core.view.ViewCSWRecordFactory;
+import org.auscope.portal.core.view.ViewKnownLayerFactory;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.servlet.ModelAndView;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Controller for handling search requests for a remote CSW
+ * @author Josh Vote (CSIRO)
+ *
+ */
+@Controller
+public class CSWSearchController extends BaseCSWController {
+
+    private LocalCSWFilterService filterService;
+    private CSWCacheService cacheService;
+    private CSWFilterService cswFilterService;
+    private WMSService wmsService;
+
+    @Autowired
+    public CSWSearchController(ViewCSWRecordFactory viewCSWRecordFactory, ViewKnownLayerFactory viewKnownLayerFactory, LocalCSWFilterService filterService, CSWCacheService cacheService, WMSService wmsService, CSWFilterService cswFilterService) {
+        super(viewCSWRecordFactory, viewKnownLayerFactory);
+        this.filterService = filterService;
+        this.cacheService = cacheService;
+        this.wmsService = wmsService;
+        this.cswFilterService = cswFilterService;
+    }
+
+    @ResponseStatus(value =  org.springframework.http.HttpStatus.BAD_REQUEST)
+    public @ResponseBody String handleException(IllegalArgumentException ex) {
+        return ex.getMessage();
+    }
+
+    /**
+     * Returns the list of keywords available for searching at a particular registry
+     * @param serviceId
+     * @return
+     */
+    @RequestMapping("facetedKeywords.do")
+    public ModelAndView facetedKeywords(@RequestParam("serviceId") String[] serviceIds) {
+        final Set<String> keywords = new HashSet<String>();
+
+        for (String serviceId : serviceIds) {
+            Set<String> kwCache = this.cacheService.getKeywordsForEndpoint(serviceId);
+            if (kwCache != null) {
+                keywords.addAll(kwCache);
+            }
+        }
+
+        return generateJSONResponseMAV(true, keywords, "");
+    }
+
+    /**
+     * Parses and performs a faceted search on a CSW
+     * @param start 1 based index to start record search from
+     * @param limit
+     * @param serviceId
+     * @param rawFields A list of all fields to be searched on. Must match the other raw params in length.
+     * @param rawValues A list of all values to be searched against. Must match the other raw params in length.
+     * @param rawTypes A list of all value types to be searched on. Must match the other raw params in length.
+     * @param rawComparisons A list of all comparisons between field/value to be searched against. Must match the other raw params in length.
+     * @return
+     */
+    @RequestMapping("facetedCSWSearch.do")
+    public ModelAndView facetedCSWSearch(
+            @RequestParam(value="start", required=false, defaultValue="1") Integer[] starts,
+            @RequestParam(value="limit", required=false, defaultValue="10") Integer limit,
+            @RequestParam("serviceId") String[] serviceIds,
+            @RequestParam(value="field", required=false) String[] rawFields,
+            @RequestParam(value="value", required=false) String[] rawValues,
+            @RequestParam(value="type", required=false) String[] rawTypes,
+            @RequestParam(value="comparison", required=false) String[] rawComparisons) {
+
+        if (rawFields == null) {
+            rawFields = new String[0];
+        }
+
+        if (rawValues == null) {
+            rawValues = new String[0];
+        }
+
+        if (rawTypes == null) {
+            rawTypes = new String[0];
+        }
+
+        if (rawComparisons == null) {
+            rawComparisons = new String[0];
+        }
+
+        if (rawFields.length != rawValues.length || rawFields.length != rawTypes.length || rawFields.length != rawComparisons.length) {
+            throw new IllegalArgumentException("field/value/type/comparison lengths mismatch");
+        }
+
+        if (limit > 20) {
+            throw new IllegalArgumentException("Limit too high (max 20)");
+        }
+
+        //if start Id's are not specified, assume they are all 1
+        if (starts == null || starts.length == 0) {
+            starts = new Integer[serviceIds.length];
+            Arrays.fill(starts, 1);
+        }
+
+        //Build our mapping between service ids and start indexes
+        if (starts.length != serviceIds.length) {
+            throw new IllegalArgumentException("start/serviceId lengths mismatch");
+        }
+        Map<String, Integer> startIndexes = new HashMap<String, Integer>();
+        for (int i = 0; i < starts.length; i++) {
+            startIndexes.put(serviceIds[i], starts[i]);
+        }
+
+        //Parse our raw request info into a list of search facets
+        List<SearchFacet<? extends Object>> facets = new ArrayList<SearchFacet<? extends Object>>();
+        for (int i = 0; i < rawFields.length; i++) {
+            Comparison cmp = null;
+            switch(rawComparisons[i]) {
+            case "gt":
+                cmp = Comparison.GreaterThan;
+                break;
+            case "lt":
+                cmp = Comparison.LessThan;
+                break;
+            case "eq":
+                cmp = Comparison.Equal;
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown comparison type: " + rawComparisons[i]);
+            }
+
+            SearchFacet<? extends Object> newFacet = null;
+            switch(rawTypes[i]) {
+            case "servicetype":
+                newFacet = new SearchFacet<OnlineResourceType>(Enum.valueOf(OnlineResourceType.class, rawValues[i]), rawFields[i], cmp);
+                break;
+            case "bbox":
+                JSONObject jsonValue = JSONObject.fromObject(rawValues[i]);
+                FilterBoundingBox bbox = FilterBoundingBox.parseFromValues("WGS:84", jsonValue.getDouble("northBoundLatitude"), jsonValue.getDouble("southBoundLatitude"), jsonValue.getDouble("eastBoundLongitude"), jsonValue.getDouble("westBoundLongitude"));
+
+                if (bbox == null) {
+                    throw new IllegalArgumentException("Unable to parse bounding box");
+                }
+
+                newFacet = new SearchFacet<FilterBoundingBox>(bbox, rawFields[i], cmp);
+                break;
+            case "date":
+                DateTime value = new DateTime(Long.parseLong(rawValues[i]));
+                newFacet = new SearchFacet<DateTime>(value, rawFields[i], cmp);
+                break;
+            case "string":
+                newFacet = new SearchFacet<String>(rawValues[i], rawFields[i], cmp);
+                break;
+            }
+
+            facets.add(newFacet);
+        }
+
+        //Make our request and then convert the records for transport to the view
+        FacetedMultiSearchResponse response;
+        try {
+            response = filterService.getFilteredRecords(serviceIds, facets, startIndexes, limit);
+            workaroundMissingNCIMetadata(response.getRecords());
+        } catch (Exception ex) {
+            log.error("Unable to filter records from remote service", ex);
+            return generateJSONResponseMAV(false);
+        }
+
+        List<ModelMap> viewRecords = new ArrayList<ModelMap>(response.getRecords().size());
+        for (CSWRecord record : response.getRecords()) {
+            viewRecords.add(viewCSWRecordFactory.toView(record));
+        }
+        int recordsMatched = 0;
+        for(int serviceCount : response.getRecordsMatched().values()) {
+        	recordsMatched += serviceCount;
+        }
+        ModelMap mm = new ModelMap();
+        mm.put("startIndexes", response.getStartIndexes());
+        mm.put("nextIndexes", response.getNextIndexes());
+        mm.put("records", viewRecords);
+        mm.put("recordsMatched", recordsMatched);
+
+        return generateJSONResponseMAV(true, mm, "");
+    }
+    
+    /**
+     * gets csw record information based on file identifier and service id
+     * @param fileIdentifier
+     * @param serviceId
+     * @return
+     */
+    @RequestMapping("/getCSWRecord.do")
+    public ModelAndView getCSWRecord(
+            @RequestParam(value = "fileIdentifier") String fileIdentifier,
+            @RequestParam(value = "serviceId") String serviceId) {
+    	
+    	int startPosition = 1;
+    	int maxRecords = 100;    	
+    	CSWGetDataRecordsFilter filter = new CSWGetDataRecordsFilter();
+    	filter.setFileIdentifier(fileIdentifier);
+        List<CSWRecord> records = null;
+        int matchedResults = 0;
+        try {
+                CSWGetRecordResponse response = null;
+                response = cswFilterService.getFilteredRecords(serviceId, filter, maxRecords, startPosition);
+                workaroundMissingNCIMetadata(response.getRecords());
+                records = response.getRecords();
+                matchedResults = response.getRecordsMatched();
+                return generateJSONResponseMAV(records.toArray(new CSWRecord[records.size()]), matchedResults);
+        } catch (Exception ex) {
+            log.warn(String.format("Error fetching filtered records for filter '%1$s'", filter), ex);
+            return generateJSONResponseMAV(false, null, "Error fetching filtered records");
+        }
+    }
+    
+
+    private boolean nameIsRewriteCandidate(String name) {
+        return name.equalsIgnoreCase("Link to Web Map Service") ||
+               name.equalsIgnoreCase("Link to Web Coverage Service") ||
+               name.contains("S for dataset ") ||
+               name.equals("WCS") ||
+               name.equals("WMS");
+    }
+
+    /**
+     * This is a workaround to address Online Resource "name" metadata lacking in records coming from NCI/GA.
+     *
+     *  Currently we receive a number of records where the Online Resource "name" element comes in the form
+     *     + WCS for dataset UUID
+     *     + WMS for dataset UUID
+     *     + NCSS for dataset UUID
+     *
+     *  This is unhelpful and forces us to actually go back to the THREDDS instance for more info.
+     *
+     *  This method iterates the supplied records, searches for the above pattern in online resources and rewrites the online
+     *  resources (using WMS GetCapabilities requests) if found. It will be assumed that all online resources matching the pattern
+     *  can be rewritten to have the same layer/coverage/variable names.
+     * @param records
+     * @throws PortalServiceException
+     */
+    private void workaroundMissingNCIMetadata(List<CSWRecord> records) {
+        for (CSWRecord record : records) {
+            //Firstly figure out whether there are one or more "bad resources". We identify a bad resource
+            //as a WMS with a name matching the pattern
+            AbstractCSWOnlineResource layerNameSource = null;
+            for (AbstractCSWOnlineResource wmsOr : record.getOnlineResourcesByType(OnlineResourceType.WMS)) {
+                if (nameIsRewriteCandidate(wmsOr.getName())) {
+                    layerNameSource = wmsOr;
+                    break;
+                }
+            }
+            if (layerNameSource == null) {
+                continue;
+            }
+
+            //Now find our WMS resource that we will use to lookup all the layer/coverage/variable names
+            List<String> layerNames = new ArrayList<String>();
+            try {
+                GetCapabilitiesRecord getCap = wmsService.getWmsCapabilities(layerNameSource.getLinkage().toString(), "1.3.0");
+                for (GetCapabilitiesWMSLayerRecord layer : getCap.getLayers()) {
+                    String name = layer.getName().trim();
+                    if (!StringUtils.isEmpty(name)) {
+                        layerNames.add(layer.getName());
+                    }
+                }
+            } catch (Exception ex) {
+                log.error("Unable to retrieve WMS capabilities. metadata will not be rewritten: " + ex.getMessage());
+                log.debug("Exception:", ex);
+                continue;
+            }
+
+            //Now seperate our online resources into those being rewritten and those being saved
+            List<AbstractCSWOnlineResource> resourcesToSave = new ArrayList<AbstractCSWOnlineResource>();
+            for (AbstractCSWOnlineResource or : record.getOnlineResources()) {
+                switch (or.getType()) {
+                case WCS:
+                case WMS:
+                case NCSS:
+                    if (!nameIsRewriteCandidate(or.getName())) {
+                        resourcesToSave.add(or);
+                        break;
+                    }
+
+                    for (String layerName : layerNames) {
+                        resourcesToSave.add(new CSWOnlineResourceImpl(or.getLinkage(), or.getProtocol(), layerName, or.getDescription()));
+                    }
+
+                    break;
+                default:
+                    resourcesToSave.add(or);
+                }
+            }
+
+            record.setOnlineResources(resourcesToSave.toArray(new AbstractCSWOnlineResource[resourcesToSave.size()]));
+        }
+    }
+
+    /**
+     * Gets a list of CSWServiceItem objects that the portal is using for sources of CSWRecords.
+     *
+     * @return
+     */
+    @RequestMapping("/getFacetedCSWServices.do")
+    public ModelAndView getCSWServices() {
+        List<ModelMap> convertedServiceItems = new ArrayList<ModelMap>();
+
+        //Simplify our service items for the view
+        for (CSWServiceItem item : this.filterService.getCSWServiceItems()) {
+            //VT: skip the loop if we intend to hide this from catalogue.
+            if (item.getHideFromCatalogue()) {
+                continue;
+            }
+            ModelMap map = new ModelMap();
+
+            map.put("title", item.getTitle());
+            map.put("id", item.getId());
+            map.put("url", item.getServiceUrl());
+            convertedServiceItems.add(map);
+        }
+
+        return generateJSONResponseMAV(true, convertedServiceItems, "");
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/LocalCSWFilterService.java
+++ b/src/main/java/org/auscope/portal/core/services/LocalCSWFilterService.java
@@ -1,0 +1,462 @@
+package org.auscope.portal.core.services;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.auscope.portal.core.services.CSWFilterService;
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.csw.CSWServiceItem;
+import org.auscope.portal.core.services.csw.SearchFacet;
+import org.auscope.portal.core.services.methodmakers.filter.FilterBoundingBox;
+import org.auscope.portal.core.services.methodmakers.filter.csw.CSWGetDataRecordsFilter;
+import org.auscope.portal.core.services.methodmakers.filter.csw.CSWGetDataRecordsFilter.KeywordMatchType;
+import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource.OnlineResourceType;
+import org.auscope.portal.core.services.responses.csw.CSWGetRecordResponse;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.services.responses.search.FacetedMultiSearchResponse;
+import org.auscope.portal.core.services.responses.search.FacetedSearchResponse;
+import org.joda.time.DateTime;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * An wrapper around CSWFilterService that allows local/client side
+ * filtering at the expense of a more limited API (no pagination)
+ * and slower performance.
+ * @author Josh Vote (CSIRO)
+ *
+ */
+@Service
+public class LocalCSWFilterService {
+
+    public static final int DEFAULT_PAGE_SIZE = 100;
+
+    private CSWFilterService filterService;
+    private final Log log = LogFactory.getLog(getClass());
+    private int pageSize = DEFAULT_PAGE_SIZE;
+    private Executor executor;
+
+    @Autowired
+    public LocalCSWFilterService(CSWFilterService filterService, Executor executor) {
+        this.filterService = filterService;
+        this.executor = executor;
+    }
+
+    /**
+     * The amount of records requested from a CSW in a batch for filtering operations. This is always static
+     * as local filtering means that we can't ever know how many we'll need. Defaults to DEFAULT_PAGE_SIZE
+     * @param pageSize
+     */
+    public int getPageSize() {
+        return pageSize;
+    }
+
+    /**
+     * The amount of records requested from a CSW in a batch for filtering operations. This is always static
+     * as local filtering means that we can't ever know how many we'll need. Defaults to DEFAULT_PAGE_SIZE
+     * @param pageSize
+     */
+    public void setPageSize(int pageSize) {
+        this.pageSize = pageSize;
+    }
+
+    /**
+     * Iterates facets and for each item either a) Adds the facet to remoteFilter or b) returns the facet in the return list for use
+     * in a local filter later.
+     * @param facets
+     * @param remoteFilter
+     * @return
+     */
+    private List<SearchFacet<? extends Object>> seperateFacets(List<SearchFacet<? extends Object>> facets, CSWGetDataRecordsFilter remoteFilter) {
+        List<SearchFacet<? extends Object>> localFacets = new ArrayList<SearchFacet<? extends Object>>();
+        for (SearchFacet<? extends Object> facet : facets) {
+            switch(facet.getField()) {
+            case "anytext":
+                remoteFilter.setAnyText((String)facet.getValue());
+                break;
+            case "bbox":
+                remoteFilter.setSpatialBounds((FilterBoundingBox)facet.getValue());
+                break;
+            case "keyword":
+                String kw = (String)facet.getValue();
+                String[] keywords = ArrayUtils.add(remoteFilter.getKeywords(), kw);
+                remoteFilter.setKeywords(keywords);
+                remoteFilter.setKeywordMatchType(KeywordMatchType.All);
+                break;
+            case "datefrom":
+                remoteFilter.setModifiedDateFrom((DateTime)facet.getValue());
+                break;
+            case "dateto":
+                remoteFilter.setModifiedDateTo((DateTime)facet.getValue());
+                break;
+            default:
+                localFacets.add(facet);
+                break;
+            }
+        }
+        return localFacets;
+    }
+
+    /**
+     * Tests a CSWRecord against a given search facet
+     * @param record
+     * @param facet
+     * @return true if the record passes the facet.
+     */
+    private boolean recordPassesSearchFacet(CSWRecord record, SearchFacet<? extends Object> facet) {
+        switch(facet.getField()) {
+        case "servicetype":
+            OnlineResourceType type = (OnlineResourceType) facet.getValue();
+            return record.getOnlineResourcesByType(type).length > 0;
+        default:
+            log.error("Unable to local filter on field: " + facet.getField());
+            return false;
+        }
+    }
+
+    /**
+     * Enumerates CSWRecords from source testing each against the search facets. Any passing record is copied to sink.
+     * @param source
+     * @param sink
+     * @param facets
+     * @param maxRecords At most this many records will be copied
+     * @return The 0 based index of the LAST examined record from source or -1
+     */
+    private int performLocalFilter(List<CSWRecord> source, List<CSWRecord> sink, List<SearchFacet<? extends Object>> facets, int maxRecords) {
+        int lastIndex = -1;
+        int recordsCopied = 0;
+
+        for (int i = 0; i < source.size(); i++) {
+            CSWRecord record = source.get(i);
+            lastIndex = i;
+            boolean allPassing = true;
+            for (SearchFacet<? extends Object> facet : facets) {
+                if (!recordPassesSearchFacet(record, facet)) {
+                    allPassing = false;
+                    break;
+                }
+            }
+
+            if (allPassing) {
+                sink.add(record);
+                if (++recordsCopied >= maxRecords) {
+                    break;
+                }
+            }
+        }
+
+        return lastIndex;
+    }
+
+    /**
+     * Given a specific service to query with a set of local/remote search facets. Perform a full filter until maxRecords are received or the remote CSW runs out of records. This can result
+     * in many calls to the remote CSW if the local portion of the filter is quite specific and the remote portion of very permissive.
+     * @param serviceId
+     * @param facets
+     * @param startIndex
+     * @param maxRecords
+     * @return
+     * @throws PortalServiceException
+     */
+    public FacetedSearchResponse getFilteredRecords(String serviceId, List<SearchFacet<? extends Object>> facets, int startIndex, int maxRecords) throws PortalServiceException {
+        //Build our remote filter and keep track of what facets need to be done locally
+        CSWGetDataRecordsFilter remoteFilter = new CSWGetDataRecordsFilter();
+        List<SearchFacet<? extends Object>> localFacets = seperateFacets(facets, remoteFilter);
+
+        //Keep getting pages of data until we serve up enough records
+        FacetedSearchResponse result = new FacetedSearchResponse();
+        result.setStartIndex(startIndex);
+        result.setRecords(new ArrayList<CSWRecord>(maxRecords));
+        int recordsRemaining, currentStartIndex = startIndex;
+        int recordsMatched = 0;
+        while((recordsRemaining = (maxRecords - result.getRecords().size())) > 0) {
+
+            //If we are dealing with a purely remote filter we can just request the exact number of records
+            int recsToRequest = this.pageSize;
+            if (localFacets.size() == 0) {
+                recsToRequest = Math.min(this.pageSize, recordsRemaining);
+            }
+
+            //If this starts spamming requests we can always look at upping the page size every iteration.
+            CSWGetRecordResponse cswResponse = filterService.getFilteredRecords(serviceId, remoteFilter, recsToRequest, currentStartIndex);
+            
+            // Update macthed record count
+            recordsMatched = cswResponse.getRecordsMatched();
+
+            //Filter our response and copy passing records to our result list
+            int lastIndex;
+            if (localFacets.size() == 0) {
+                result.getRecords().addAll(cswResponse.getRecords());
+                lastIndex = cswResponse.getRecords().size() - 1;
+            } else {
+                lastIndex = performLocalFilter(cswResponse.getRecords(), result.getRecords(), localFacets, recordsRemaining);
+            }
+
+            if (lastIndex < 0) {
+                //If we got an empty response then we are done.
+                result.setNextIndex(0);
+                break;
+            } else {
+                currentStartIndex += lastIndex + 1;
+                result.setNextIndex(currentStartIndex);
+            }
+
+            //If there are no more records to retrieve, abort early
+            if (cswResponse.getNextRecord() <= 0) {
+                result.setNextIndex(0);
+                break;
+            }
+        }
+        result.setRecordsMatched(recordsMatched);
+        return result;
+    }
+
+    /**
+     * Notifies all runners to terminate if they haven't already. Returns the count of the runner with the MOST records
+     * @param allRunners
+     * @return
+     * @throws PortalServiceException
+     */
+    private int cleanupConcurrentFilteredRecords(ArrayList<FilterRunner> allRunners, Object lock) throws PortalServiceException {
+        int maxDepth = -1;
+        synchronized(lock) {
+            for (FilterRunner runner : allRunners) {
+                if (runner.error != null) {
+                    log.error("Error accessing CSW records from service " + runner.serviceId + " : " + runner.error.getMessage());
+                    log.debug("Exception", runner.error);
+                }
+
+                if (runner.state != FilterRunnerState.Terminated) {
+                    synchronized(runner) {
+                        runner.requestTerminate = true;
+                        runner.notifyAll();
+                    }
+                }
+
+                if (runner.records.size() > maxDepth) {
+                    maxDepth = runner.records.size();
+                }
+            }
+        }
+
+        return maxDepth;
+    }
+
+    /**
+     * Given a set of services to query with a set of local/remote search facets. Perform a full filter until maxRecords are received or the remote CSW runs out of records. This can result
+     * in many calls to the remote CSW if the local portion of the filter is quite specific and the remote portion of very permissive.
+     *
+     * In order to fulfill the multiple registries, maxRecords will be shared between the various serviceIds. If a registry is unable to fulfill their portion of the records then their portion
+     * will be handed off to the other services for fulfillment.
+     *
+     * The result set will be interleaved so that the records will be returned CSW1, CSW2, CS3, CS1, CSW2 etc..
+     *
+     * This method is synchronous but utilises the internal executor to concurrently call multiple services
+     *
+     * @param serviceIds
+     * @param facets
+     * @param startIndexes
+     * @param maxRecords
+     * @return
+     * @throws PortalServiceException
+     */
+    public FacetedMultiSearchResponse getFilteredRecords(String[] serviceIds, List<SearchFacet<? extends Object>> facets, Map<String, Integer> startIndexes, int maxRecords) throws PortalServiceException {
+        //Distribute our max records evenly across the service Ids (this will only be a suggested amount, we may need to redistribute)
+        HashMap<String, Integer> fulfillment = new HashMap<String, Integer>();
+        for (int i = 0; i < serviceIds.length; i++) {
+            int fulfillmentCount = maxRecords / serviceIds.length;
+            if (i < maxRecords % serviceIds.length) {
+                fulfillmentCount++;
+            }
+            fulfillment.put(serviceIds[i], fulfillmentCount);
+        }
+
+        //Fire off our requests concurrently
+        HashMap<String, FilterRunner> runners = new HashMap<String, FilterRunner>();
+        Object lock = runners; //this doubles as our lock object for this request
+        for (String serviceId : serviceIds) {
+            FilterRunner runner = new FilterRunner(this, serviceId, fulfillment.get(serviceId), facets, startIndexes.get(serviceId), lock);
+            runners.put(serviceId, runner);
+            this.executor.execute(runner);
+        }
+        ArrayList<FilterRunner> allRunners = new ArrayList<FilterRunner>(runners.values());
+
+        //Check our runner statuses repeatedly, waking up when they tell us to
+        while(true) {
+            //Check our state inside the lock so don't end up with the state changing underneath us
+            synchronized(lock) {
+                boolean stillWaiting = false;
+                for (FilterRunner runner : allRunners) {
+                    if (!runner.isFulfilled() &&
+                        runner.state != FilterRunnerState.Terminated) {
+                        //A running unfulfilled runner requires us to wait for it to finish
+                        stillWaiting = true;
+                    } else if (!runner.isFulfilled() &&
+                               runner.state == FilterRunnerState.Terminated) {
+                        //Redistribute remaining fulfillment to other runners/services if we have a
+                        //service run dry of records
+                        int remainingFulfillment = runner.currentFulfillment - runner.records.size();
+                        runner.currentFulfillment = runner.records.size();
+                        ArrayList<FilterRunner> availRunners = new ArrayList<FilterRunner>();
+                        for (FilterRunner availRunner : allRunners) {
+                            if (availRunner.state != FilterRunnerState.Terminated) {
+                                availRunners.add(availRunner);
+                            }
+                        }
+
+                        if (!availRunners.isEmpty()) {
+                            stillWaiting = true;
+                            for (int i = 0; i < availRunners.size(); i++) {
+                                int additionalFulfillment = remainingFulfillment / availRunners.size();
+                                if (i < remainingFulfillment % availRunners.size()) {
+                                    additionalFulfillment++;
+                                }
+
+                                FilterRunner availRunner = availRunners.get(i);
+                                synchronized(availRunner) {
+                                    availRunner.currentFulfillment += additionalFulfillment;
+                                    availRunner.notifyAll();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                if (!stillWaiting) {
+                    break;
+                }
+
+                try {
+                    lock.wait();
+                } catch (InterruptedException e) {
+                    log.error("Interrupted:", e);
+                    cleanupConcurrentFilteredRecords(allRunners, lock);
+                    throw new PortalServiceException("Interrupted:", e);
+                }
+            }
+        }
+
+        //Cleanup runners, check for errors
+        int maxDepth = cleanupConcurrentFilteredRecords(allRunners, lock);
+
+        //Build our response object from the finished runner states (also cleanup our runners if some are paused)
+        //make sure we interleave the results "fairly"
+        FacetedMultiSearchResponse response = new FacetedMultiSearchResponse();
+        for (int depth = 0; depth < maxDepth && response.getRecords().size() < maxRecords; depth++) {
+            for (FilterRunner runner : allRunners) {
+                if (depth < runner.records.size()) {
+                    response.getRecords().add(runner.records.get(depth));
+                    response.getRecordsMatched().put(runner.serviceId, runner.recordsMatched);
+                    if (response.getRecords().size() == maxRecords) {
+                        break;
+                    }
+                }
+            }
+        }
+        for (FilterRunner runner : allRunners) {
+            response.getNextIndexes().put(runner.serviceId, runner.currentNextIndex);
+            response.getStartIndexes().put(runner.serviceId, runner.currentStartIndex);
+        }
+
+        return response;
+    }
+
+    /**
+     * Returns the list of internal CSWServiceItems that powers this service (passes straight through to underlying CSWFilterService
+     *
+     * @return
+     */
+    public CSWServiceItem[] getCSWServiceItems() {
+        return filterService.getCSWServiceItems();
+    }
+
+    private enum FilterRunnerState {
+        Running,
+        Terminated
+    }
+
+    /**
+     * Handles calling getFilteredRecords on a seperate thread. If the underlying CSW runs out of records, this will terminate. If
+     * the request for records is fulfilled then this will instead pause using Object.wait(). Notify at the parent level
+     * to trigger an updated request for fulfillment.
+     * @author Josh Vote (CSIRO)
+     *
+     */
+    private class FilterRunner implements Runnable {
+
+        private final Log log = LogFactory.getLog(getClass());
+
+        public Object lock;
+        public LocalCSWFilterService parent;
+        public String serviceId;
+        public int currentFulfillment;
+        public List<SearchFacet<? extends Object>> facets;
+        public int currentStartIndex;
+        public int currentNextIndex;
+        public int recordsMatched;
+        public FilterRunnerState state;
+        public List<CSWRecord> records;
+        public volatile boolean requestTerminate = false;
+        public Throwable error;
+
+        public FilterRunner(LocalCSWFilterService parent, String serviceId, int currentFulfillment,
+                List<SearchFacet<? extends Object>> facets, int currentStartIndex, Object lock) {
+            super();
+            this.parent = parent;
+            this.serviceId = serviceId;
+            this.currentFulfillment = currentFulfillment;
+            this.facets = facets;
+            this.currentStartIndex = currentStartIndex;
+            this.currentNextIndex = currentStartIndex;
+            this.recordsMatched = 0;
+            this.state = FilterRunnerState.Running;
+            this.records = new ArrayList<CSWRecord>();
+            this.lock = lock;
+        }
+
+        public boolean isFulfilled() {
+            return this.records.size() >= this.currentFulfillment;
+        }
+
+        public void run() {
+            try {
+                while(!requestTerminate) {
+                    if (isFulfilled()) {
+                        synchronized(this) {
+                            this.wait(); //wait for the parent to notify this to look for more due to an increase in fulfillment
+                        }
+                    } else {
+                        FacetedSearchResponse response = parent.getFilteredRecords(serviceId, facets, currentNextIndex, currentFulfillment - this.records.size());
+                        synchronized(this.lock) {
+                            this.records.addAll(response.getRecords());
+                            this.currentNextIndex =  response.getNextIndex();
+                            this.recordsMatched = response.getRecordsMatched();
+
+                            if (response.getNextIndex() <= 0) {
+                                //Having no more records means it's pointless to continue hitting this CSW
+                                break;
+                            } else {
+                                this.lock.notifyAll();
+                            }
+                        }
+                    }
+                }
+            } catch (Throwable e) {
+                log.error("Unable to access filtered records: " + e.getMessage());
+                log.debug("Exception", e);
+                this.error = e;
+            }
+
+            synchronized(this.lock) {
+                this.state = FilterRunnerState.Terminated;
+                this.lock.notifyAll(); //notify parent that we finished
+            }
+        }
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/csw/GriddedCSWRecord.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/GriddedCSWRecord.java
@@ -1,0 +1,45 @@
+package org.auscope.portal.core.services.csw;
+
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+
+/**
+ * An extension to the CSWRecord that adds additional gridded data information
+ * specific to Geoscience Australia.
+ * 
+ * @author Josh Vote
+ *
+ */
+public class GriddedCSWRecord extends CSWRecord {
+
+    private GriddedDataPositionalAccuracy[] griddedInfo;
+    private String dateStamp;
+    
+    public GriddedCSWRecord(String fileIdentifier) {
+        super(fileIdentifier);
+    }
+
+    /**
+     * Positional accuracy information about this CSWRecord
+     * @return
+     */
+    public GriddedDataPositionalAccuracy[] getGriddedInfo() {
+        return griddedInfo;
+    }
+
+    /**
+     * Positional accuracy information about this CSWRecord
+     * @param griddedInfo
+     */
+    public void setGriddedInfo(GriddedDataPositionalAccuracy[] griddedInfo) {
+        this.griddedInfo = griddedInfo;
+    }
+
+    public String getDateStamp() {
+        return dateStamp;
+    }
+
+    public void setDateStamp(String dateStamp) {
+        this.dateStamp = dateStamp;
+    }    
+    
+}

--- a/src/main/java/org/auscope/portal/core/services/csw/GriddedCSWRecordTransformer.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/GriddedCSWRecordTransformer.java
@@ -1,0 +1,50 @@
+package org.auscope.portal.core.services.csw;
+
+import javax.xml.xpath.XPathExpressionException;
+
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.services.responses.csw.CSWRecordTransformer;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * CSWRecord parser that also considers
+ * @author Josh Vote
+ *
+ */
+public class GriddedCSWRecordTransformer extends CSWRecordTransformer {
+
+    public GriddedCSWRecordTransformer() throws PortalServiceException {
+        super();
+    }
+    
+    public GriddedCSWRecordTransformer(Node mdMetadataNode)  {
+        super(mdMetadataNode);
+    }
+    
+    @Override
+    public CSWRecord transformToCSWRecord() throws XPathExpressionException {
+        //Parse basic information
+        GriddedCSWRecord cswRecord = new GriddedCSWRecord(null);
+        super.transformToCSWRecord(cswRecord);
+        
+        //Extract Date as a string
+        cswRecord.setDateStamp(evalXPathString(this.mdMetadataNode, "gmd:dateStamp/gco:DateTime"));
+        
+        //Extract gridded positional data
+        NodeList posAccuracyEls = evalXPathNodeList(this.mdMetadataNode, "gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:report/gmd:DQ_GriddedDataPositionalAccuracy");
+        GriddedDataPositionalAccuracy[] posAccuracyObjs = new GriddedDataPositionalAccuracy[posAccuracyEls.getLength()];
+        for (int i = 0; i < posAccuracyEls.getLength(); i++) {
+            posAccuracyObjs[i] = new GriddedDataPositionalAccuracy();
+            
+            posAccuracyObjs[i].setNameOfMeasure(evalXPathString(posAccuracyEls.item(i), "gmd:nameOfMeasure/gco:CharacterString"));
+            posAccuracyObjs[i].setUnitOfMeasure(evalXPathString(posAccuracyEls.item(i), "gmd:result/gmd:DQ_QuantitativeResult/gmd:valueUnit/gml:UnitDefinition/gml:identifier"));
+            posAccuracyObjs[i].setValue(evalXPathString(posAccuracyEls.item(i), "gmd:result/gmd:DQ_QuantitativeResult/gmd:value/gco:Record"));
+        }
+        cswRecord.setGriddedInfo(posAccuracyObjs);
+        
+        return cswRecord;
+    }
+
+}

--- a/src/main/java/org/auscope/portal/core/services/csw/GriddedCSWRecordTransformerFactory.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/GriddedCSWRecordTransformerFactory.java
@@ -1,0 +1,31 @@
+package org.auscope.portal.core.services.csw;
+
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.responses.csw.CSWRecordTransformer;
+import org.auscope.portal.core.services.responses.csw.CSWRecordTransformerFactory;
+import org.w3c.dom.Node;
+
+public class GriddedCSWRecordTransformerFactory extends
+        CSWRecordTransformerFactory {
+    /**
+     * Creates a new instance of GriddedCSWRecordTransformer which will draw from the specified
+     * gmd:MD_Metadata Node representation as a template
+     * @param mdMetadataNode
+     * @return
+     */
+    @Override
+    public CSWRecordTransformer newCSWRecordTransformer(Node mdMetadataNode) {
+        return new GriddedCSWRecordTransformer(mdMetadataNode);
+    }
+    
+    /**
+     * Creates a new instance of GriddedCSWRecordTransformer and generates an empty document that will be
+     * used for constructing DOM.
+     * @return
+     * @throws PortalServiceException 
+     */
+    @Override
+    public CSWRecordTransformer newCSWRecordTransformer() throws PortalServiceException  {
+        return new GriddedCSWRecordTransformer();
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/csw/GriddedDataPositionalAccuracy.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/GriddedDataPositionalAccuracy.java
@@ -1,0 +1,41 @@
+package org.auscope.portal.core.services.csw;
+
+/**
+ * Highly simplified version of a DQ_GriddedDataPositionalAccuracy element
+ * @author Josh Vote
+ *
+ */
+public class GriddedDataPositionalAccuracy {
+    private String nameOfMeasure;
+    private String unitOfMeasure;
+    private String value;
+    
+    
+    public GriddedDataPositionalAccuracy() {
+        super();
+    }
+    
+    public String getNameOfMeasure() {
+        return nameOfMeasure;
+    }
+    
+    public void setNameOfMeasure(String nameOfMeasure) {
+        this.nameOfMeasure = nameOfMeasure;
+    }
+    
+    public String getUnitOfMeasure() {
+        return unitOfMeasure;
+    }
+    
+    public void setUnitOfMeasure(String unitOfMeasure) {
+        this.unitOfMeasure = unitOfMeasure;
+    }
+    
+    public String getValue() {
+        return value;
+    }
+    
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/csw/SearchFacet.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/SearchFacet.java
@@ -1,0 +1,46 @@
+package org.auscope.portal.core.services.csw;
+
+/**
+ * Represents a typed search that can be applied to a CSW service.
+ * @author Josh Vote (CSIRO)
+ *
+ * @param <T>
+ */
+public class SearchFacet<T> {
+
+    public enum Comparison {
+        GreaterThan,
+        LessThan,
+        Equal
+    }
+
+    private T value;
+    private String field;
+    private Comparison comparison;
+
+    public SearchFacet(T value, String field, Comparison comparison) {
+        super();
+        this.value = value;
+        this.field = field;
+        this.comparison = comparison;
+    }
+
+    public T getValue() {
+        return value;
+    }
+    public void setValue(T value) {
+        this.value = value;
+    }
+    public String getField() {
+        return field;
+    }
+    public void setField(String field) {
+        this.field = field;
+    }
+    public Comparison getComparison() {
+        return comparison;
+    }
+    public void setComparison(Comparison comparison) {
+        this.comparison = comparison;
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/csw/ViewGriddedCSWRecordFactory.java
+++ b/src/main/java/org/auscope/portal/core/services/csw/ViewGriddedCSWRecordFactory.java
@@ -1,0 +1,30 @@
+package org.auscope.portal.core.services.csw;
+
+import java.util.Arrays;
+
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.view.ViewCSWRecordFactory;
+import org.springframework.ui.ModelMap;
+
+/**
+ * Similar to ViewCSWRecordFactory but with the expectation of a GriddedCSWRecord instead
+ * of a CSWRecord
+ * @author Josh Vote
+ *
+ */
+public class ViewGriddedCSWRecordFactory extends ViewCSWRecordFactory {
+    
+    @Override
+    public ModelMap toView(CSWRecord record) {
+        ModelMap map = super.toView(record);
+        
+        ModelMap extensions = new ModelMap();
+        
+        extensions.put("griddedInfo", Arrays.asList(((GriddedCSWRecord) record).getGriddedInfo()));
+        extensions.put("dateStamp", ((GriddedCSWRecord) record).getDateStamp());
+        
+        map.put("extensions", extensions);
+        
+        return map;
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/responses/search/FacetedMultiSearchResponse.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/search/FacetedMultiSearchResponse.java
@@ -1,0 +1,89 @@
+package org.auscope.portal.core.services.responses.search;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+
+/**
+ * Represents a response from multiple faceted search requests.
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public class FacetedMultiSearchResponse implements Serializable {
+	private static final long serialVersionUID = -615570404768745749L;
+	
+	private List<CSWRecord> records;
+    private Map<String, Integer> startIndexes;
+    private Map<String, Integer> nextIndexes;
+    private Map<String, Integer> recordsMatched;
+
+    public FacetedMultiSearchResponse() {
+        super();
+        this.records = new ArrayList<CSWRecord>();
+        this.startIndexes = new HashMap<String, Integer>();
+        this.nextIndexes = new HashMap<String, Integer>();
+        this.setRecordsMatched(new HashMap<String, Integer>());
+    }
+    /**
+     * The CSWRecords parsed from the CSW response
+     * @return
+     */
+    public List<CSWRecord> getRecords() {
+        return records;
+    }
+    /**
+     * The CSWRecords parsed from the CSW response
+     * @param records
+     */
+    public void setRecords(List<CSWRecord> records) {
+        this.records = records;
+    }
+    /**
+     * The first record index where searching started keyed by service id
+     * @return
+     */
+    public Map<String, Integer> getStartIndexes() {
+        return startIndexes;
+    }
+    /**
+     * The first record index where searching started keyed by service id
+     * @param startIndexes
+     */
+    public void setStartIndexes(Map<String, Integer> startIndexes) {
+        this.startIndexes = startIndexes;
+    }
+    /**
+     * The index of the last record index + 1 keyed by service id
+     * @return
+     */
+    public Map<String, Integer> getNextIndexes() {
+        return nextIndexes;
+    }
+    /**
+     * The index of the last record index + 1 keyed by service id
+     * @param nextIndexes
+     */
+    public void setNextIndexes(Map<String, Integer> nextIndexes) {
+        this.nextIndexes = nextIndexes;
+    }
+    
+    /**
+     * The total number of records matched for the search by service id
+     * @return
+     */
+	public Map<String, Integer> getRecordsMatched() {
+		return recordsMatched;
+	}
+	
+	/**
+	 * The total number of records matched for the search by service id
+	 * @param recordsMatched
+	 */
+	public void setRecordsMatched(Map<String, Integer> recordsMatched) {
+		this.recordsMatched = recordsMatched;
+	}
+}

--- a/src/main/java/org/auscope/portal/core/services/responses/search/FacetedSearchResponse.java
+++ b/src/main/java/org/auscope/portal/core/services/responses/search/FacetedSearchResponse.java
@@ -1,0 +1,82 @@
+package org.auscope.portal.core.services.responses.search;
+
+import java.io.Serializable;
+import java.util.List;
+
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+
+/**
+ * Represents a response from a faceted search request.
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public class FacetedSearchResponse implements Serializable {
+	private static final long serialVersionUID = 3321276637339015960L;
+	
+	private List<CSWRecord> records;
+    private int startIndex;
+    private int nextIndex;
+    private int recordsMatched;
+
+    /**
+     * The CSWRecords parsed from the CSW response
+     * @return
+     */
+    public List<CSWRecord> getRecords() {
+        return records;
+    }
+    /**
+     * The CSWRecords parsed from the CSW response
+     * @param records
+     */
+    public void setRecords(List<CSWRecord> records) {
+        this.records = records;
+    }
+    /**
+     * The first record index where searching started (not necessarily the same index as records[0])
+     * @return
+     */
+    public int getStartIndex() {
+        return startIndex;
+    }
+
+    /**
+     * The first record index where searching started (not necessarily the same index as records[0])
+     */
+    public void setStartIndex(int startIndex) {
+        this.startIndex = startIndex;
+    }
+    /**
+     * The index of the last record index + 1 (or 0 if there are no more records)
+     * @return
+     */
+    public int getNextIndex() {
+        return nextIndex;
+    }
+
+    /**
+     * The index of the last record index + 1 (or 0 if there are no more records)
+     * @param nextIndex
+     */
+    public void setNextIndex(int nextIndex) {
+        this.nextIndex = nextIndex;
+    }
+    
+    /**
+     * The total number of records matched by the faceted search
+     * @return
+     */
+	public int getRecordsMatched() {
+		return recordsMatched;
+	}
+	
+	/**
+	 * The total number of records matched by the faceted search
+	 * @param recordsMatched
+	 */
+	public void setRecordsMatched(int recordsMatched) {
+		this.recordsMatched = recordsMatched;
+	}
+
+
+}

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestCSWCacheController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestCSWCacheController.java
@@ -1,0 +1,209 @@
+package org.auscope.portal.core.server.controllers;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
+import org.auscope.portal.core.services.CSWCacheService;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.test.ByteBufferedServletOutputStream;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.core.view.ViewCSWRecordFactory;
+import org.auscope.portal.core.view.ViewKnownLayerFactory;
+import org.jmock.Expectations;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * User: Mathew Wyatt
+ * Date: 27/08/2009.
+ *
+ * @version $Id$
+ */
+public class TestCSWCacheController extends PortalTestClass {
+
+    /** The Constant SUCCESSJSON. */
+    private static final String SUCCESSJSON = "success";
+
+    /** The mock csw service. */
+    private CSWCacheService mockCSWService = context.mock(CSWCacheService.class);
+
+    /** The mock http request. */
+    private HttpServletRequest mockHttpRequest = context.mock(HttpServletRequest.class);
+
+    /** The mock http response. */
+    private HttpServletResponse mockHttpResponse = context.mock(HttpServletResponse.class);
+
+    /** The mock view csw record factory. */
+    private ViewCSWRecordFactory mockViewCSWRecordFactory = context.mock(ViewCSWRecordFactory.class);
+
+    /** The mock view known layer factory. */
+    private ViewKnownLayerFactory mockViewKnownLayerFactory = context.mock(ViewKnownLayerFactory.class);
+
+    /** The mock csw record1. */
+    private CSWRecord mockCSWRecord1 = context.mock(CSWRecord.class, "mockCSWRecord1");
+
+    /** The mock csw record2. */
+    private CSWRecord mockCSWRecord2 = context.mock(CSWRecord.class, "mockCSWRecord2");
+
+    /** The csw controller. */
+    private CSWCacheController cswController;
+
+    /**
+     * Setup.
+     */
+    @Before
+    public void setUp() {
+        context.checking(new Expectations() {{
+            oneOf(mockCSWService).updateCache();
+        }});
+
+        cswController = new CSWCacheController(mockCSWService, mockViewCSWRecordFactory, mockViewKnownLayerFactory);
+    }
+
+    private String renderMav(ModelAndView mav) throws Exception {
+        final ByteBufferedServletOutputStream rawResponse = new ByteBufferedServletOutputStream(1024 * 200);
+        context.checking(new Expectations() {
+            {
+                allowing(mockHttpResponse).setContentType(with(any(String.class)));
+                allowing(mockHttpResponse).setCharacterEncoding(with(any(String.class)));
+                allowing(mockHttpResponse).addHeader(with(any(String.class)), with(any(String.class)));
+                allowing(mockHttpResponse).getOutputStream();will(returnValue(rawResponse));
+
+                allowing(mockHttpRequest).getParameter(with(any(String.class)));will(returnValue(null));
+                allowing(mockHttpRequest).getAttribute(with(any(String.class)));will(returnValue(null));
+            }
+        });
+        mav.getView().render(mav.getModel(), mockHttpRequest, mockHttpResponse);
+
+        return rawResponse.getStream().toString("UTF-8");
+    }
+
+    /**
+     * Test get record response_ success.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testGetRecordResponse_Success() throws Exception {
+        ModelMap viewCSWRecord1 = new ModelMap();
+        ModelMap viewCSWRecord2 = new ModelMap();
+
+        viewCSWRecord1.put("rec1", "val1");
+        viewCSWRecord2.put("rec2", "val2");
+
+        context.checking(new Expectations() {{
+            oneOf(mockCSWService).getRecordCache();
+            will(returnValue(Arrays.asList(mockCSWRecord1, mockCSWRecord2)));
+
+            oneOf(mockViewCSWRecordFactory).toView(mockCSWRecord1);
+            will(returnValue(viewCSWRecord1));
+            oneOf(mockViewCSWRecordFactory).toView(mockCSWRecord2);
+            will(returnValue(viewCSWRecord2));
+        }});
+
+        //Run the method, get our response rendered as a JSONObject
+        ModelAndView mav = cswController.getCSWRecords();
+        String json = renderMav(mav);
+        JSONObject jsonObj = JSONObject.fromObject(json);
+
+        //Check our response contains useful info...
+        Assert.assertEquals(true, jsonObj.getBoolean(SUCCESSJSON));
+        JSONArray records = jsonObj.getJSONArray("data");
+        Assert.assertNotNull(records);
+        Assert.assertEquals(2, records.size());
+
+        JSONObject jsonRec1 = records.getJSONObject(0);
+        JSONObject jsonRec2 = records.getJSONObject(1);
+
+        Assert.assertEquals("val1", jsonRec1.get("rec1"));
+        Assert.assertEquals("val2", jsonRec2.get("rec2"));
+    }
+
+    /**
+     * Test get record response_ transform error.
+     *
+     * @throws Exception the exception
+     */
+    @Test
+    public void testGetRecordResponse_TransformError() throws Exception {
+        ModelMap viewCSWRecord1 = new ModelMap();
+        ModelMap viewCSWRecord2 = new ModelMap();
+
+        viewCSWRecord1.put("rec1", "val1");
+        viewCSWRecord2.put("rec2", "val2");
+
+        context.checking(new Expectations() {{
+            oneOf(mockCSWService).getRecordCache();
+            will(returnValue(Arrays.asList(mockCSWRecord1, mockCSWRecord2)));
+
+            oneOf(mockViewCSWRecordFactory).toView(mockCSWRecord1);
+            will(returnValue(viewCSWRecord1));
+            oneOf(mockViewCSWRecordFactory).toView(mockCSWRecord2);
+            will(throwException(new Exception()));
+        }});
+
+        //Run the method, get our response rendered as a JSONObject
+        ModelAndView mav = cswController.getCSWRecords();
+        String json = renderMav(mav);
+        JSONObject jsonObj = JSONObject.fromObject(json);
+
+        //Check our response contains useful info...
+        Assert.assertEquals(false, jsonObj.getBoolean(SUCCESSJSON));
+        JSONArray records = (JSONArray)jsonObj.get("data");
+        Assert.assertNotNull(records);
+        Assert.assertEquals(0, records.size());
+    }
+
+    /**
+     * Tests that the underlying services are called correctly and the response
+     * is transformed into an appropriate format.
+     */
+    @Test
+    public void testGetKeywords() {
+        Map<String, Set<CSWRecord>> expectedKeywords = new HashMap<>();
+        expectedKeywords.put("keyword1", new HashSet<>(Arrays.asList(new CSWRecord("a"), new CSWRecord("b"))));
+        expectedKeywords.put("keyword1", new HashSet<>(Arrays.asList(new CSWRecord("c"), new CSWRecord("b"), new CSWRecord("a"))));
+
+        ModelMap kw1 = new ModelMap();
+        kw1.put("keyword", "keyword1");
+        kw1.put("count", 2);
+        ModelMap kw2 = new ModelMap();
+        kw2.put("keyword", "keyword2");
+        kw2.put("count", 3);
+
+        context.checking(new Expectations() {{
+            oneOf(mockCSWService).getKeywordCache();
+            will(returnValue(expectedKeywords));
+        }});
+
+        ModelAndView mav = cswController.getCSWKeywords();
+        Assert.assertNotNull(mav);
+        Assert.assertTrue((Boolean)mav.getModel().get(SUCCESSJSON));
+
+        @SuppressWarnings("unchecked")
+        final
+        List<ModelMap> data = (List<ModelMap>) mav.getModel().get("data");
+        Assert.assertEquals(expectedKeywords.size(), data.size());
+        for (ModelMap kwResponse : data) {
+
+            String keyword = (String) kwResponse.get("keyword");
+            Integer count = (Integer)kwResponse.get("count");
+
+            Assert.assertEquals(expectedKeywords.get(keyword).size(), count.intValue());
+        }
+    }
+
+}

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestCSWSearchController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestCSWSearchController.java
@@ -1,0 +1,139 @@
+package org.auscope.portal.core.server.controllers;
+
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.auscope.portal.core.server.controllers.CSWSearchController;
+import org.auscope.portal.core.services.CSWCacheService;
+import org.auscope.portal.core.services.CSWFilterService;
+import org.auscope.portal.core.services.LocalCSWFilterService;
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.WMSService;
+import org.auscope.portal.core.services.responses.csw.CSWOnlineResourceImpl;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.services.responses.search.FacetedMultiSearchResponse;
+import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord;
+import org.auscope.portal.core.services.responses.wms.GetCapabilitiesWMSLayerRecord;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.core.view.ViewCSWRecordFactory;
+import org.auscope.portal.core.view.ViewKnownLayerFactory;
+import org.jmock.Expectations;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.ui.ModelMap;
+import org.springframework.web.servlet.ModelAndView;
+
+/**
+ * Unit tests for CSWSearchController
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public class TestCSWSearchController extends PortalTestClass {
+    private CSWCacheService mockCSWService = context.mock(CSWCacheService.class);
+    private LocalCSWFilterService mockFilterService = context.mock(LocalCSWFilterService.class);
+    private WMSService mockWmsService = context.mock(WMSService.class);
+    private CSWFilterService mockCswFilterService = context.mock(CSWFilterService.class);
+
+    private CSWSearchController controller;
+
+    /**
+     * Setup.
+     */
+    @Before
+    public void setUp() {
+        context.checking(new Expectations() {{
+
+        }});
+
+        controller = new CSWSearchController(new ViewCSWRecordFactory(), new ViewKnownLayerFactory(), mockFilterService, mockCSWService, mockWmsService, mockCswFilterService);
+    }
+
+    private <T, U> Map<T, U> singleKeyMap(T key, U value) {
+        HashMap<T,U> newMap = new HashMap<T,U>();
+        newMap.put(key, value);
+        return newMap;
+    }
+
+    /**
+     * Tests rewriting a record with a bad WMS will result the rewrite getting skipped and not crashing the entire search.
+     *
+     * @throws Exception the exception
+     */
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testBadWMSGetCap() throws Exception {
+        final Integer[] start = new Integer[] {1};
+        final Integer limit = 2;
+        final String[] serviceId = new String[] {"service-id-value"};
+        final String newName = "new-layer-name";
+        final String[] rawFields = new String[] {};
+        final String[] rawValues = new String[] {};
+        final String[] rawTypes = new String[] {};
+        final String[] rawComparisons = new String[] {};
+
+        CSWRecord rec1 = new CSWRecord("aaa");
+        CSWRecord rec2 = new CSWRecord("bbb");
+
+        rec1.setOnlineResources(new CSWOnlineResourceImpl[] {new CSWOnlineResourceImpl(new URL("http://example.com/wms1"), "OGC:WMS", "Link to Web Map Service", "description"),
+                                                             new CSWOnlineResourceImpl(new URL("http://example.com/wcs1"), "OGC:WCS", "Link to Web Coverage Service", "description")});
+        rec2.setOnlineResources(new CSWOnlineResourceImpl[] {new CSWOnlineResourceImpl(new URL("http://example.com/wms2"), "OGC:WMS", "Link to Web Map Service", "description"),
+                                                             new CSWOnlineResourceImpl(new URL("http://example.com/wcs2"), "OGC:WCS", "Link to Web Coverage Service", "description")});
+
+        final FacetedMultiSearchResponse response = new FacetedMultiSearchResponse();
+        response.setNextIndexes(singleKeyMap(serviceId[0], -1));
+        response.setStartIndexes(singleKeyMap(serviceId[0], start[0]));
+        response.setRecords(Arrays.asList(rec1, rec2));
+
+        final GetCapabilitiesRecord mockGetCap = context.mock(GetCapabilitiesRecord.class);
+        final GetCapabilitiesWMSLayerRecord mockGetCapLayer = context.mock(GetCapabilitiesWMSLayerRecord.class);
+
+        context.checking(new Expectations() {{
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)), with(any(List.class)), with(any(Map.class)), with(equal(limit)));
+            will(returnValue(response));
+
+            oneOf(mockWmsService).getWmsCapabilities(with(equal("http://example.com/wms1")), with(any(String.class)));
+            will(throwException(new PortalServiceException("pretend error")));
+
+            oneOf(mockWmsService).getWmsCapabilities(with(equal("http://example.com/wms2")), with(any(String.class)));
+            will(returnValue(mockGetCap));
+
+            allowing(mockGetCap).getLayers();
+            will(returnValue(new ArrayList<GetCapabilitiesWMSLayerRecord>(Arrays.asList(mockGetCapLayer))));
+
+            allowing(mockGetCapLayer).getName();
+            will(returnValue("new-layer-name"));
+        }});
+
+        ModelAndView mav = controller.facetedCSWSearch(start, limit, serviceId, rawFields, rawValues, rawTypes, rawComparisons);
+
+        Assert.assertTrue((Boolean) mav.getModelMap().get("success"));
+        Assert.assertNotNull(mav.getModelMap().get("data"));
+
+        ModelMap data = (ModelMap) mav.getModelMap().get("data");
+        Assert.assertEquals(1, ((Map) data.get("startIndexes")).get(serviceId[0]));
+        Assert.assertEquals(-1, ((Map) data.get("nextIndexes")).get(serviceId[0]));
+
+        List<ModelMap> recs = (List<ModelMap>) data.get("records");
+
+        Assert.assertEquals(2, recs.size());
+
+        List<Map<String, Object>> rec1Resources = (List<Map<String, Object>>) recs.get(0).get("onlineResources");
+        List<Map<String, Object>> rec2Resources = (List<Map<String, Object>>) recs.get(1).get("onlineResources");
+        Assert.assertNotNull(rec1Resources);
+        Assert.assertEquals(2, rec1Resources.size());
+        Assert.assertNotNull(rec2Resources);
+        Assert.assertEquals(2, rec2Resources.size());
+
+        Assert.assertEquals("Link to Web Map Service", rec1Resources.get(0).get("name"));
+        Assert.assertEquals("Link to Web Coverage Service", rec1Resources.get(1).get("name"));
+
+        Assert.assertEquals(newName, rec2Resources.get(0).get("name"));
+        Assert.assertEquals(newName, rec2Resources.get(1).get("name"));
+    }
+
+}

--- a/src/test/java/org/auscope/portal/core/services/TestLocalCSWFilterService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestLocalCSWFilterService.java
@@ -1,0 +1,736 @@
+package org.auscope.portal.core.services;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.auscope.portal.core.services.CSWFilterService;
+import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.csw.SearchFacet;
+import org.auscope.portal.core.services.csw.SearchFacet.Comparison;
+import org.auscope.portal.core.services.methodmakers.filter.FilterBoundingBox;
+import org.auscope.portal.core.services.methodmakers.filter.csw.CSWGetDataRecordsFilter.KeywordMatchType;
+import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
+import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource.OnlineResourceType;
+import org.auscope.portal.core.services.responses.csw.CSWGetRecordResponse;
+import org.auscope.portal.core.services.responses.csw.CSWOnlineResourceImpl;
+import org.auscope.portal.core.services.responses.csw.CSWRecord;
+import org.auscope.portal.core.services.responses.search.FacetedMultiSearchResponse;
+import org.auscope.portal.core.services.responses.search.FacetedSearchResponse;
+import org.auscope.portal.core.test.BasicThreadExecutor;
+import org.auscope.portal.core.test.PortalTestClass;
+import org.auscope.portal.core.test.jmock.CSWGetDataRecordsFilterMatcher;
+import org.jmock.Expectations;
+import org.jmock.Sequence;
+import org.joda.time.DateTime;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit tests for the filtering at LocalCSWFilterService
+ * @author Josh Vote (CSIRO)
+ *
+ */
+public class TestLocalCSWFilterService extends PortalTestClass {
+
+    private CSWFilterService mockFilterService = context.mock(CSWFilterService.class);
+    private CSWGetRecordResponse mockResponse1 = context.mock(CSWGetRecordResponse.class, "mockResponse1");
+    private CSWGetRecordResponse mockResponse2 = context.mock(CSWGetRecordResponse.class, "mockResponse2");
+    private CSWGetRecordResponse mockResponse3 = context.mock(CSWGetRecordResponse.class, "mockResponse3");
+    private LocalCSWFilterService localFilterService;
+    private BasicThreadExecutor executor;
+
+    @Before
+    public void setup() {
+        executor = new BasicThreadExecutor();
+        localFilterService = new LocalCSWFilterService(mockFilterService, executor);
+    }
+
+    @After
+    public void teardown() throws InterruptedException {
+        executor.getExecutorService().shutdown();
+        executor.getExecutorService().awaitTermination(5000, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Ensures our remote filter only requests the bare minimum number of records (while also respecting page size)
+     * @throws Exception
+     */
+    @Test
+    public void testRemoteFilter() throws Exception {
+        final String serviceId = "service-id";
+        final FilterBoundingBox bbox = new FilterBoundingBox("WGS:84", new double[] {-10.0,  -10.0}, new double[] {10.0,  10.0});
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<FilterBoundingBox>(bbox, "bbox", Comparison.Equal),
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal),
+                new SearchFacet<DateTime>(new DateTime(0l), "datefrom", Comparison.GreaterThan),
+                new SearchFacet<DateTime>(new DateTime(1000l), "dateto", Comparison.LessThan));
+
+        final int startIndex = 1;
+        final int maxRecords = 3;
+        final int pageSize = 2;
+
+        localFilterService.setPageSize(pageSize);
+
+        context.checking(new Expectations() {{
+            //Request a full page initially
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                                                        with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                                                        with(equal(pageSize)),
+                                                        with(equal(startIndex)));
+            will(returnValue(mockResponse1));
+
+            allowing(mockResponse1).getNextRecord();will(returnValue(3));
+            allowing(mockResponse1).getRecordsMatched();will(returnValue(4));
+            allowing(mockResponse1).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("rec1"), new CSWRecord("rec2"))));
+
+            //one remaining record to get on the second request (despite 2 being available)
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                    with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(1)),
+                    with(equal(startIndex + pageSize)));
+            will(returnValue(mockResponse2));
+
+            allowing(mockResponse2).getNextRecord();will(returnValue(4));
+            allowing(mockResponse2).getRecordsMatched();will(returnValue(4));
+            allowing(mockResponse2).getRecordsReturned();will(returnValue(1));
+            allowing(mockResponse2).getRecords();will(returnValue(Arrays.asList(new CSWRecord("rec3"))));
+
+        }});
+
+        FacetedSearchResponse response = localFilterService.getFilteredRecords(serviceId, facets, startIndex, maxRecords);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(4, response.getNextIndex());
+        Assert.assertEquals(3, response.getRecords().size());
+
+        Assert.assertEquals("rec1", response.getRecords().get(0).getFileIdentifier());
+        Assert.assertEquals("rec2", response.getRecords().get(1).getFileIdentifier());
+        Assert.assertEquals("rec3", response.getRecords().get(2).getFileIdentifier());
+    }
+
+    /**
+     * Ensures our local filter filters correctly (and requests appropriate sized requests)
+     * @throws Exception
+     */
+    @Test
+    public void testLocalFilter() throws Exception {
+        final String serviceId = "service-id";
+        final FilterBoundingBox bbox = new FilterBoundingBox("WGS:84", new double[] {-10.0,  -10.0}, new double[] {10.0,  10.0});
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<FilterBoundingBox>(bbox, "bbox", Comparison.Equal),
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal),
+                new SearchFacet<OnlineResourceType>(OnlineResourceType.WCS, "servicetype", Comparison.Equal),
+                new SearchFacet<OnlineResourceType>(OnlineResourceType.WMS, "servicetype", Comparison.Equal));
+
+        final int startIndex = 1;
+        final int maxRecords = 3;
+        final int pageSize = 2;
+
+        localFilterService.setPageSize(pageSize);
+
+        context.checking(new Expectations() {{
+            //Request a full page initially
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                                                        with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                                                        with(equal(pageSize)),
+                                                        with(equal(startIndex)));
+            will(returnValue(mockResponse1));
+            allowing(mockResponse1).getNextRecord();will(returnValue(3));
+            allowing(mockResponse1).getRecordsMatched();will(returnValue(100));
+            allowing(mockResponse1).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse1).getRecords();will(returnValue(Arrays.asList(
+                    new CSWRecord(serviceId, "rec1", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WCS", "wcs", "")}, null),
+                    new CSWRecord(serviceId, "rec2", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null))));
+
+            //Still 3 records to find
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                    with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(pageSize)),
+                    with(equal(startIndex + pageSize)));
+            will(returnValue(mockResponse2));
+
+            allowing(mockResponse2).getNextRecord();will(returnValue(5));
+            allowing(mockResponse2).getRecordsMatched();will(returnValue(100));
+            allowing(mockResponse2).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse2).getRecords();will(returnValue(Arrays.asList(
+                    new CSWRecord(serviceId, "rec3", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WCS", "wcs", ""), new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null),
+                    new CSWRecord(serviceId, "rec4", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WCS", "wcs", ""), new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null))));
+
+            //Still 1 more record to find
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                    with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(pageSize)),
+                    with(equal(startIndex + pageSize * 2)));
+            will(returnValue(mockResponse3));
+
+            allowing(mockResponse3).getNextRecord();will(returnValue(7));
+            allowing(mockResponse3).getRecordsMatched();will(returnValue(100));
+            allowing(mockResponse3).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse3).getRecords();will(returnValue(Arrays.asList(
+                    new CSWRecord(serviceId, "rec5", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WCS", "wcs", ""), new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null),
+                    new CSWRecord(serviceId, "rec6", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WCS", "wcs", ""), new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null))));
+        }});
+
+        FacetedSearchResponse response = localFilterService.getFilteredRecords(serviceId, facets, startIndex, maxRecords);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(3, response.getRecords().size());
+        Assert.assertEquals(6, response.getNextIndex());
+
+        Assert.assertEquals("rec3", response.getRecords().get(0).getFileIdentifier());
+        Assert.assertEquals("rec4", response.getRecords().get(1).getFileIdentifier());
+        Assert.assertEquals("rec5", response.getRecords().get(2).getFileIdentifier());
+    }
+
+    /**
+     * Ensures our local filter filters correctly abort searching if the remote source indicates no more records
+     * @throws Exception
+     */
+    @Test
+    public void testLocalFilterRunoff() throws Exception {
+        final String serviceId = "service-id";
+        final FilterBoundingBox bbox = new FilterBoundingBox("WGS:84", new double[] {-10.0,  -10.0}, new double[] {10.0,  10.0});
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<FilterBoundingBox>(bbox, "bbox", Comparison.Equal),
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal),
+                new SearchFacet<OnlineResourceType>(OnlineResourceType.WCS, "servicetype", Comparison.Equal));
+
+        final int startIndex = 1;
+        final int maxRecords = 2;
+        final int pageSize = 2;
+
+        localFilterService.setPageSize(pageSize);
+
+        context.checking(new Expectations() {{
+            //Request a full page initially
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                                                        with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                                                        with(equal(pageSize)),
+                                                        with(equal(startIndex)));
+            will(returnValue(mockResponse1));
+            allowing(mockResponse1).getNextRecord();will(returnValue(3));
+            allowing(mockResponse1).getRecordsMatched();will(returnValue(4));
+            allowing(mockResponse1).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse1).getRecords();will(returnValue(Arrays.asList(
+                    new CSWRecord(serviceId, "rec1", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WCS", "wcs", "")}, null),
+                    new CSWRecord(serviceId, "rec2", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null))));
+
+            //Still 1 record to find
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                    with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(pageSize)),
+                    with(equal(startIndex + pageSize)));
+            will(returnValue(mockResponse2));
+
+            allowing(mockResponse2).getNextRecord();will(returnValue(0));
+            allowing(mockResponse2).getRecordsMatched();will(returnValue(4));
+            allowing(mockResponse2).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse2).getRecords();will(returnValue(Arrays.asList(
+                    new CSWRecord(serviceId, "rec3", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null),
+                    new CSWRecord(serviceId, "rec4", null, null, new AbstractCSWOnlineResource[] {new CSWOnlineResourceImpl(new URL("http://example.com"), "OGC:WMS", "wms", "")}, null))));
+        }});
+
+        FacetedSearchResponse response = localFilterService.getFilteredRecords(serviceId, facets, startIndex, maxRecords);
+
+        Assert.assertNotNull(response);
+        Assert.assertEquals(1, response.getRecords().size());
+        Assert.assertEquals(0, response.getNextIndex());
+
+        Assert.assertEquals("rec1", response.getRecords().get(0).getFileIdentifier());
+    }
+
+    /**
+     * Ensures we handle service exceptions gracefully
+     * @throws Exception
+     */
+    @Test(expected=PortalServiceException.class)
+    public void testServiceException() throws Exception {
+        final String serviceId = "service-id";
+        final FilterBoundingBox bbox = new FilterBoundingBox("WGS:84", new double[] {-10.0,  -10.0}, new double[] {10.0,  10.0});
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<FilterBoundingBox>(bbox, "bbox", Comparison.Equal),
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal),
+                new SearchFacet<DateTime>(new DateTime(0l), "datefrom", Comparison.GreaterThan),
+                new SearchFacet<DateTime>(new DateTime(1000l), "dateto", Comparison.LessThan));
+
+        final int startIndex = 1;
+        final int maxRecords = 3;
+        final int pageSize = 2;
+
+        localFilterService.setPageSize(pageSize);
+
+        context.checking(new Expectations() {{
+            //Request a full page initially
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                                                        with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                                                        with(equal(pageSize)),
+                                                        with(equal(startIndex)));
+            will(returnValue(mockResponse1));
+
+            allowing(mockResponse1).getNextRecord();will(returnValue(3));
+            allowing(mockResponse1).getRecordsMatched();will(returnValue(4));
+            allowing(mockResponse1).getRecordsReturned();will(returnValue(2));
+            allowing(mockResponse1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("rec1"), new CSWRecord("rec2"))));
+
+            //Second request throws an exception
+            oneOf(mockFilterService).getFilteredRecords(with(equal(serviceId)),
+                    with(new CSWGetDataRecordsFilterMatcher(bbox,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(1)),
+                    with(equal(startIndex + pageSize)));
+            will(throwException(new PortalServiceException("Test exception")));
+        }});
+
+        localFilterService.getFilteredRecords(serviceId, facets, startIndex, maxRecords);
+    }
+
+    /**
+     * Tests that the underlying implementation correctly redistributes fulfillment across services the remaining services
+     * @throws Exception
+     */
+    @Test
+    public void testGetMultiFilteredRecords_RedistributeFulfillment() throws Exception {
+        final int RECORD_REQUEST_COUNT = 11;
+        final String[] serviceIds = new String[] {"service1", "service2", "service3"};
+        final HashMap<String, Integer> startIndexes = new HashMap<String, Integer>();
+        startIndexes.put("service1", 1);
+        startIndexes.put("service2", 100);
+        startIndexes.put("service3", 10);
+
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal));
+
+        final CSWGetRecordResponse mockServ1Res1 = context.mock(CSWGetRecordResponse.class, "mockServ1Res1");
+        final CSWGetRecordResponse mockServ1Res2 = context.mock(CSWGetRecordResponse.class, "mockServ1Res2");
+        final CSWGetRecordResponse mockServ1Res3 = context.mock(CSWGetRecordResponse.class, "mockServ1Res3");
+        final CSWGetRecordResponse mockServ2Res1 = context.mock(CSWGetRecordResponse.class, "mockServ2Res1");
+        final CSWGetRecordResponse mockServ3Res1 = context.mock(CSWGetRecordResponse.class, "mockServ3Res1");
+        final CSWGetRecordResponse mockServ3Res2 = context.mock(CSWGetRecordResponse.class, "mockServ3Res2");
+
+        final Sequence serv1Sequence = context.sequence("serv1Sequence");
+        final Sequence serv2Sequence = context.sequence("serv2Sequence");
+        final Sequence serv3Sequence = context.sequence("serv3Sequence");
+
+        context.checking(new Expectations() {{
+            //Service 1 will make three requests. The first 4 records and then a redistributed 2 and then a final redistributed 1
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(1)));
+            inSequence(serv1Sequence);
+            will(delayReturnValue(1000, mockServ1Res1));
+
+            allowing(mockServ1Res1).getNextRecord();will(returnValue(5));
+            allowing(mockServ1Res1).getRecordsMatched();will(returnValue(88));
+            allowing(mockServ1Res1).getRecordsReturned();will(returnValue(4));
+            allowing(mockServ1Res1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec1"), new CSWRecord("s1rec2"), new CSWRecord("s1rec3"), new CSWRecord("s1rec4"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(2)),
+                    with(equal(5)));
+            inSequence(serv1Sequence);
+            will(delayReturnValue(500, mockServ1Res2));
+            allowing(mockServ1Res2).getNextRecord();will(returnValue(7));
+            allowing(mockServ1Res2).getRecordsMatched();will(returnValue(88));
+            allowing(mockServ1Res2).getRecordsReturned();will(returnValue(2));
+            allowing(mockServ1Res2).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec5"), new CSWRecord("s1rec6"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(1)),
+                    with(equal(7)));
+            inSequence(serv1Sequence);
+            will(returnValue(mockServ1Res3));
+            allowing(mockServ1Res3).getNextRecord();will(returnValue(8));
+            allowing(mockServ1Res3).getRecordsMatched();will(returnValue(88));
+            allowing(mockServ1Res3).getRecordsReturned();will(returnValue(1));
+            allowing(mockServ1Res3).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec7"))));
+
+            //Service 2 will make one request for four records and then return 0
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service2")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(100)));
+            inSequence(serv2Sequence);
+            will(delayReturnValue(250, mockServ2Res1));
+            allowing(mockServ2Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsMatched();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsReturned();will(returnValue(0));
+            allowing(mockServ2Res1).getRecords();will(returnValue(new ArrayList<CSWRecord>()));
+
+
+            //Service 3 will make one two requests. The first for 3 records will be fulfilled, the second redistributed request for 2 will only be half fulfilled
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service3")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(3)),
+                    with(equal(10)));
+            inSequence(serv3Sequence);
+            will(delayReturnValue(500, mockServ3Res1));
+            allowing(mockServ3Res1).getNextRecord();will(returnValue(14));
+            allowing(mockServ3Res1).getRecordsMatched();will(returnValue(4));
+            allowing(mockServ3Res1).getRecordsReturned();will(returnValue(3));
+            allowing(mockServ3Res1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s3rec1"), new CSWRecord("s3rec2"), new CSWRecord("s3rec3"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service3")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(2)),
+                    with(equal(13)));
+            inSequence(serv3Sequence);
+            will(delayReturnValue(1000, mockServ3Res2));
+            allowing(mockServ3Res2).getNextRecord();will(returnValue(0));
+            allowing(mockServ3Res2).getRecordsMatched();will(returnValue(1));
+            allowing(mockServ3Res2).getRecordsReturned();will(returnValue(1));
+            allowing(mockServ3Res2).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s3rec4"))));
+        }});
+
+        FacetedMultiSearchResponse response = localFilterService.getFilteredRecords(serviceIds, facets, startIndexes, RECORD_REQUEST_COUNT);
+        Assert.assertNotNull(response);
+        Assert.assertNotNull(response.getNextIndexes());
+        Assert.assertNotNull(response.getRecords());
+        Assert.assertNotNull(response.getStartIndexes());
+
+        Assert.assertEquals(new Integer(8), response.getNextIndexes().get("service1"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service2"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service3"));
+
+        Assert.assertEquals(new Integer(1), response.getStartIndexes().get("service1"));
+        Assert.assertEquals(new Integer(100), response.getStartIndexes().get("service2"));
+        Assert.assertEquals(new Integer(10), response.getStartIndexes().get("service3"));
+
+        String[] expectedRecordOrdering = new String[] {"s1rec1","s3rec1","s1rec2","s3rec2","s1rec3","s3rec3","s1rec4","s3rec4","s1rec5","s1rec6","s1rec7"};
+        Assert.assertEquals(expectedRecordOrdering.length, response.getRecords().size());
+        for (int i = 0; i < expectedRecordOrdering.length; i++) {
+            Assert.assertEquals(expectedRecordOrdering[i], response.getRecords().get(i).getFileIdentifier());
+        }
+    }
+
+    /**
+     * Tests that everything correctly shutsdown if we don't have enough records to fulfill the entire request
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testGetMultiFilteredRecords_Unfulfillable() throws Exception {
+        final int RECORD_REQUEST_COUNT = 11;
+        final String[] serviceIds = new String[] {"service1", "service2", "service3"};
+        final HashMap<String, Integer> startIndexes = new HashMap<String, Integer>();
+        startIndexes.put("service1", 1);
+        startIndexes.put("service2", 100);
+        startIndexes.put("service3", 10);
+
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal));
+
+        final CSWGetRecordResponse mockServ1Res1 = context.mock(CSWGetRecordResponse.class, "mockServ1Res1");
+        final CSWGetRecordResponse mockServ1Res2 = context.mock(CSWGetRecordResponse.class, "mockServ1Res2");
+        final CSWGetRecordResponse mockServ2Res1 = context.mock(CSWGetRecordResponse.class, "mockServ2Res1");
+        final CSWGetRecordResponse mockServ3Res1 = context.mock(CSWGetRecordResponse.class, "mockServ3Res1");
+
+        final Sequence serv1Sequence = context.sequence("serv1Sequence");
+        final Sequence serv2Sequence = context.sequence("serv2Sequence");
+        final Sequence serv3Sequence = context.sequence("serv3Sequence");
+
+        context.checking(new Expectations() {{
+            //Service 1 will make 2 requests. The first 4 records and then a redistribution of 4 from service 2 (as service 3 will have no more available to redistribute to)
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(1)));
+            inSequence(serv1Sequence);
+            will(delayReturnValue(1000, mockServ1Res1)); //We need a delay here so that we can be sure that service3 and service2 fulfillment redistributions have both occurred
+                                                         //(otherwise our mock object expectation definitions become silly complicated)
+
+            allowing(mockServ1Res1).getNextRecord();will(returnValue(5));
+            allowing(mockServ1Res1).getRecordsMatched();will(returnValue(5));
+            allowing(mockServ1Res1).getRecordsReturned();will(returnValue(4));
+            allowing(mockServ1Res1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec1"), new CSWRecord("s1rec2"), new CSWRecord("s1rec3"), new CSWRecord("s1rec4"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(5)));
+            inSequence(serv1Sequence);
+            will(returnValue(mockServ1Res2));
+            allowing(mockServ1Res2).getNextRecord();will(returnValue(0));
+            allowing(mockServ1Res2).getRecordsMatched();will(returnValue(5));
+            allowing(mockServ1Res2).getRecordsReturned();will(returnValue(1));
+            allowing(mockServ1Res2).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec5"))));
+
+            //Service 2 will make one request for four records and then return 0
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service2")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(100)));
+            inSequence(serv2Sequence);
+            will(delayReturnValue(250, mockServ2Res1));
+            allowing(mockServ2Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsMatched();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsReturned();will(returnValue(0));
+            allowing(mockServ2Res1).getRecords();will(returnValue(new ArrayList<CSWRecord>()));
+
+
+            //Service 3 will make one request. The first for 3 records will be fulfilled but there will be no more available.
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service3")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(3)),
+                    with(equal(10)));
+            inSequence(serv3Sequence);
+            will(delayReturnValue(500, mockServ3Res1));
+            allowing(mockServ3Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ3Res1).getRecordsMatched();will(returnValue(3));
+            allowing(mockServ3Res1).getRecordsReturned();will(returnValue(3));
+            allowing(mockServ3Res1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s3rec1"), new CSWRecord("s3rec2"), new CSWRecord("s3rec3"))));
+        }});
+
+        FacetedMultiSearchResponse response = localFilterService.getFilteredRecords(serviceIds, facets, startIndexes, RECORD_REQUEST_COUNT);
+        Assert.assertNotNull(response);
+        Assert.assertNotNull(response.getNextIndexes());
+        Assert.assertNotNull(response.getRecords());
+        Assert.assertNotNull(response.getStartIndexes());
+
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service1"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service2"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service3"));
+
+        Assert.assertEquals(new Integer(1), response.getStartIndexes().get("service1"));
+        Assert.assertEquals(new Integer(100), response.getStartIndexes().get("service2"));
+        Assert.assertEquals(new Integer(10), response.getStartIndexes().get("service3"));
+
+        String[] expectedRecordOrdering = new String[] {"s1rec1","s3rec1","s1rec2","s3rec2","s1rec3","s3rec3","s1rec4","s1rec5"};
+        Assert.assertEquals(expectedRecordOrdering.length, response.getRecords().size());
+        for (int i = 0; i < expectedRecordOrdering.length; i++) {
+            Assert.assertEquals(expectedRecordOrdering[i], response.getRecords().get(i).getFileIdentifier());
+        }
+    }
+
+    /**
+     * Tests that everything works correctly when we get absolutely nothing back
+     * @throws Exception
+     */
+    @Test
+    public void testGetMultiFilteredRecords_NullSet() throws Exception {
+        final int RECORD_REQUEST_COUNT = 11;
+        final String[] serviceIds = new String[] {"service1", "service2", "service3"};
+        final HashMap<String, Integer> startIndexes = new HashMap<String, Integer>();
+        startIndexes.put("service1", 1);
+        startIndexes.put("service2", 100);
+        startIndexes.put("service3", 10);
+
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal));
+
+        final CSWGetRecordResponse mockServ1Res1 = context.mock(CSWGetRecordResponse.class, "mockServ1Res1");
+        final CSWGetRecordResponse mockServ2Res1 = context.mock(CSWGetRecordResponse.class, "mockServ2Res1");
+        final CSWGetRecordResponse mockServ3Res1 = context.mock(CSWGetRecordResponse.class, "mockServ3Res1");
+
+        final Sequence serv1Sequence = context.sequence("serv1Sequence");
+        final Sequence serv2Sequence = context.sequence("serv2Sequence");
+        final Sequence serv3Sequence = context.sequence("serv3Sequence");
+
+        context.checking(new Expectations() {{
+            //Service 1 will make 2 requests. The first 4 records and then a redistributed 1 (of 2)
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(any(Integer.class)),
+                    with(equal(1)));
+            inSequence(serv1Sequence);
+            will(returnValue(mockServ1Res1));
+            allowing(mockServ1Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ1Res1).getRecordsMatched();will(returnValue(0));
+            allowing(mockServ1Res1).getRecordsReturned();will(returnValue(0));
+            allowing(mockServ1Res1).getRecords();will(returnValue(new ArrayList<CSWRecord>()));
+
+            //Service 2 will make one request for four records and then return 0
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service2")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(any(Integer.class)),
+                    with(equal(100)));
+            inSequence(serv2Sequence);
+            will(returnValue(mockServ2Res1));
+            allowing(mockServ2Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsMatched();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsReturned();will(returnValue(0));
+            allowing(mockServ2Res1).getRecords();will(returnValue(new ArrayList<CSWRecord>()));
+
+
+            //Service 3 will make one requests. The first for 3 records will be fulfilled
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service3")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(any(Integer.class)),
+                    with(equal(10)));
+            inSequence(serv3Sequence);
+            will(returnValue(mockServ3Res1));
+            allowing(mockServ3Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ3Res1).getRecordsMatched();will(returnValue(0));
+            allowing(mockServ3Res1).getRecordsReturned();will(returnValue(0));
+            allowing(mockServ3Res1).getRecords();will(returnValue(new ArrayList<CSWRecord>()));
+        }});
+
+        FacetedMultiSearchResponse response = localFilterService.getFilteredRecords(serviceIds, facets, startIndexes, RECORD_REQUEST_COUNT);
+        Assert.assertNotNull(response);
+        Assert.assertNotNull(response.getNextIndexes());
+        Assert.assertNotNull(response.getRecords());
+        Assert.assertNotNull(response.getStartIndexes());
+
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service1"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service2"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service3"));
+
+        Assert.assertEquals(new Integer(1), response.getStartIndexes().get("service1"));
+        Assert.assertEquals(new Integer(100), response.getStartIndexes().get("service2"));
+        Assert.assertEquals(new Integer(10), response.getStartIndexes().get("service3"));
+
+        Assert.assertEquals(0, response.getRecords().size());
+    }
+
+    /**
+     * Tests that the underlying implementation correctly redistributes fulfillment across services the remaining services, even when an exception is thrown
+     * @throws Exception
+     */
+    // Carsten: Commented out due to issues: This test has a degree of non-determination and not all valid sequences of events 
+    //          result in the test passing. This gives frequent false positives during unit tests. Commented out until fixed.
+    //    @Test
+    //   
+    public void testGetMultiFilteredRecords_HandleException() throws Exception {
+        final int RECORD_REQUEST_COUNT = 11;
+        final String[] serviceIds = new String[] {"service1", "service2", "service3"};
+        final HashMap<String, Integer> startIndexes = new HashMap<String, Integer>();
+        startIndexes.put("service1", 1);
+        startIndexes.put("service2", 100);
+        startIndexes.put("service3", 10);
+
+        final List<SearchFacet<? extends Object>> facets = Arrays.asList(
+                new SearchFacet<String>("kw1", "keyword", Comparison.Equal),
+                new SearchFacet<String>("kw2", "keyword", Comparison.Equal));
+
+        final CSWGetRecordResponse mockServ1Res1 = context.mock(CSWGetRecordResponse.class, "mockServ1Res1");
+        final CSWGetRecordResponse mockServ1Res2 = context.mock(CSWGetRecordResponse.class, "mockServ1Res2");
+        final CSWGetRecordResponse mockServ2Res1 = context.mock(CSWGetRecordResponse.class, "mockServ2Res1");
+        final CSWGetRecordResponse mockServ3Res1 = context.mock(CSWGetRecordResponse.class, "mockServ3Res1");
+        final CSWGetRecordResponse mockServ3Res2 = context.mock(CSWGetRecordResponse.class, "mockServ3Res2");
+
+        final Sequence serv1Sequence = context.sequence("serv1Sequence");
+        final Sequence serv2Sequence = context.sequence("serv2Sequence");
+        final Sequence serv3Sequence = context.sequence("serv3Sequence");
+
+        context.checking(new Expectations() {{
+            //Service 1 will make three requests. The first 4 records and then a redistributed 2 and then throw a exception
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(1)));
+            inSequence(serv1Sequence);
+            will(returnValue(mockServ1Res1));
+
+            allowing(mockServ1Res1).getNextRecord();will(returnValue(5));
+            allowing(mockServ1Res1).getRecordsMatched();will(returnValue(88));
+            allowing(mockServ1Res1).getRecordsReturned();will(returnValue(4));
+            allowing(mockServ1Res1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec1"), new CSWRecord("s1rec2"), new CSWRecord("s1rec3"), new CSWRecord("s1rec4"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(2)),
+                    with(equal(5)));
+            inSequence(serv1Sequence);
+            will(returnValue(mockServ1Res2));
+            allowing(mockServ1Res2).getNextRecord();will(returnValue(7));
+            allowing(mockServ1Res2).getRecordsMatched();will(returnValue(88));
+            allowing(mockServ1Res2).getRecordsReturned();will(returnValue(2));
+            allowing(mockServ1Res2).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s1rec5"), new CSWRecord("s1rec6"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service1")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(1)),
+                    with(equal(7)));
+            inSequence(serv1Sequence);
+            will(throwException(new IOException("mock IO exception")));
+
+            //Service 2 will make one request for four records and then return 0
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service2")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(4)),
+                    with(equal(100)));
+            inSequence(serv2Sequence);
+            will(returnValue(mockServ2Res1));
+            allowing(mockServ2Res1).getNextRecord();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsMatched();will(returnValue(0));
+            allowing(mockServ2Res1).getRecordsReturned();will(returnValue(0));
+            allowing(mockServ2Res1).getRecords();will(returnValue(new ArrayList<CSWRecord>()));
+
+
+            //Service 3 will make one two requests. The first for 3 records will be fulfilled, the second redistributed request for 2 will only be half fulfilled
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service3")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(3)),
+                    with(equal(10)));
+            inSequence(serv3Sequence);
+            will(returnValue(mockServ3Res1));
+            allowing(mockServ3Res1).getNextRecord();will(returnValue(14));
+            allowing(mockServ3Res1).getRecordsMatched();will(returnValue(4));
+            allowing(mockServ3Res1).getRecordsReturned();will(returnValue(3));
+            allowing(mockServ3Res1).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s3rec1"), new CSWRecord("s3rec2"), new CSWRecord("s3rec3"))));
+
+            oneOf(mockFilterService).getFilteredRecords(
+                    with(equal("service3")),
+                    with(new CSWGetDataRecordsFilterMatcher(null,new String[] {"kw1", "kw2"}, null, null, KeywordMatchType.All, null, null, null, null)),
+                    with(equal(2)),
+                    with(equal(13)));
+            inSequence(serv3Sequence);
+            will(returnValue(mockServ3Res2));
+            allowing(mockServ3Res2).getNextRecord();will(returnValue(0));
+            allowing(mockServ3Res2).getRecordsMatched();will(returnValue(1));
+            allowing(mockServ3Res2).getRecordsReturned();will(returnValue(1));
+            allowing(mockServ3Res2).getRecords();will(returnValue(Arrays.asList(new CSWRecord("s3rec4"))));
+        }});
+
+        FacetedMultiSearchResponse response = localFilterService.getFilteredRecords(serviceIds, facets, startIndexes, RECORD_REQUEST_COUNT);
+        Assert.assertNotNull(response);
+        Assert.assertNotNull(response.getNextIndexes());
+        Assert.assertNotNull(response.getRecords());
+        Assert.assertNotNull(response.getStartIndexes());
+
+        Assert.assertEquals(new Integer(7), response.getNextIndexes().get("service1"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service2"));
+        Assert.assertEquals(new Integer(0), response.getNextIndexes().get("service3"));
+
+        Assert.assertEquals(new Integer(1), response.getStartIndexes().get("service1"));
+        Assert.assertEquals(new Integer(100), response.getStartIndexes().get("service2"));
+        Assert.assertEquals(new Integer(10), response.getStartIndexes().get("service3"));
+
+        Assert.assertEquals(10, response.getRecords().size());
+        Assert.assertEquals("s1rec1", response.getRecords().get(0).getFileIdentifier());
+    }
+}


### PR DESCRIPTION
Moved all of VGL's CSW search classes into portal-core so they can be used by other projects.

Only actual change to existing portal-core components was adding a Component annotation to ServiceConfiguration so it can be autowired.