### PR TITLE
Annotate CloudJob to assist with subclass persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,11 @@
             <artifactId>jstl</artifactId>
         </dependency>
         <dependency>
+		    <groupId>org.hibernate.javax.persistence</groupId>
+		    <artifactId>hibernate-jpa-2.1-api</artifactId>
+		    <version>1.0.2.Final</version>
+		</dependency>
+        <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
             <version>1.11.396</version>

--- a/src/main/java/org/auscope/portal/core/cloud/CloudJob.java
+++ b/src/main/java/org/auscope/portal/core/cloud/CloudJob.java
@@ -7,11 +7,17 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
 /**
  * Base class representing the base state of a job that is sent to the cloud for processing.
  *
  * @author Josh Vote
  */
+@MappedSuperclass
 public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
 
     /**
@@ -23,6 +29,8 @@ public class CloudJob implements Serializable, StagedFileOwner, CloudFileOwner {
     public static final String DATE_FORMAT = "yyyyMMdd_HHmmss";
 
     /** Unique ID identifying this job */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     protected Integer id;
     /** Descriptive name of this job */
     protected String name;


### PR DESCRIPTION
Added a few basic annotations so that classes that extend CloudJob can persist its fields.
This was an issue for ANVGL-Portal which uses annotation based persistence and had to shadow CloudJob's variables so that the subclass (VEGLJob) was able to persist them.