### PR TITLE
ServiceConfiguration's Component annotation was breaking other projects.

### DIFF
--- a/src/main/java/org/auscope/portal/core/configuration/ServiceConfiguration.java
+++ b/src/main/java/org/auscope/portal/core/configuration/ServiceConfiguration.java
@@ -2,10 +2,7 @@ package org.auscope.portal.core.configuration;
 
 import java.util.List;
 
-import org.springframework.stereotype.Component;
 
-
-@Component
 public class ServiceConfiguration {
 
     List<ServiceConfigurationItem> serviceConfigurationItems;


### PR DESCRIPTION
Was using a Component annotation to pull the bean in via Spring Boot's component scan, will manually create beans that use ServiceConfiguation (such as DownloadController) instead.