### PR TITLE
Changed Raijin to Gadi

### DIFF
--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeService.java
@@ -19,8 +19,8 @@ abstract public class CloudComputeService {
         NovaKeystone,
         /** Connect to an Amazon Web Services instance via EC2 */
         AWSEc2,
-        /** Connect to Raijin NCI HPC */
-        RAIJIN
+        /** Connect to GADI NCI HPC */
+        GADI
     }
 
     /**


### PR DESCRIPTION
NCI has retired Raijin and replaced it with Gadi. Most of the changes will be in VGL, but one enum needs to be changed in portal-core.