### PR TITLE
Aus 3286

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,10 @@
            <artifactId>spring-orm</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+        </dependency>
+        <dependency>
           <groupId>com.racquettrack</groupId>
           <artifactId>spring-security-oauth2-client</artifactId>
           <version>1.3-AUSCOPE-SNAPSHOT</version>

--- a/src/main/java/org/auscope/portal/core/server/controllers/WFSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WFSController.java
@@ -23,6 +23,7 @@ import org.auscope.portal.core.util.FileIOUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.servlet.ModelAndView;
 
@@ -301,6 +302,29 @@ public class WFSController extends BasePortalController {
         } catch (Exception ex) {
             log.warn(String.format("Internal error requesting/writing popup for '%1$s' from '%2$s': %3$s", typeName,
                     serviceUrl, ex));
+            log.debug("Exception: ", ex);
+            response.sendError(HttpStatus.SC_INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * This method converts supplied WFS string from WMS pop up into HTML.
+     * @param gml    a WFS feature in GML format
+     * @throws Exception
+     */
+    @RequestMapping(value="transformToHtmlPopup.do", method = {RequestMethod.GET, RequestMethod.POST})
+    public void transformToHtml(HttpServletResponse response, @RequestParam("gml") String gml) throws Exception {
+        response.setContentType("text/html; charset=utf-8");
+        ServletOutputStream outputStream = response.getOutputStream();
+
+        //Make our request, transform and then return it.
+        WFSTransformedResponse htmlResponse = null;
+        WFSService service = wfsService;
+        try {
+        	htmlResponse = service.transformToHtml(gml, null);
+            outputStream.write(htmlResponse.getTransformed().getBytes());
+        } catch (Exception ex) {
+            log.warn(String.format("Internal error requesting/writing popup for '%1$s': %3$s", gml, ex));
             log.debug("Exception: ", ex);
             response.sendError(HttpStatus.SC_INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/org/auscope/portal/core/server/controllers/WFSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WFSController.java
@@ -10,20 +10,16 @@ import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.http.HttpStatus;
-import org.auscope.portal.core.server.controllers.BasePortalController;
-import org.auscope.portal.core.server.http.HttpServiceCaller;
-import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;
+import org.auscope.portal.core.services.WFSGml32Service;
+import org.auscope.portal.core.services.WFSService;
 import org.auscope.portal.core.services.methodmakers.filter.FilterBoundingBox;
 import org.auscope.portal.core.services.methodmakers.filter.SimpleBBoxFilter;
 import org.auscope.portal.core.services.methodmakers.filter.SimplePropertyFilter;
-import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.auscope.portal.core.services.responses.wfs.WFSCountResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSGetCapabilitiesResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSTransformedResponse;
 import org.auscope.portal.core.util.FileIOUtil;
-import org.auscope.portal.core.services.WFSService;
-import org.auscope.portal.core.xslt.GmlToHtml;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -42,22 +38,14 @@ import org.springframework.web.servlet.ModelAndView;
 public class WFSController extends BasePortalController {
 
     private WFSService wfsService;
-    
-    private WFSService wfsGml32Service;
+
+    private WFSGml32Service wfsGml32Service;
 
     @Autowired
-    public WFSController(WFSService wfsService) {
+    public WFSController(WFSService wfsService, WFSGml32Service wfsGml32Service) {
         this.wfsService = wfsService;
-        WFSGetFeatureMethodMaker methodMaker = new WFSGetFeatureMethodMaker();
-        this.wfsGml32Service = new WFSService(
-                new HttpServiceCaller(900000),
-                methodMaker,
-                // can instantiate with a different XSLT for GML 32 mapping?
-                new GmlToHtml()
-                );       
-        // give it a ERML 2.0 namespace context
-        methodMaker.setNamespaces(new ErmlNamespaceContext("2.0"));
-        
+        this.wfsGml32Service = wfsGml32Service;
+
     }
 
     
@@ -83,7 +71,7 @@ public class WFSController extends BasePortalController {
 
         WFSResponse wfsResponse = null;
         try {
-            wfsResponse = wfsGml32Service.getGml32WfsResponse(serviceUrl, featureType, filterString, maxFeatures, srs);
+            wfsResponse = wfsGml32Service.getWfsResponse(serviceUrl, featureType, filterString, maxFeatures, srs);
         } catch (Exception ex) {
             log.warn(String.format("Exception getting '%2$s' from '%1$s': %3$s", serviceUrl, featureType, ex));
             log.debug("Exception: ", ex);

--- a/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
@@ -21,6 +21,7 @@ import org.auscope.portal.core.server.controllers.BaseCSWController;
 import org.auscope.portal.core.server.http.HttpClientInputStream;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.WMSService;
+import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.auscope.portal.core.services.responses.csw.AbstractCSWOnlineResource;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicBoundingBox;
 import org.auscope.portal.core.services.responses.csw.CSWGeographicElement;
@@ -548,12 +549,14 @@ public class WMSController extends BaseCSWController {
 
     @RequestMapping(value="transformToHtmlPopup.do", method = {RequestMethod.GET, RequestMethod.POST})
     public void transformToHtml(HttpServletResponse response, @RequestParam("gml") String gml) throws Exception {
-    	String responseString;
-    	if (gml != null) {
-            responseString = wmsService.transform(gml, null);
-        	InputStream responseStream = new ByteArrayInputStream(responseString.getBytes());
-            FileIOUtil.writeInputToOutputStream(responseStream, response.getOutputStream(), BUFFERSIZE, true);
+    	if (gml == null) {
+    		return;
     	}
+    	// all the ER(old) WMS layers at the moment only use ER1 and soon will be obsolete
+    	ErmlNamespaceContext namespaces = new ErmlNamespaceContext();
+    	String responseString = wmsService.transform(gml, namespaces);
+        InputStream responseStream = new ByteArrayInputStream(responseString.getBytes());
+        FileIOUtil.writeInputToOutputStream(responseStream, response.getOutputStream(), BUFFERSIZE, true);
     }
 
 }

--- a/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
@@ -545,4 +545,15 @@ public class WMSController extends BaseCSWController {
         return style;
     }
 
+
+    @RequestMapping(value="transformToHtmlPopup.do", method = {RequestMethod.GET, RequestMethod.POST})
+    public void transformToHtml(HttpServletResponse response, @RequestParam("gml") String gml) throws Exception {
+    	String responseString;
+    	if (gml != null) {
+            responseString = wmsService.transform(gml, null);
+        	InputStream responseStream = new ByteArrayInputStream(responseString.getBytes());
+            FileIOUtil.writeInputToOutputStream(responseStream, response.getOutputStream(), BUFFERSIZE, true);
+    	}
+    }
+
 }

--- a/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/WMSController.java
@@ -545,18 +545,4 @@ public class WMSController extends BaseCSWController {
         String style = header + rule + tail;
         return style;
     }
-
-
-    @RequestMapping(value="transformToHtmlPopup.do", method = {RequestMethod.GET, RequestMethod.POST})
-    public void transformToHtml(HttpServletResponse response, @RequestParam("gml") String gml) throws Exception {
-    	if (gml == null) {
-    		return;
-    	}
-    	// all the ER(old) WMS layers at the moment only use ER1 and soon will be obsolete
-    	ErmlNamespaceContext namespaces = new ErmlNamespaceContext();
-    	String responseString = wmsService.transform(gml, namespaces);
-        InputStream responseStream = new ByteArrayInputStream(responseString.getBytes());
-        FileIOUtil.writeInputToOutputStream(responseStream, response.getOutputStream(), BUFFERSIZE, true);
-    }
-
 }

--- a/src/main/java/org/auscope/portal/core/services/WFSGml32Service.java
+++ b/src/main/java/org/auscope/portal/core/services/WFSGml32Service.java
@@ -47,6 +47,6 @@ public class WFSGml32Service extends WFSService {
         HttpRequestBase method = generateWFSRequest(wfsUrl, featureType, null, filterString, maxFeature, srs,
                 ResultType.Results, "gml32", null);
 
-        return super.doRequest(method, wfsUrl);
+        return super.doRequest(method);
     }
 }

--- a/src/main/java/org/auscope/portal/core/services/WFSGml32Service.java
+++ b/src/main/java/org/auscope/portal/core/services/WFSGml32Service.java
@@ -41,6 +41,13 @@ public class WFSGml32Service extends WFSService {
         super(httpServiceCaller, wfsMethodMaker, gmlToHtml);
     }
 
+    /**
+     * Makes a WFS GetFeature request with gml32 outputFormat constrained by the specified parameters
+     *
+     * The response is returned as a String
+     *
+     * @see WFSService#getWfsResponse(String, String, String, Integer, String)
+     */
     @Override
 	public WFSResponse getWfsResponse(String wfsUrl, String featureType, String filterString,
             Integer maxFeature, String srs) throws PortalServiceException, URISyntaxException {

--- a/src/main/java/org/auscope/portal/core/services/WFSGml32Service.java
+++ b/src/main/java/org/auscope/portal/core/services/WFSGml32Service.java
@@ -1,0 +1,52 @@
+package org.auscope.portal.core.services;
+
+import java.net.URISyntaxException;
+
+import org.apache.http.client.methods.HttpRequestBase;
+import org.auscope.portal.core.server.http.HttpServiceCaller;
+import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;
+import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker.ResultType;
+import org.auscope.portal.core.services.responses.wfs.WFSResponse;
+import org.auscope.portal.core.xslt.GmlToHtml;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * A service class encapsulating high level access to a remote Web Feature Service
+ * that supports GML 3.2.
+ *
+ * @author Josh Vote
+ * @author Rini Angreani
+ *
+ */
+@Service
+public class WFSGml32Service extends WFSService {
+
+    /**
+     * Creates a new instance of this class with the specified dependencies
+     *
+     * @param httpServiceCaller
+     *            Will be used for making requests
+     * @param wfsMethodMaker
+     *            Will be used for generating WFS methods
+     * @param gmlToKml
+     *            Will be used for transforming GML (WFS responses) into KML
+     * @param gmlToHtml
+     *            Will be used for transforming GML (WFS responses) into HTML
+     */
+    @Autowired
+    public WFSGml32Service(HttpServiceCaller httpServiceCaller,
+            WFSGetFeatureMethodMaker wfsMethodMaker,
+            GmlToHtml gmlToHtml) {
+        super(httpServiceCaller, wfsMethodMaker, gmlToHtml);
+    }
+
+    @Override
+	public WFSResponse getWfsResponse(String wfsUrl, String featureType, String filterString,
+            Integer maxFeature, String srs) throws PortalServiceException, URISyntaxException {
+        HttpRequestBase method = generateWFSRequest(wfsUrl, featureType, null, filterString, maxFeature, srs,
+                ResultType.Results, "gml32", null);
+
+        return super.doRequest(method, wfsUrl);
+    }
+}

--- a/src/main/java/org/auscope/portal/core/services/WFSService.java
+++ b/src/main/java/org/auscope/portal/core/services/WFSService.java
@@ -48,7 +48,7 @@ public class WFSService extends BaseWFSService {
         this.gmlToHtml = gmlToHtml;
     }
 
-    private WFSResponse doRequest(HttpRequestBase method, String serviceUrl)
+    protected WFSResponse doRequest(HttpRequestBase method, String serviceUrl)
             throws PortalServiceException {
         try {
             String wfs = httpServiceCaller.getMethodResponseAsString(method);
@@ -117,15 +117,7 @@ public class WFSService extends BaseWFSService {
             Integer maxFeatures, String srs) throws PortalServiceException, URISyntaxException {
         HttpRequestBase method = generateWFSRequest(wfsUrl, featureType, null, filterString, maxFeatures, srs,
                 ResultType.Results);
-        
-        return doRequest(method, wfsUrl);
-    }
-    
-    public WFSResponse getGml32WfsResponse(String wfsUrl, String featureType, String filterString,
-            Integer maxFeature, String srs) throws PortalServiceException, URISyntaxException {
-        HttpRequestBase method = generateWFSRequest(wfsUrl, featureType, null, filterString, maxFeature, srs,
-                ResultType.Results, "gml32", null);
-        
+
         return doRequest(method, wfsUrl);
     }
 

--- a/src/main/java/org/auscope/portal/core/services/WFSService.java
+++ b/src/main/java/org/auscope/portal/core/services/WFSService.java
@@ -64,19 +64,30 @@ public class WFSService extends BaseWFSService {
         try {
             String wfs = httpServiceCaller.getMethodResponseAsString(method);
             OWSExceptionParser.checkForExceptionResponse(wfs);
-            ErmlNamespaceContext erml;
-            if (wfs.contains("http://xmlns.earthresourceml.org/EarthResource/2.0")) {
-            	// Tell the XSLT which ERML version to use
-            	erml = new ErmlNamespaceContext("2.0");
-            } else {
-            	erml = new ErmlNamespaceContext();
-            }
-            String kml = gmlToHtml.convert(wfs, erml);
-
-            return new WFSTransformedResponse(wfs, kml, method);
+            return transformToHtml(wfs, method);
         } catch (Exception ex) {
             throw new PortalServiceException(method, ex);
         }
+    }
+
+    /**
+	 * Transform WFS document into HTML format.
+	 *
+	 * @param wfs    GML feature string
+	 * @param method HttpRequestBase used to make the WFS request, or null if this
+	 *               comes from WMS GetFeatureInfo popup.
+	 * @return HTML converted response
+	 */
+    public WFSTransformedResponse transformToHtml(String wfs, HttpRequestBase method) {
+    	ErmlNamespaceContext erml;
+        if (wfs.contains("http://xmlns.earthresourceml.org/EarthResource/2.0")) {
+        	// Tell the XSLT which ERML version to use
+        	erml = new ErmlNamespaceContext("2.0");
+        } else {
+        	erml = new ErmlNamespaceContext();
+        }
+    	String html = this.gmlToHtml.convert(wfs, erml);
+    	return new WFSTransformedResponse(wfs, html, method);
     }
 
     /**

--- a/src/main/java/org/auscope/portal/core/services/WMSService.java
+++ b/src/main/java/org/auscope/portal/core/services/WMSService.java
@@ -13,10 +13,8 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.server.http.HttpClientInputStream;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.methodmakers.WMSMethodMakerInterface;
-import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.auscope.portal.core.services.responses.ows.OWSExceptionParser;
 import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord;
-import org.auscope.portal.core.xslt.GmlToHtml;
 
 /**
  * Service class providing functionality for interacting with a Web Map Service
@@ -31,14 +29,11 @@ public class WMSService {
 
     protected List<WMSMethodMakerInterface> listOfSupportedWMSMethodMaker;
 
-	private GmlToHtml gmlToHtml;
 
     // ----------------------------------------------------------- Constructors
-    public WMSService(HttpServiceCaller serviceCaller, List<WMSMethodMakerInterface> methodMaker,
-    		GmlToHtml gmlToHtml) {
+    public WMSService(HttpServiceCaller serviceCaller, List<WMSMethodMakerInterface> methodMaker) {
         this.serviceCaller = serviceCaller;
         this.listOfSupportedWMSMethodMaker = methodMaker;
-        this.gmlToHtml = gmlToHtml;
     }
 
     // ------------------------------------------- Property Setters and Getters
@@ -217,9 +212,5 @@ public class WMSService {
         methodMaker = getSupportedMethodMaker(url, version);
         String sldBody = methodMaker.getStyle(sldUrl);
         return sldBody;
-    }
-
-    public String transform(String document, ErmlNamespaceContext namespaces) {
-    	return this.gmlToHtml.convert(document, namespaces);
     }
 }

--- a/src/main/java/org/auscope/portal/core/services/WMSService.java
+++ b/src/main/java/org/auscope/portal/core/services/WMSService.java
@@ -13,6 +13,7 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.server.http.HttpClientInputStream;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.methodmakers.WMSMethodMakerInterface;
+import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.auscope.portal.core.services.responses.ows.OWSExceptionParser;
 import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord;
 import org.auscope.portal.core.xslt.GmlToHtml;
@@ -218,7 +219,7 @@ public class WMSService {
         return sldBody;
     }
 
-    public String transform(String document, String url) {
-    	return this.gmlToHtml.convert(document, url);
+    public String transform(String document, ErmlNamespaceContext namespaces) {
+    	return this.gmlToHtml.convert(document, namespaces);
     }
 }

--- a/src/main/java/org/auscope/portal/core/services/WMSService.java
+++ b/src/main/java/org/auscope/portal/core/services/WMSService.java
@@ -15,6 +15,7 @@ import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.methodmakers.WMSMethodMakerInterface;
 import org.auscope.portal.core.services.responses.ows.OWSExceptionParser;
 import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord;
+import org.auscope.portal.core.xslt.GmlToHtml;
 
 /**
  * Service class providing functionality for interacting with a Web Map Service
@@ -29,11 +30,14 @@ public class WMSService {
 
     protected List<WMSMethodMakerInterface> listOfSupportedWMSMethodMaker;
 
+	private GmlToHtml gmlToHtml;
+
     // ----------------------------------------------------------- Constructors
-    public WMSService(HttpServiceCaller serviceCaller, List<WMSMethodMakerInterface> methodMaker) {
+    public WMSService(HttpServiceCaller serviceCaller, List<WMSMethodMakerInterface> methodMaker,
+    		GmlToHtml gmlToHtml) {
         this.serviceCaller = serviceCaller;
         this.listOfSupportedWMSMethodMaker = methodMaker;
-
+        this.gmlToHtml = gmlToHtml;
     }
 
     // ------------------------------------------- Property Setters and Getters
@@ -212,5 +216,9 @@ public class WMSService {
         methodMaker = getSupportedMethodMaker(url, version);
         String sldBody = methodMaker.getStyle(sldUrl);
         return sldBody;
+    }
+
+    public String transform(String document, String url) {
+    	return this.gmlToHtml.convert(document, url);
     }
 }

--- a/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
+++ b/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 
 /**
  * Utility class for converting Gml to a 'pretty' HTML representation
- * 
+ *
  * @author Josh Vote
  *
  */
@@ -39,10 +39,6 @@ public class GmlToHtml extends PortalXSLTTransformer {
         }
         stylesheetParams.setProperty("er", namespaces.getNamespaceURI("er"));
         return convert(wfs, stylesheetParams);
-    }
-
-    public String convert(String wfs) {
-    	return convert(wfs, new ErmlNamespaceContext());
     }
 
 }

--- a/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
+++ b/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 
 import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 /**
  * Utility class for converting Gml to a 'pretty' HTML representation
@@ -14,12 +15,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class GmlToHtml extends PortalXSLTTransformer {
 
+	/**
+	 * The base URL needed to build service calls from the XSLT
+	 */
 	private String portalBackendUrl;
-
-	public GmlToHtml(String url) {
-		super("/org/auscope/portal/core/xslt/WfsToHtml.xsl");
-		this.portalBackendUrl = url;
-	}
 
 	public GmlToHtml() {
 	    super("/org/auscope/portal/core/xslt/WfsToHtml.xsl");
@@ -30,13 +29,19 @@ public class GmlToHtml extends PortalXSLTTransformer {
      *
      * @param wfs
      *            WFS response to be transformed
+     * @param namespaces
+     *            EarthResourceML namespace context (v1.1 or v2.0)
      * @return html output string
      */
     public String convert(String wfs, ErmlNamespaceContext namespaces) {
     	Properties stylesheetParams = new Properties();
-        if (this.portalBackendUrl != null) {
-            stylesheetParams.setProperty("portalBaseURL", this.portalBackendUrl);
-        }
+
+    	if (this.portalBackendUrl == null) {
+            this.portalBackendUrl = ServletUriComponentsBuilder
+        		.fromCurrentContextPath().build().toUriString();
+    	}
+
+        stylesheetParams.setProperty("portalBaseURL", portalBackendUrl);
         stylesheetParams.setProperty("er", namespaces.getNamespaceURI("er"));
         return convert(wfs, stylesheetParams);
     }

--- a/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
+++ b/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
@@ -1,12 +1,8 @@
 package org.auscope.portal.core.xslt;
 
-import java.io.InputStream;
-import java.io.StringReader;
 import java.util.Properties;
 
-import javax.xml.transform.stream.StreamSource;
-
-import org.auscope.portal.core.xslt.PortalXSLTTransformer;
+import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.springframework.stereotype.Component;
 
 /**
@@ -34,45 +30,19 @@ public class GmlToHtml extends PortalXSLTTransformer {
      *
      * @param wfs
      *            WFS response to be transformed
-     * @param serviceUrl
-     *            The WFS URL where the response came from
-     * @return Kml output string
+     * @return html output string
      */
-    public String convert(String wfs, String serviceUrl) {
-        return convert(new StreamSource(new StringReader(wfs)), serviceUrl);
-    }
-
-    /**
-     * Utility method to transform a WFS response into HTML
-     *
-     * @param wfs
-     *            WFS response to be transformed
-     * @param serviceUrl
-     *            The WFS URL where the response came from
-     * @return Xml output string
-     */
-    public String convert(InputStream wfs, String serviceUrl) {
-        return convert(new StreamSource(wfs), serviceUrl);
-    }
-
-    /**
-     * Utility method to transform a WFS response into HTML
-     *
-     * @param wfs
-     *            WFS response to be transformed
-     * @param serviceUrl
-     *            The WFS URL where the response came from
-     * @return Xml output string
-     */
-    public String convert(StreamSource wfs, String serviceUrl) {
-        Properties stylesheetParams = new Properties();
-        if (serviceUrl != null) {
-        	// this is only used for Yilgarn...
-            stylesheetParams.setProperty("serviceUrl", serviceUrl);
-        }
+    public String convert(String wfs, ErmlNamespaceContext namespaces) {
+    	Properties stylesheetParams = new Properties();
         if (this.portalBackendUrl != null) {
             stylesheetParams.setProperty("portalBaseURL", this.portalBackendUrl);
         }
+        stylesheetParams.setProperty("er", namespaces.getNamespaceURI("er"));
         return convert(wfs, stylesheetParams);
     }
+
+    public String convert(String wfs) {
+    	return convert(wfs, new ErmlNamespaceContext());
+    }
+
 }

--- a/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
+++ b/src/main/java/org/auscope/portal/core/xslt/GmlToHtml.java
@@ -18,9 +18,16 @@ import org.springframework.stereotype.Component;
 @Component
 public class GmlToHtml extends PortalXSLTTransformer {
 
-    public GmlToHtml() {
-        super("/org/auscope/portal/core/xslt/WfsToHtml.xsl");
-    }
+	private String portalBackendUrl;
+
+	public GmlToHtml(String url) {
+		super("/org/auscope/portal/core/xslt/WfsToHtml.xsl");
+		this.portalBackendUrl = url;
+	}
+
+	public GmlToHtml() {
+	    super("/org/auscope/portal/core/xslt/WfsToHtml.xsl");
+	}
 
     /**
      * Utility method to transform a WFS response into HTML
@@ -59,7 +66,13 @@ public class GmlToHtml extends PortalXSLTTransformer {
      */
     public String convert(StreamSource wfs, String serviceUrl) {
         Properties stylesheetParams = new Properties();
-        stylesheetParams.setProperty("serviceUrl", serviceUrl);
+        if (serviceUrl != null) {
+        	// this is only used for Yilgarn...
+            stylesheetParams.setProperty("serviceUrl", serviceUrl);
+        }
+        if (this.portalBackendUrl != null) {
+            stylesheetParams.setProperty("portalBaseURL", this.portalBackendUrl);
+        }
         return convert(wfs, stylesheetParams);
     }
 }

--- a/src/main/java/org/auscope/portal/core/xslt/PortalXSLTTransformer.java
+++ b/src/main/java/org/auscope/portal/core/xslt/PortalXSLTTransformer.java
@@ -22,7 +22,7 @@ import net.sf.saxon.value.StringValue;
 
 /**
  * Class for performing XSLT Transformations
- * 
+ *
  * @author Josh Vote
  *
  */
@@ -33,7 +33,7 @@ public class PortalXSLTTransformer {
 
     /**
      * Creates a new instance of this class for transforming using a single XSLT
-     * 
+     *
      * @param xsltResourceName
      *            The name of the resource (relative to this class)
      */
@@ -43,7 +43,7 @@ public class PortalXSLTTransformer {
 
     /**
      * Utility for creating an instance of the Transformer class
-     * 
+     *
      * @param xslt
      *            The style sheet contents that will form the basis of the transformer
      * @param stylesheetParams
@@ -61,12 +61,12 @@ public class PortalXSLTTransformer {
         // determines the actual class to instantiate:
         // org.apache.xalan.transformer.TransformerImpl.
         // However, we prefer Saxon...
-        TransformerFactory tFactory =  new net.sf.saxon.TransformerFactoryImpl();
+        SaxonTransformerFactory tFactory =  new net.sf.saxon.TransformerFactoryImpl();
         log.debug("XSLT implementation in use: " + tFactory.getClass());
 
         // Ensure we resolve resources locally
-        tFactory.setURIResolver(new ResourceURIResolver(getClass()));
-
+        ResourceURIResolver uriResolver = new ResourceURIResolver(getClass());
+        tFactory.setURIResolver(uriResolver);
 
         // Set stylesheet parameters
         CompilerInfo info = new CompilerInfo(tFactory.getConfiguration());
@@ -139,7 +139,7 @@ public class PortalXSLTTransformer {
                 log.error(tce);
             } catch (TransformerException e) {
                 log.error("Failed to transform xml: " + e);
-            } 
+            }
         } catch (IOException e1) {
             log.error("Failed to read xslt resource: " + e1.getMessage(), e1);
         }

--- a/src/main/resources/org/auscope/portal/core/xslt/ER1.xsl
+++ b/src/main/resources/org/auscope/portal/core/xslt/ER1.xsl
@@ -1,0 +1,978 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0"
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"    
+                xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gml="http://www.opengis.net/gml"
+                xmlns:wfs="http://www.opengis.net/wfs"
+                xmlns:wfs_2="http://www.opengis.net/wfs/2.0"                
+                xmlns:er="urn:cgi:xmlns:GGIC:EarthResource:1.1"                
+                exclude-result-prefixes="er gml wfs wfs_2 gsml xlink">
+             
+                
+    <xsl:output method="html" indent="yes"/>
+    
+    <xsl:template name="ERBody">
+                <!-- we apply the template on both featuremember and featuremembers as both are valid response.
+                     GeoServer provides the option of encoding the different result via its setting
+                     http://docs.geoserver.org/latest/en/user/data/app-schema/wfs-service-settings.html
+                     The reasoning for this configuration option can be refered here
+                     http://jira.codehaus.org/browse/GEOT-3046  -->
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MineralOccurrence |
+                        wfs:FeatureCollection/gml:featureMember/er:MineralOccurrence | er:MineralOccurrence"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:Mine |
+                        wfs:FeatureCollection/gml:featureMember/er:Mine | er:Mine"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MiningActivity |
+                        wfs:FeatureCollection/gml:featureMember/er:MiningActivity | er:MiningActivity"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:Commodity |
+                        wfs:FeatureCollection/gml:featureMember/er:Commodity | er:Commodity"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MiningFeatureOccurrence |
+                        wfs:FeatureCollection/gml:featureMember/er:MiningFeatureOccurrence | er:MiningFeatureOccurrence"/>
+                <!-- WFS 2.0 -->
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:Mine"/>                
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:MineralOccurrence"/>
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:MiningActivity"/>  
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:Commodity"/>
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:MiningFeatureOccurrence"/>  
+    </xsl:template>
+
+    <!-- TEMPLATE FOR TRANSLATING Mining Activity -->
+    <!-- =============================================================== -->
+    <xsl:template match="er:MiningActivity">
+        <xsl:variable name="miningActivityID" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+        <xsl:variable name="substring" select="substring((./er:producedMaterial/er:Product/er:sourceCommodity/@xlink:href)[1], 2)"/>
+        <xsl:variable name="commodity" select="//*[@gml:id=$substring]"/>
+
+
+
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - MiningActivity</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$miningActivityID"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <!-- Mining Activity Type -->
+                <tr>
+                    <td class="our_row header">Mining Activity Type</td>
+                    <td class="our_row"><xsl:value-of select="./er:activityType"/></td>
+                    <td class="our_row header">MiningActivity Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                        <xsl:with-param name="friendly-name" select="$miningActivityID"/>
+                        <xsl:with-param name="real-url" select="$miningActivityID"/>
+                    </xsl:call-template></td>
+                </tr>
+                <!-- Start Date -->
+                <tr>
+                    <td class="our_row header">Start Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/></td>
+                    <td class="our_row header">End Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
+                    <td class="our_row">&#160;</td>
+                </tr>
+                <!-- Associated Mine Name -->
+                <tr>
+                    <td class="our_row header">Associated Mine</td>
+                    <td class="our_row"></td>
+                    <td class="our_row header">Associated Mine Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                        <xsl:with-param name="friendly-name" select="./er:associatedMine/@xlink:href"/>
+                        <xsl:with-param name="real-url" select="./er:associatedMine/@xlink:href"/>
+                    </xsl:call-template></td>
+                </tr>
+                <!-- Amount of Ore Processed -->
+                <tr>
+                    <td class="our_row header">Amount of Ore Processed</td>
+                    <td class="our_row"><xsl:value-of select="./er:oreProcessed"/><xsl:value-of select="' '"/>
+                        <xsl:choose>
+                            <xsl:when test="contains(./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                <xsl:value-of select="substring-after(./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </td>
+                    <td class="our_row" colspan="3">&#160;</td>
+                </tr>
+                <!-- Commodity -->
+               <xsl:for-each select="./er:producedMaterial/er:Product/er:sourceCommodity">
+
+                    <xsl:choose>
+                        <xsl:when test="exists(./er:Commodity/er:commodityName)">
+                            <xsl:variable name="commodityName">
+                                <xsl:value-of select="./er:Commodity/er:commodityName" />
+                            </xsl:variable>
+
+                            <xsl:variable name="commodityID">
+                                <xsl:choose>
+                                    <xsl:when test="exists(./er:Commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616'])">
+                                        <xsl:value-of select="./er:Commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']" />
+                                    </xsl:when>
+                                    <xsl:when test="starts-with(@xlink:href, '#')">
+                                        <xsl:value-of select="$commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']" />
+                                    </xsl:when>
+                                    <xsl:otherwise>
+                                        <xsl:value-of select="@xlink:href" />
+                                    </xsl:otherwise>
+                                </xsl:choose>
+                            </xsl:variable>
+
+                            <tr>
+                                <td class="our_row header">Commodity</td>
+                                <td class="our_row"><xsl:value-of select="$commodityName"/></td>
+                                <td class="our_row header">Commodity Id:</td>
+                                <td class="our_row" colspan="2">
+                                    <xsl:choose>
+                                        <xsl:when test="starts-with($commodityID, 'http://')">
+                                            <a href="wfsFeaturePopup.do?url={$commodityID}" onclick="var w=window.open('wfsFeaturePopup.do?url={$commodityID}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="$commodityID"/></a>
+                                        </xsl:when>
+                                        <xsl:otherwise>
+                                            <xsl:value-of select="$commodityID"/>
+                                        </xsl:otherwise>
+                                    </xsl:choose>
+                                </td>
+                            </tr>
+                        </xsl:when>
+                    </xsl:choose>
+
+                </xsl:for-each>
+
+                <!-- Product Name -->
+                <xsl:for-each select="./er:producedMaterial">
+                    <xsl:choose>
+                        <xsl:when test="position()=1">
+                        <tr>
+                            <td class="our_row">&#160;</td>
+                            <td class="our_row">&#160;</td>
+                            <td class="our_row col_header">Production Amount</td>
+                            <td class="our_row col_header">Recovery %</td>
+                            <td class="our_row col_header">Grade</td>
+                        </tr>
+                        <tr>
+                            <td class="header">Product Name</td>
+                            <td><xsl:value-of select="./er:Product/er:productName"/></td>
+                            <td><xsl:value-of select="./er:Product/er:production"/><xsl:value-of select="' '"/>
+                            <xsl:choose>
+                                <xsl:when test="contains(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                    <xsl:value-of select="substring-after(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            </td>
+                            <td><xsl:value-of select="./er:Product/er:recovery"/></td>
+                            <td><xsl:value-of select="./er:Product/er:grade"/><xsl:value-of select="' '"/>
+                            <xsl:choose>
+                                <xsl:when test="contains(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                    <xsl:value-of select="substring-after(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            </td>
+                        </tr>
+                        </xsl:when>
+                        <xsl:otherwise>
+                        <tr>
+                            <td>&#160;</td>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:productName"/></td>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:production"/><xsl:value-of select="' '"/>
+                            <xsl:choose>
+                                <xsl:when test="contains(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                    <xsl:value-of select="substring-after(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            </td>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:recovery"/></td>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:grade"/><xsl:value-of select="' '"/>
+                            <xsl:choose>
+                                <xsl:when test="contains(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                    <xsl:value-of select="substring-after(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                                </xsl:when>
+                                <xsl:otherwise>
+                                    <xsl:value-of select="./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                                </xsl:otherwise>
+                            </xsl:choose>
+                            </td>
+                        </tr>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:for-each>
+                <!-- Raw Material -->
+                <xsl:if test="./er:composition">
+                    <tr>
+                        <td class="our_row header">Raw Material</td>
+                        <td class="our_row col_header">Lithology</td>
+                        <td class="our_row col_header">Role</td>
+                        <td class="our_row col_header">Proportion</td>
+                        <td class="our_row col_header">&#160;</td>
+                    </tr>
+                    <tr>
+                        <td>&#160;</td>
+                        <td ><xsl:value-of select="./er:composition/er:rawMaterial/er:material/gsml:RockMaterial/gsml:lithology"/></td>
+                        <td ><xsl:value-of select="./er:composition/er:RawMaterial/er:rawMaterialRole"/></td>
+                        <td ><xsl:value-of select="./er:composition/er:RawMaterial/er:proportion"/></td>
+                        <td>&#160;</td>
+                    </tr>
+                </xsl:if>
+                <!-- Associated Earth Resources -->
+                <tr>
+                    <td class="our_row header">Associated Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Earth Resource Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                        <xsl:with-param name="friendly-name" select="./er:deposit/@xlink:href"/>
+                        <xsl:with-param name="real-url" select="./er:deposit/@xlink:href"/>
+                    </xsl:call-template></td>
+                </tr>
+            </tbody>
+        </table>
+    </xsl:template>
+
+
+    <!-- TEMPLATE FOR TRANSLATING Mine -->
+    <!-- =============================================================== -->
+    <xsl:template match="er:Mine">
+        <xsl:variable name="mineID" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+        <xsl:variable name="minePrefName" select="./er:mineName/er:MineName[./er:isPreferred = true()]/er:mineName/text()" />
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Mine</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$mineID"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <!-- Mine Name -->
+                <tr>
+                    <td class="our_row header">Mine Name</td>
+                    <td class="our_row"><xsl:value-of select="$minePrefName"/></td>
+                    <td class="our_row header">Mine Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$mineID"/>
+                            <xsl:with-param name="real-url" select="$mineID"/>
+                        </xsl:call-template></td>
+                </tr>
+                <!-- Alternative Mine Name -->
+                <xsl:for-each select="./er:mineName/er:MineName[./er:isPreferred = 'false']">
+                    <xsl:variable name="currentOtherName" select="./er:mineName/text()"/>
+                    <xsl:choose>
+                        <xsl:when test="position()=1">
+                        <tr>
+                            <td class="our_row header">Alternative Mine Name</td>
+                            <td class="our_row"><xsl:value-of select="$currentOtherName"/></td>
+                            <td class="our_row" colspan="3">&#160;</td>
+                        </tr>
+                        </xsl:when>
+                        <xsl:otherwise>
+                        <tr>
+                            <td></td>
+                            <td><xsl:value-of select="$currentOtherName"/></td>
+                            <td colspan="3">&#160;</td>
+                        </tr>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:for-each>
+                <!-- Status -->
+                <tr>
+                    <td class="our_row header">Status</td>
+                    <td class="our_row"><xsl:value-of select="./er:status"/></td>
+                    <td class="our_row header">Occurrence</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                        <xsl:with-param name="friendly-name" select="./er:occurrence/@xlink:href"/>
+                        <xsl:with-param name="real-url" select="./er:occurrence/@xlink:href"/>
+                    </xsl:call-template></td>
+
+
+                </tr>
+
+                <xsl:for-each select="./er:relatedActivity/er:MiningActivity">
+                    <!-- Related Mining Activity -->
+                    <xsl:variable name="rel-mine-id" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+                    <xsl:choose>
+                        <xsl:when test="position()=1">
+                         <tr>
+                            <td class="our_row header">&#160;</td>
+                            <td class="our_row col_header">Start Date - End Date</td>
+                            <td class="our_row header">&#160;</td>
+                            <td class="our_row" colspan="2">&#160;</td>
+                        </tr>
+                        <tr>
+                            <td class="our_row header">Related Mining Activity</td>
+                            <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
+                            <td class="our_row header">Mining Activity Id:</td>
+                            <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                                    <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
+                                    <xsl:with-param name="real-url" select="$rel-mine-id"/>
+                                </xsl:call-template></td>
+                        </tr>
+                        </xsl:when>
+                        <xsl:otherwise>
+                        <tr>
+                            <td class="header">&#160;</td>
+                            <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
+                            <td class="our_row header">Mining Activity Id:</td>
+                            <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                                    <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
+                                    <xsl:with-param name="real-url" select="$rel-mine-id"/>
+                                </xsl:call-template></td>
+                        </tr>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    <!-- Related Mine -->
+                    <!--<xsl:for-each select="./er:associatedMine">
+                        <xsl:variable name="rel-mine-id" select="@xlink:href"/>
+                        <xsl:choose>
+                            <xsl:when test="position()=1">
+                            <tr>
+                                <td class="our_row header">Related Mine</td>
+                                <td class="our_row">&#160;</td>
+                                <td class="our_row header">Mine Id:</td>
+                                <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                                        <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
+                                        <xsl:with-param name="real-url" select="$rel-mine-id"/>
+                                    </xsl:call-template></td>
+                            </tr>
+                            </xsl:when>
+                            <xsl:otherwise>
+                            <tr>
+                                <td>&#160;</td>
+                                <td>&#160;</td>
+                                <td class="our_row header">Mine Id:</td>
+                                <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                                        <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
+                                        <xsl:with-param name="real-url" select="$rel-mine-id"/>
+                                    </xsl:call-template></td>
+                            </tr>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </xsl:for-each>-->
+                </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
+
+
+    <!-- TEMPLATE FOR TRANSLATING Commodity -->
+    <!-- =============================================================== -->
+    <xsl:template match="er:Commodity">
+        <xsl:variable name="commodity_id" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+        <xsl:variable name="commodity_name" select="./er:commodityName"/>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="2" rowspan="1">EarthResourceML - Commodity</td>
+                    <td>&#160;</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$commodity_id"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <!-- Commodity -->
+                <tr>
+                    <td class="our_row header">Commodity</td>
+                    <td class="our_row">
+                        <xsl:value-of select="$commodity_name"/>
+                    </td>
+                    <td class="our_row header">Commodity Id:</td>
+                    <td class="our_row" colspan="1">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$commodity_id"/>
+                            <xsl:with-param name="real-url" select="$commodity_id"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Local Name*</td>
+                    <td class="our_row"><xsl:value-of select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
+                    <td class="our_row header">Local Group*</td>
+                    <td class="our_row" colspan="1"><xsl:value-of select="./er:commodityGroup[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Importance</td>
+                    <td class="our_row" ><xsl:value-of select="./er:commodityImportance"/></td>
+                    <td class="our_row header">Rank:</td>
+                    <td class="our_row" colspan="1"><xsl:value-of select="./er:commodityRank"/></td>
+                </tr>
+        <xsl:for-each select="./er:source">
+            <xsl:choose>
+                <xsl:when test="position()=1">
+                <tr>
+                    <td class="our_row header">Associated Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Earth Resource Id:</td>
+                    <td class="our_row" colspan="1">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="@xlink:href"/>
+                            <xsl:with-param name="real-url" select="@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                </xsl:when>
+                <xsl:otherwise>
+                <tr>
+                    <td>&#160;</td>
+                    <td>&#160;</td>
+                    <td class="our_row header">Earth Resource Id:</td>
+                    <td class="our_row" colspan="1">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="@xlink:href"/>
+                            <xsl:with-param name="real-url" select="@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+            </tbody>
+        </table>
+    </xsl:template>
+
+
+    <!-- TEMPLATE FOR TRANSLATING Mineral Occurrence -->
+    <!-- =============================================================== -->
+    <xsl:template match="er:MineralOccurrence">
+        <xsl:variable name="minocc_id">
+            <xsl:value-of select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+        </xsl:variable>
+        <table>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="2" rowspan="1">EarthResourceML - MineralOccurrence</td>
+                    <td>&#160;</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$minocc_id"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <!-- Type -->
+                <tr>
+                    <td class="our_row header">Type</td>
+                    <td class="our_row"><xsl:value-of select="er:type"/></td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$minocc_id"/>
+                            <xsl:with-param name="real-url" select="$minocc_id"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <!-- Mineral Occurrence Name -->
+        <xsl:for-each select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]">
+            <xsl:choose>
+                <xsl:when test="position()=1">
+                <tr>
+                    <td class="our_row header">Mineral Occurrence Name</td>
+                    <td class="our_row"><xsl:value-of select="."/></td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row">&#160;</td>
+                </tr>
+                </xsl:when>
+                <xsl:otherwise>
+                <tr>
+                    <td>&#160;</td>
+                    <td><xsl:value-of select="."/></td>
+                    <td>&#160;</td>
+                    <td>&#160;</td>
+                    <td>&#160;</td>
+                </tr>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:for-each>
+                <!-- Description -->
+        <xsl:if test="gml:description">
+                <tr>
+                    <td class="our_row header" rowspan="1">Description</td>
+                    <td class="our_row" rowspan="2" colspan="4"><xsl:value-of select="./gml:description"/></td>
+                </tr>
+                <tr></tr><!-- VT: workaround to fix a spacing bug in the output-->
+        </xsl:if>
+                <!-- Commodity -->
+        <xsl:for-each select="./er:commodityDescription">
+            <xsl:variable name="comm_description">
+                <xsl:value-of select="@xlink:href"/>
+            </xsl:variable>
+            <xsl:variable name="comm_name">
+                <xsl:value-of select="./er:Commodity/er:commodityName"/>
+            </xsl:variable>
+            <xsl:variable name="comm_url">
+                <xsl:value-of select="./er:Commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+            </xsl:variable>
+            <tr>
+                    <td class="our_row header">Commodity</td>
+                    <td class="our_row"><xsl:value-of select="$comm_name"/></td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$comm_url"/>
+                            <xsl:with-param name="real-url" select="$comm_url"/>
+                        </xsl:call-template>
+                    </td>
+            </tr>
+                
+        </xsl:for-each>
+                <!-- Observation Method -->
+                <tr>
+                    <td class="our_row header">Observation Method</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td class="our_row header">Purpose:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./gsml:purpose"/></td>
+                </tr>
+                 <!-- Dimension -->
+       <xsl:if test="./er:dimension">
+                <tr>
+                    <td class="our_row header">Dimension</td>
+                    <td class="our_row col_header">Area</td>
+                    <td class="our_row col_header">Depth</td>
+                    <td class="our_row col_header">Length</td>
+                    <td class="our_row col_header">Width</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:area/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:area/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:depth/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:depth/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:length/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:length/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:width/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:width/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                </tr>
+       </xsl:if>
+                <!-- Appearance -->
+       <xsl:if test="./er:form | ./er:expression | ./er:shape">
+                <tr>
+                    <td class="our_row header">Appearance</td>
+                    <td class="our_row col_header">Form</td>
+                    <td class="our_row col_header">Expression</td>
+                    <td class="our_row col_header">Shape</td>
+                    <td class="our_row col_header">&#160;</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:form/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td><xsl:value-of select="./er:expression/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td><xsl:value-of select="./er:shape/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td></td>
+                </tr>
+       </xsl:if>
+                <!-- Linear Orientation -->
+       <xsl:if test="./er:linearOrientation">
+                <tr>
+                    <td class="our_row header">Linear Orientation</td>
+                    <td class="our_row col_header">Plunge</td>
+                    <td class="our_row col_header">Trend</td>
+                    <td class="our_row col_header">&#160;</td>
+                    <td class="our_row col_header">&#160;</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:linearOrientation/gsml:CGI_LinearOrientation/gsml:plungeValue"/></td>
+                    <td><xsl:value-of select="./er:linearOrientation/gsml:CGI_LinearOrientation/gsml:trend"/></td>
+                    <td></td>
+                    <td></td>
+                </tr>
+       </xsl:if>
+                <!-- Planar Orientation -->
+       <xsl:if test="./er:planarOrientation">
+                <tr>
+                    <td class="our_row header">Planar Orientation</td>
+                    <td class="our_row col_header">Convention</td>
+                    <td class="our_row col_header">Azimuth</td>
+                    <td class="our_row col_header">Dip</td>
+                    <td class="our_row col_header">&#160;</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:planarOrientation/gsml:CGI_PlanarOrientation/gsml:convention"/></td>
+                    <td><xsl:value-of select="./er:planarOrientation/gsml:CGI_PlanarOrientation/gsml:azimuth/gsml:CGI_NumericValue/gsml:principalValue"/></td>
+                    <td><xsl:value-of select="./er:planarOrientation/gsml:CGI_PlanarOrientation/gsml:dip/gsml:CGI_NumericValue/gsml:principalValue"/></td>
+                    <td></td>
+                </tr>
+       </xsl:if>
+                <!-- Classification -->
+       <xsl:if test="./er:classification">
+                <tr>
+                    <td class="our_row header">Classification</td>
+                    <td class="our_row col_header">Deposit Group</td>
+                    <td class="our_row col_header">&#160;</td>
+                    <td class="our_row col_header">Deposit Type</td>
+                    <td class="our_row col_header">&#160;</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:classification/er:MineralDepositModel/er:mineralDepositGroup"/></td>
+                    <td></td>
+                    <td><xsl:value-of select="./er:classification/er:MineralDepositModel/er:mineralDepositType"/></td>
+                    <td></td>
+                </tr>
+       </xsl:if>
+                <!-- Supergene Modification -->
+       <xsl:if test="./er:supergeneModification">
+                <tr>
+                    <td class="our_row header">Supergene Modification</td>
+                    <td class="col_header">Lithology</td>
+                    <td class="col_header">Supergene Type</td>
+                    <td class="col_header">Depth</td>
+                    <td class="col_header"></td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td></td>
+                    <!-- <td><xsl:value-of select="./er:supergeneModification/er:SupergeneProcesses/er:material/gsml:lithology"/></td> -->
+                    <td><xsl:value-of select="./er:supergeneModification/er:SupergeneProcesses/er:type/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td><xsl:value-of select="./er:supergeneModification/er:SupergeneProcesses/er:depth/gsml:CGI_Numeric/gsml:CGI_NumericValue/gsml:principalValue"/></td>
+                    <td></td>
+                </tr>
+       </xsl:if>
+                <!-- Composition
+                Note: there are more than one type of thing in here. -->
+       <xsl:if test="./er:composition">
+           <xsl:for-each select="./er:composition">
+                <tr>
+                    <td class="our_row header">Composition</td>
+                 <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title">
+                    <td class="our_row col_header">Lithology</td>
+                </xsl:if>
+                 <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title">
+                    <td class="our_row col_header">Mineral Name</td>
+                </xsl:if>
+
+                    <td class="our_row col_header">Role</td>
+                    <td class="our_row col_header">Proportion</td>
+                    <td class="our_row col_header"></td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title">
+                        <td><xsl:value-of select="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title"/></td>
+                    </xsl:if>
+                     <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title">
+                        <td><xsl:value-of select="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title"/></td>
+                    </xsl:if>
+                    <td><xsl:value-of select="./er:EarthResourceMaterial/er:earthResourceMaterialRole"/></td>
+                    <td><xsl:value-of select="./er:EarthResourceMaterial/er:proportion/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:call-template name="convert-escaped-percentage">
+                            <xsl:with-param name="value" select="substring-after(./er:composition/er:EarthResourceMaterial/er:proportion/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                        </xsl:call-template>
+                    </td>
+                    <td></td>
+                </tr>
+           </xsl:for-each>
+       </xsl:if>
+                <!-- Geological History -->
+       <xsl:if test="./gsml:preferredAge/gsml:GeologicEvent">
+                <tr>
+                    <td class="our_row header">Geological History</td>
+                    <td class="our_row col_header">Age</td>
+                    <td class="our_row col_header">Process</td>
+                    <td class="our_row col_header">Environment</td>
+                    <td class="our_row col_header"></td>
+                </tr>
+            <xsl:for-each select="./gsml:preferredAge/gsml:GeologicEvent">
+                <tr>
+                    <td></td>
+                    <td>
+                    <xsl:choose>
+                        <xsl:when test="./gsml:eventAge/gsml:CGI_TermValue/gsml:value">
+                            <xsl:value-of select="./gsml:eventAge/gsml:CGI_TermValue/gsml:value"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="./gsml:eventAge/gsml:CGI_NumericValue/gsml:principalValue"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                    </td>
+                    <td><xsl:value-of select="./gsml:eventProcess/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td><xsl:value-of select="./gsml:eventEnvironment/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td></td>
+                </tr>
+            </xsl:for-each>
+       </xsl:if>
+                <!-- Reserves -->
+        <xsl:for-each select="./er:oreAmount/er:Reserve">
+                <tr>
+                    <td class="our_row header">Reserves</td>
+                    <td class="our_row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td class="our_row"><xsl:value-of select="./er:category"/></td>
+                    <td class="our_row header">Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:date"/></td>
+                </tr>
+            <xsl:for-each select="./er:measureDetails">
+                <xsl:variable name="comm_description" select="substring-after(./er:CommodityMeasure/er:commodityOfInterest/@xlink:href,'#')"></xsl:variable>
+                <xsl:variable name="comm_org_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"></xsl:variable>
+                <xsl:variable name="comm_std_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/er:commodityName[@codeSpace='urn:cgi:classifierScheme:GA:commodity']"></xsl:variable>
+                <xsl:variable name="comm_url" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"></xsl:variable>
+                <tr>
+                    <td class="col_header" >Commodity:</td>
+                    <td class="our_row"><xsl:value-of select="$comm_std_name"/></td>
+                    <td class="our_row header">Commodity Id:</td>
+                        <td class="our_row" colspan="2">
+                            <xsl:call-template name="make-wfspopup-url">
+                                <xsl:with-param name="friendly-name" select="$comm_description"/>
+                                <xsl:with-param name="real-url" select="$comm_description"/>
+                            </xsl:call-template>
+                        </td>
+                    </tr>
+                <tr>
+                    <td></td>
+                    <td class="our_row col_header">Commodity Amount</td>
+                    <td class="our_row col_header">Cut-off Grade</td>
+                    <td class="our_row col_header">Grade</td>
+                    <td class="our_row col_header">Importance</td>
+                </tr>
+                <xsl:variable name="cut_off_grade_uom">
+                    <xsl:choose>
+                        <xsl:when test="contains(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:variable name="grade_uom">
+                    <xsl:choose>
+                        <xsl:when test="contains(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:choose>
+                            <xsl:when test="contains(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                <xsl:value-of select="substring-after(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:call-template name="convert-escaped-percentage">
+                            <xsl:with-param name="value" select="$cut_off_grade_uom"/>
+                        </xsl:call-template>
+                    </td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:call-template name="convert-escaped-percentage">
+                            <xsl:with-param name="value" select="$grade_uom"/>
+                        </xsl:call-template>
+                    </td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityOfInterest/er:commodityImportance"/></td>
+                </tr>
+            </xsl:for-each>
+        </xsl:for-each>
+                <!-- Resources -->
+        <xsl:for-each select="./er:oreAmount/er:Resource">
+                <tr>
+                    <td class="our_row header">Resources</td>
+                    <td class="our_row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td class="our_row"><xsl:value-of select="./er:category"/></td>
+                    <td class="our_row header">Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:date"/></td>
+                </tr>
+            <xsl:for-each select="./er:measureDetails">
+                <xsl:variable name="comm_description" select="substring-after(./er:CommodityMeasure/er:commodityOfInterest/@xlink:href,'#')"></xsl:variable>
+                <xsl:variable name="comm_org_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"></xsl:variable>
+                <xsl:variable name="comm_std_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/er:commodityName[@codeSpace='urn:cgi:classifierScheme:GA:commodity']"></xsl:variable>
+                <xsl:variable name="comm_url" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"></xsl:variable>
+                    <tr>
+                        <td class="col_header" >Commodity:</td>
+                        <td class="our_row">
+                            <xsl:call-template name="make-popup-url">
+                                <xsl:with-param name="friendly-name" select="$comm_std_name"/>
+                                <xsl:with-param name="real-url" select="$comm_std_name"/>
+                            </xsl:call-template>
+                        </td>
+                        <td class="our_row header">Id:</td>
+                        <td class="our_row" colspan="2">
+                            <xsl:call-template name="make-wfspopup-url">
+                                <xsl:with-param name="friendly-name" select="$comm_url"/>
+                                <xsl:with-param name="real-url" select="$comm_url"/>
+                            </xsl:call-template>
+                        </td>
+                    </tr>
+                <xsl:variable name="cut_off_grade_uom">
+                    <xsl:choose>
+                        <xsl:when test="contains(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <xsl:variable name="grade_uom">
+                    <xsl:choose>
+                        <xsl:when test="contains(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                        </xsl:when>
+                        <xsl:otherwise>
+                            <xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                        </xsl:otherwise>
+                    </xsl:choose>
+                </xsl:variable>
+                <tr>
+                    <td></td>
+                    <td class="our_row col_header">Commodity Amount</td>
+                    <td class="our_row col_header">Cut-off Grade</td>
+                    <td class="our_row col_header">Grade</td>
+                    <td class="our_row col_header">Importance</td>
+                </tr>
+                <tr>
+                    <td></td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:choose>
+                            <xsl:when test="contains(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
+                                <xsl:value-of select="substring-after(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
+                            </xsl:when>
+                            <xsl:otherwise>
+                                <xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
+                            </xsl:otherwise>
+                        </xsl:choose>
+                    </td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:call-template name="convert-escaped-percentage">
+                            <xsl:with-param name="value" select="$cut_off_grade_uom"/>
+                        </xsl:call-template>
+                    </td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
+                        <xsl:call-template name="convert-escaped-percentage">
+                            <xsl:with-param name="value" select="$grade_uom"/>
+                        </xsl:call-template>
+                    </td>
+                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityOfInterest/er:commodityImportance"/></td>
+                </tr>
+            </xsl:for-each>
+        </xsl:for-each>
+                <!-- Associated Mining Activity -->
+       <xsl:if test="./er:resourceExtraction">
+                <tr>
+                    <td class="our_row header">Associated Mining Activity</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
+                        <a href="wfsFeaturePopup.do?url={./er:resourceExtraction/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:resourceExtraction/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:resourceExtraction/@xlink:href,'=')"/></a>
+                    </td>
+                </tr>
+       </xsl:if>
+                <!-- Parent Earth Resources -->
+       <xsl:if test="./er:parent">
+                <tr>
+                    <td class="our_row header">Parent Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
+                        <a href="wfsFeaturePopup.do?url={./er:parent/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:parent/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:parent/@xlink:href,'=')"/></a>
+                    </td>
+                </tr>
+       </xsl:if>
+                <!-- Child Earth Resources -->
+       <xsl:if test="./er:child">
+                <tr>
+                    <td class="our_row header">Child Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
+                        <a href="wfsFeaturePopup.do?url={./er:child/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:child/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:child/@xlink:href,'=')"/></a>
+                    </td>
+                </tr>
+       </xsl:if>
+            </tbody>
+        </table>
+    </xsl:template>
+
+
+
+    <!-- TEMPLATE FOR TRANSLATING MiningFeatureOccurrence -->
+    <!-- =============================================================== -->
+    <xsl:template match="er:MiningFeatureOccurrence">
+        <xsl:variable name="mfoID" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - MiningFeatureOccurrence</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$mfoID"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+
+                <!-- MiningFeatureOccurrence Type -->
+                <tr>
+                    <td class="our_row header">Mining Feature Occurrence Description:</td>
+                    <td class="our_row"><xsl:value-of select="./gml:description"/></td>
+                    <td class="our_row header">Mining Feature Occurrence Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$mfoID"/>
+                            <xsl:with-param name="real-url" select="$mfoID"/>
+                        </xsl:call-template></td>
+                </tr>
+                <!-- Observation Method -->
+                <tr>
+                    <td class="our_row header" colspan="2">Observation Method:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./er:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td class="our_row" colspan="1">&#160;</td>
+                </tr>
+                <!-- Positional Accuracy -->
+                <tr>
+                    <td class="our_row header" colspan="2">Positional Accuracy:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./er:positionalAccuracy/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td class="our_row" colspan="1">&#160;</td>
+                </tr>
+            </tbody>
+        </table>&#160;
+
+        <xsl:for-each select="./er:specification/er:Mine">
+            <p></p>
+            <table>
+                <tbody>
+                    <xsl:apply-templates select=". | er:Mine"/>
+                </tbody>
+            </table>&#160;
+        </xsl:for-each>
+
+        <xsl:for-each select="./er:specification/er:Mine/er:relatedActivity/er:MiningActivity">
+        <p></p>
+            <table>
+                <tbody>
+                    <xsl:apply-templates select=". | er:MiningActivity"/>
+                </tbody>
+            </table>&#160;
+        </xsl:for-each>
+    </xsl:template>    
+</xsl:stylesheet>

--- a/src/main/resources/org/auscope/portal/core/xslt/ER2.xsl
+++ b/src/main/resources/org/auscope/portal/core/xslt/ER2.xsl
@@ -1,0 +1,329 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="3.0" 
+                xmlns="http://www.w3.org/1999/xhtml"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"   
+                xmlns:xlink="http://www.w3.org/1999/xlink"   
+                xmlns:gml="http://www.opengis.net/gml/3.2"   
+                xmlns:gsml="http://xmlns.geosciml.org/GeoSciML-Core/3.2"
+                xmlns:gsmlu="http://xmlns.geosciml.org/Utilities/3.2"
+                xmlns:er="http://xmlns.earthresourceml.org/EarthResource/2.0"
+                xmlns:swe="http://www.opengis.net/swe/2.0"
+                xmlns:wfs="http://www.opengis.net/wfs"
+                xmlns:wfs_2="http://www.opengis.net/wfs/2.0"
+                exclude-result-prefixes="er gml wfs wfs_2 gsml gsmlu xlink wfs swe">
+                
+    <xsl:output method="html" indent="yes"/>
+                
+    <xsl:template name="ERBody">
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MineralOccurrence |
+                        wfs:FeatureCollection/gml:featureMember/er:MineralOccurrence | er:MineralOccurrence"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:Mine |
+                        wfs:FeatureCollection/gml:featureMember/er:Mine | er:Mine"/>                
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:Commodity |
+                        wfs:FeatureCollection/gml:featureMember/er:Commodity | er:Commodity"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MiningFeatureOccurrence |
+                        wfs:FeatureCollection/gml:featureMember/er:MiningFeatureOccurrence | er:MiningFeatureOccurrence"/>
+                <!-- WFS 2.0 -->
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:Mine"/>                
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:MineralOccurrence"/>
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:Commodity"/>
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/er:MiningFeatureOccurrence"/>   
+    </xsl:template>
+    <xsl:template match="er:Mine">
+        <xsl:variable name="mineID" select="./gml:identifier"/>
+        <xsl:variable name="minePrefName" select="./er:mineName/er:MineName/er:mineName/text()" />
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Mine</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$mineID"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Mine Name:</td>
+                    <td class="our_row"><xsl:value-of select="$minePrefName"/></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Mine Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$mineID"/>
+                            <xsl:with-param name="real-url" select="$mineID"/>
+                        </xsl:call-template></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Status:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="./er:status/@xlink:title"/>
+                            <xsl:with-param name="real-url" select="./er:status/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Source Reference:</td>
+                    <td class="our_row"><xsl:value-of select="./er:sourceReference/@xlink:title"/></td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="./er:sourceReference/@xlink:title"/>
+                            <xsl:with-param name="real-url" select="./er:sourceReference/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+            </tbody>
+        </table>&#160;
+        <xsl:for-each select="./er:occurrence/er:MiningFeatureOccurrence">
+            <xsl:apply-templates select=". | er:MiningFeatureOccurrence"/>&#160;
+        </xsl:for-each>
+     </xsl:template>
+     <xsl:template match="er:MiningFeatureOccurrence">
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Mining Feature Occurrence</td>
+                    <td colspan="2" ALIGN="right"/>
+                </tr>
+                
+                <xsl:apply-templates select="./er:observationMethod/swe:Category"/>
+                <xsl:apply-templates select="./er:positionalAccuracy/swe:Quantity"/>
+                <tr>
+                    <td class="our_row header">Shape:</td>
+                    <td class="our_row"><xsl:value-of select="./er:shape"/></td>
+                </tr>
+             </tbody>
+         </table>
+     </xsl:template>
+     <xsl:template match="swe:Category">
+         <tr>
+             <td class="our_row header">Observation Method:</td>  
+             <td class="our_row" colspan="2">
+                 <xsl:call-template name="make-popup-url">
+                     <xsl:with-param name="friendly-name" select="./swe:label"/>
+                     <xsl:with-param name="real-url" select="./@definition"/>
+                 </xsl:call-template>
+             </td>
+         </tr>
+     </xsl:template>
+     <xsl:template match="swe:Quantity">
+         <tr>
+             <td class="our_row header">Positional Accuracy:</td>
+             <td class="our_row"><xsl:value-of 
+                    select="concat(./swe:value, ' (', ./swe:uom/@code, ')')"/>
+             </td>
+         </tr>
+     </xsl:template>
+     <xsl:template match="er:CommodityMeasure">
+         <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Commodity Measure</td>
+                    <td colspan="2" ALIGN="right"/>
+                </tr>
+                <tr>
+                    <td class="our_row header">Grade (lower value):</td>  
+                    <td class="our_row"><xsl:value-of 
+                        select="concat(./er:grade/gsmlu:GSML_QuantityRange/gsmlu:lowerValue, ./er:grade/gsmlu:GSML_QuantityRange/swe:uom/@code)"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Grade (upper value):</td>  
+                    <td class="our_row"><xsl:value-of 
+                        select="concat(./er:grade/gsmlu:GSML_QuantityRange/gsmlu:upperValue, ./er:grade/gsmlu:GSML_QuantityRange/swe:uom/@code)"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Commodity of Interest:</td>  
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="./er:commodityOfInterest/@xlink:title"/>
+                            <xsl:with-param name="real-url" select="./er:commodityOfInterest/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+     </xsl:template>
+     <xsl:template match="er:Commodity">
+        <xsl:variable name="minePrefName" select="./er:mineName/er:MineName/er:mineName/text()" />
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Commodity</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="./gml:identifier"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Identifier:</td>  
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="./gml:identifier"/>
+                            <xsl:with-param name="real-url" select="./gml:identifier"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Commodity:</td>  
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="./er:commodity/@xlink:title"/>
+                            <xsl:with-param name="real-url" select="./er:commodity/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Commodity Importance:</td>
+                    <td class="our_row"><xsl:value-of select="./er:commodityImportance"/></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Commodity Rank:</td>
+                    <td class="our_row"><xsl:value-of select="./er:commodityRank"/></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Source:</td>  
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="./er:source/@xlink:href"/>
+                            <xsl:with-param name="real-url" select="./er:source/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+            </tbody>
+         </table>
+     </xsl:template>
+     <xsl:template match="er:MineralOccurrence">
+        <xsl:variable name="id" select="./gml:identifier"/>
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Mineral Occurrence</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$id"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Identifier:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="$id"/>
+                            <xsl:with-param name="real-url" select="$id"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Name:</td>
+                    <td class="our_row"><xsl:value-of select="./gml:name"/></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Purpose:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:purpose"/></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Parent:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="./er:parent/@xlink:href"/>
+                            <xsl:with-param name="real-url" select="./er:parent/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Type:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="./er:type/@xlink:title"/>
+                            <xsl:with-param name="real-url" select="./er:type/@xlink:href"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>                
+                <xsl:apply-templates select="./gsml:observationMethod/swe:Category"/>
+            </tbody>
+        </table>&#160;
+        <xsl:apply-templates select="./gsml:occurrence/gsml:MappedFeature" />&#160;
+        <xsl:for-each select="./er:commodityDescription/er:Commodity">
+            <xsl:apply-templates select=". | er:Commodity" />&#160;
+        </xsl:for-each>
+
+        <xsl:for-each select="./er:child/er:MineralOccurrence">
+            <p class="child_table"><xsl:value-of select="concat('Child ', position(), ':')" /></p>
+            <xsl:apply-templates select=". | er:MineralOccurrence" />&#160;
+        </xsl:for-each>
+
+        <xsl:for-each select="./er:oreAmount/er:Resource/er:measureDetails/er:CommodityMeasure">
+            <xsl:apply-templates select=". | er:CommodityMeasure" />&#160;
+        </xsl:for-each>
+    </xsl:template>
+
+    <xsl:template match="gsml:MappedFeature">
+        <table>
+            <colgroup span="1" width="15%" />
+            <colgroup span="1" width="25%" />
+            <colgroup span="2" width="15%" />
+            <colgroup span="1" width="35%" />
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">GeoSciML - Mapped Feature</td>
+                    <td colspan="2" ALIGN="right"/>
+                </tr>
+                <xsl:apply-templates
+                    select="./gsml:observationMethod/swe:Category" />
+                <xsl:apply-templates
+                    select="./gsml:positionalAccuracy/swe:Quantity" />
+                <tr>
+                    <td class="our_row header">Sampling Frame:</td>
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param
+                                name="friendly-name"
+                                select="./gsml:samplingFrame/@xlink:href" />
+                            <xsl:with-param
+                                name="real-url"
+                                select="./gsml:samplingFrame/@xlink:href" />
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Shape:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:shape" /></td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Specification:</td>
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param
+                                name="friendly-name"
+                                select="./gsml:specification/@xlink:href" />
+                            <xsl:with-param
+                                name="real-url"
+                                select="./gsml:specification/@xlink:href" />
+                        </xsl:call-template>
+                    </td>
+                </tr>
+            </tbody>
+        </table>            
+    </xsl:template>
+</xsl:stylesheet>

--- a/src/main/resources/org/auscope/portal/core/xslt/ER2.xsl
+++ b/src/main/resources/org/auscope/portal/core/xslt/ER2.xsl
@@ -68,7 +68,6 @@
                 </tr>
                 <tr>
                     <td class="our_row header">Source Reference:</td>
-                    <td class="our_row"><xsl:value-of select="./er:sourceReference/@xlink:title"/></td>
                     <td class="our_row" colspan="2"><xsl:call-template name="make-popup-url">
                             <xsl:with-param name="friendly-name" select="./er:sourceReference/@xlink:title"/>
                             <xsl:with-param name="real-url" select="./er:sourceReference/@xlink:href"/>

--- a/src/main/resources/org/auscope/portal/core/xslt/WfsToHtml.xsl
+++ b/src/main/resources/org/auscope/portal/core/xslt/WfsToHtml.xsl
@@ -1,27 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0"
-                xmlns="http://www.w3.org/1999/xhtml"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-                xmlns:er="urn:cgi:xmlns:GGIC:EarthResource:1.1"
-                xmlns:fo="http://www.w3.org/1999/XSL/Format"
-                xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0"
-                xmlns:xlink="http://www.w3.org/1999/xlink"
-                xmlns:gml="http://www.opengis.net/gml"
-                xmlns:wfs="http://www.opengis.net/wfs"
-                exclude-result-prefixes="er gml wfs fo gsml xlink">
-    <xsl:output method="html" indent="yes"/>
-
-    <!-- External Parameters -->    
-    <xsl:param name="serviceURL"/>
-    <xsl:param name="vocabserviceURL"/>
-    <xsl:param name="vocabservice-reponame"/>
-    <xsl:param name="portalBaseURL"/>
-    <xsl:variable name="vocab-hard-coded-lookup" select="concat('http://services.auscope.org/sissvoc/commodity-vocab/resource.rdf?uri=http://resource.auscope.org/classifier/GA/commodity/', '')"/>
-    <xsl:variable name="vocab-hard-coded-lookupCGI" select="concat('http://services-test.auscope.org/SISSVoc/getConceptByURI?CGI/', '')"/>
-
+<xsl:stylesheet version="3.0" xmlns="http://www.w3.org/1999/xhtml" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:wfs="http://www.opengis.net/wfs"      
+        xmlns:wfs_2="http://www.opengis.net/wfs/2.0"  
+        xmlns:mo="http://xmlns.geoscience.gov.au/minoccml/1.0" 
+        xmlns:mt="http://xmlns.geoscience.gov.au/mineraltenementml/1.0"
+        xmlns:gsml="urn:cgi:xmlns:CGI:GeoSciML:2.0"
+        xmlns:gsmlp="http://xmlns.geosciml.org/geosciml-portrayal/4.0"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns:gml="http://www.opengis.net/gml"
+        xmlns:sa="http://www.opengis.net/sampling/1.0"
+        exclude-result-prefixes="gml wfs wfs_2 gsml xlink mo mt gsmlp sa">
+    <!-- ERML Namespace URI -->
+    <xsl:param name="er" required="yes" static="yes"/>  
+    <xsl:param name="portalBaseURL"/>  
+    
+    <xsl:variable name="erl" select="'http://xmlns.earthresourceml.org/earthresourceml-lite'"/>
+    
+    <xsl:include href="ER1.xsl" use-when="$er='urn:cgi:xmlns:GGIC:EarthResource:1.1'"/>
+    <xsl:include href="ER2.xsl" use-when="$er='http://xmlns.earthresourceml.org/EarthResource/2.0'"/>
+    
+    
     <!-- Global Variables -->
-
-
     <xsl:template match="/">
     <!--
     <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
@@ -78,1091 +77,46 @@
                     td.no_border {
                         border-top: none;
                     }
+                    p.child_table {
+                        text-decoration-line: underline;
+                        font-weight: bold;
+                        font-size:medium;
+                        color: Black;
+                    }
 
                 </style>
                 <title>AuScope Portal Project</title>
                 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
             </head>
             <body>
-                <!-- we apply the template on both featuremember and featuremembers as both are valid response.
-                     GeoServer provides the option of encoding the different result via its setting
-                     http://docs.geoserver.org/latest/en/user/data/app-schema/wfs-service-settings.html
-                     The reasoning for this configuration option can be refered here
-                     http://jira.codehaus.org/browse/GEOT-3046  -->
-                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MineralOccurrence |
-                        wfs:FeatureCollection/gml:featureMember/er:MineralOccurrence | er:MineralOccurrence"/>
-                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:Mine |
-                        wfs:FeatureCollection/gml:featureMember/er:Mine | er:Mine"/>
-                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MiningActivity |
-                        wfs:FeatureCollection/gml:featureMember/er:MiningActivity | er:MiningActivity"/>
-                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:Commodity |
-                        wfs:FeatureCollection/gml:featureMember/er:Commodity | er:Commodity"/>
-                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/er:MiningFeatureOccurrence |
-                        wfs:FeatureCollection/gml:featureMember/er:MiningFeatureOccurrence | er:MiningFeatureOccurrence"/>
-                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/gsml:GeologicUnit |
-                        wfs:FeatureCollection/gml:featureMember/gsml:GeologicUnit | gsml:GeologicUnit"/>
+                <!-- Specific for ER1.xsl and ER2.xsl -->
+                <xsl:call-template name="ERBody" />
+                <!-- Everything else -->
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/mo:MinOccView |
+                        wfs:FeatureCollection/gml:featureMember/mo:MinOccView | mo:MinOccView"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/mt:MineralTenement |
+                        wfs:FeatureCollection/gml:featureMember/mt:MineralTenement | mt:MineralTenement"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/gsmlp:BoreholeView |
+                        wfs:FeatureCollection/gml:featureMember/gsmlp:BoreholeView | gsmlp:BoreholeView"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/gsml:Borehole |
+                        wfs:FeatureCollection/gml:featureMember/gsml:Borehole | gsml:Borehole"/>       
+                <!-- EarthResourceML Lite. Unfortunately there's a mix of ERL1 and ERL2 in the data, so we can't specify the namespace -->
+                <!-- ERL with WFS 1.1.0 -->
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/*:MineralOccurrenceView |
+                        wfs:FeatureCollection/gml:featureMember/*:MineralOccurrenceView | *:MineralOccurrenceView"/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/*:MineView |
+                        wfs:FeatureCollection/gml:featureMember/*:MineView | *:MineView "/>
+                <xsl:apply-templates select="wfs:FeatureCollection/gml:featureMembers/*:CommodityResourceView |
+                        wfs:FeatureCollection/gml:featureMember/*:CommodityResourceView | *:CommodityResourceView"/>
+                <!-- ERL with WFS 2.0 -->                   
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/*:MineralOccurrenceView"/>
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/*:CommodityResourceView"/>
+                <xsl:apply-templates select="wfs_2:FeatureCollection/wfs_2:member/*:MineView"/>
+                
             </body>
         </html>
     </xsl:template>
-
-
-    <!-- TEMPLATE FOR TRANSLATING Mining Activity -->
-    <!-- =============================================================== -->
-    <xsl:template match="er:MiningActivity">
-        <xsl:variable name="miningActivityID" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-        <xsl:variable name="substring" select="substring((./er:producedMaterial/er:Product/er:sourceCommodity/@xlink:href)[1], 2)"/>
-        <xsl:variable name="commodity" select="//*[@gml:id=$substring]"/>
-
-
-
-        <table>
-            <colgroup span="1" width="15%"/>
-            <colgroup span="1" width="25%"/>
-            <colgroup span="2" width="15%"/>
-            <colgroup span="1" width="35%"/>
-            <tbody>
-                <tr>
-                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - MiningActivity</td>
-                    <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
-                            <xsl:with-param name="real-url" select="$miningActivityID"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <!-- Mining Activity Type -->
-                <tr>
-                    <td class="our_row header">Mining Activity Type</td>
-                    <td class="our_row"><xsl:value-of select="./er:activityType"/></td>
-                    <td class="our_row header">MiningActivity Id:</td>
-                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                        <xsl:with-param name="friendly-name" select="$miningActivityID"/>
-                        <xsl:with-param name="real-url" select="$miningActivityID"/>
-                    </xsl:call-template></td>
-                </tr>
-                <!-- Start Date -->
-                <tr>
-                    <td class="our_row header">Start Date:</td>
-                    <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/></td>
-                    <td class="our_row header">End Date:</td>
-                    <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
-                    <td class="our_row">&#160;</td>
-                </tr>
-                <!-- Associated Mine Name -->
-                <tr>
-                    <td class="our_row header">Associated Mine</td>
-                    <td class="our_row"></td>
-                    <td class="our_row header">Associated Mine Id:</td>
-                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                        <xsl:with-param name="friendly-name" select="./er:associatedMine/@xlink:href"/>
-                        <xsl:with-param name="real-url" select="./er:associatedMine/@xlink:href"/>
-                    </xsl:call-template></td>
-                </tr>
-                <!-- Amount of Ore Processed -->
-                <tr>
-                    <td class="our_row header">Amount of Ore Processed</td>
-                    <td class="our_row"><xsl:value-of select="./er:oreProcessed"/><xsl:value-of select="' '"/>
-                        <xsl:choose>
-                            <xsl:when test="contains(./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                <xsl:value-of select="substring-after(./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:value-of select="./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </td>
-                    <td class="our_row" colspan="3">&#160;</td>
-                </tr>
-                <!-- Commodity -->
-               <xsl:for-each select="./er:producedMaterial/er:Product/er:sourceCommodity">
-
-                    <xsl:choose>
-                        <xsl:when test="exists(./er:Commodity/er:commodityName)">
-                            <xsl:variable name="commodityName">
-                                <xsl:value-of select="./er:Commodity/er:commodityName" />
-                            </xsl:variable>
-
-                            <xsl:variable name="commodityID">
-                                <xsl:choose>
-                                    <xsl:when test="exists(./er:Commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616'])">
-                                        <xsl:value-of select="./er:Commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']" />
-                                    </xsl:when>
-                                    <xsl:when test="starts-with(@xlink:href, '#')">
-                                        <xsl:value-of select="$commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']" />
-                                    </xsl:when>
-                                    <xsl:otherwise>
-                                        <xsl:value-of select="@xlink:href" />
-                                    </xsl:otherwise>
-                                </xsl:choose>
-                            </xsl:variable>
-
-                            <tr>
-                                <td class="our_row header">Commodity</td>
-                                <td class="our_row"><xsl:value-of select="$commodityName"/></td>
-                                <td class="our_row header">Commodity Id:</td>
-                                <td class="our_row" colspan="2">
-                                    <xsl:choose>
-                                        <xsl:when test="starts-with($commodityID, 'http://')">
-                                            <a href="wfsFeaturePopup.do?url={$commodityID}" onclick="var w=window.open('wfsFeaturePopup.do?url={$commodityID}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="$commodityID"/></a>
-                                        </xsl:when>
-                                        <xsl:otherwise>
-                                            <xsl:value-of select="$commodityID"/>
-                                        </xsl:otherwise>
-                                    </xsl:choose>
-                                </td>
-                            </tr>
-                        </xsl:when>
-                    </xsl:choose>
-
-                </xsl:for-each>
-
-                <!-- Product Name -->
-                <xsl:for-each select="./er:producedMaterial">
-                    <xsl:choose>
-                        <xsl:when test="position()=1">
-                        <tr>
-                            <td class="our_row">&#160;</td>
-                            <td class="our_row">&#160;</td>
-                            <td class="our_row col_header">Production Amount</td>
-                            <td class="our_row col_header">Recovery %</td>
-                            <td class="our_row col_header">Grade</td>
-                        </tr>
-                        <tr>
-                            <td class="header">Product Name</td>
-                            <td><xsl:value-of select="./er:Product/er:productName"/></td>
-                            <td><xsl:value-of select="./er:Product/er:production"/><xsl:value-of select="' '"/>
-                            <xsl:choose>
-                                <xsl:when test="contains(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                    <xsl:value-of select="substring-after(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of select="./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            </td>
-                            <td><xsl:value-of select="./er:Product/er:recovery"/></td>
-                            <td><xsl:value-of select="./er:Product/er:grade"/><xsl:value-of select="' '"/>
-                            <xsl:choose>
-                                <xsl:when test="contains(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                    <xsl:value-of select="substring-after(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of select="./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            </td>
-                        </tr>
-                        </xsl:when>
-                        <xsl:otherwise>
-                        <tr>
-                            <td>&#160;</td>
-                            <td class="our_row"><xsl:value-of select="./er:Product/er:productName"/></td>
-                            <td class="our_row"><xsl:value-of select="./er:Product/er:production"/><xsl:value-of select="' '"/>
-                            <xsl:choose>
-                                <xsl:when test="contains(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                    <xsl:value-of select="substring-after(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of select="./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            </td>
-                            <td class="our_row"><xsl:value-of select="./er:Product/er:recovery"/></td>
-                            <td class="our_row"><xsl:value-of select="./er:Product/er:grade"/><xsl:value-of select="' '"/>
-                            <xsl:choose>
-                                <xsl:when test="contains(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                    <xsl:value-of select="substring-after(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                                </xsl:when>
-                                <xsl:otherwise>
-                                    <xsl:value-of select="./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                                </xsl:otherwise>
-                            </xsl:choose>
-                            </td>
-                        </tr>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:for-each>
-                <!-- Raw Material -->
-                <xsl:if test="./er:composition">
-                    <tr>
-                        <td class="our_row header">Raw Material</td>
-                        <td class="our_row col_header">Lithology</td>
-                        <td class="our_row col_header">Role</td>
-                        <td class="our_row col_header">Proportion</td>
-                        <td class="our_row col_header">&#160;</td>
-                    </tr>
-                    <tr>
-                        <td>&#160;</td>
-                        <td ><xsl:value-of select="./er:composition/er:rawMaterial/er:material/gsml:RockMaterial/gsml:lithology"/></td>
-                        <td ><xsl:value-of select="./er:composition/er:RawMaterial/er:rawMaterialRole"/></td>
-                        <td ><xsl:value-of select="./er:composition/er:RawMaterial/er:proportion"/></td>
-                        <td>&#160;</td>
-                    </tr>
-                </xsl:if>
-                <!-- Associated Earth Resources -->
-                <tr>
-                    <td class="our_row header">Associated Earth Resources</td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row header">Earth Resource Id:</td>
-                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                        <xsl:with-param name="friendly-name" select="./er:deposit/@xlink:href"/>
-                        <xsl:with-param name="real-url" select="./er:deposit/@xlink:href"/>
-                    </xsl:call-template></td>
-                </tr>
-            </tbody>
-        </table>
-    </xsl:template>
-
-
-    <!-- TEMPLATE FOR TRANSLATING Mine -->
-    <!-- =============================================================== -->
-    <xsl:template match="er:Mine">
-        <xsl:variable name="mineID" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-        <xsl:variable name="minePrefName" select="./er:mineName/er:MineName[./er:isPreferred = true()]/er:mineName/text()" />
-        <table>
-            <colgroup span="1" width="15%"/>
-            <colgroup span="1" width="25%"/>
-            <colgroup span="2" width="15%"/>
-            <colgroup span="1" width="35%"/>
-            <tbody>
-                <tr>
-                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - Mine</td>
-                    <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
-                            <xsl:with-param name="real-url" select="$mineID"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <!-- Mine Name -->
-                <tr>
-                    <td class="our_row header">Mine Name</td>
-                    <td class="our_row"><xsl:value-of select="$minePrefName"/></td>
-                    <td class="our_row header">Mine Id:</td>
-                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="$mineID"/>
-                            <xsl:with-param name="real-url" select="$mineID"/>
-                        </xsl:call-template></td>
-                </tr>
-                <!-- Alternative Mine Name -->
-                <xsl:for-each select="./er:mineName/er:MineName[./er:isPreferred = 'false']">
-                    <xsl:variable name="currentOtherName" select="./er:mineName/text()"/>
-                    <xsl:choose>
-                        <xsl:when test="position()=1">
-                        <tr>
-                            <td class="our_row header">Alternative Mine Name</td>
-                            <td class="our_row"><xsl:value-of select="$currentOtherName"/></td>
-                            <td class="our_row" colspan="3">&#160;</td>
-                        </tr>
-                        </xsl:when>
-                        <xsl:otherwise>
-                        <tr>
-                            <td></td>
-                            <td><xsl:value-of select="$currentOtherName"/></td>
-                            <td colspan="3">&#160;</td>
-                        </tr>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:for-each>
-                <!-- Status -->
-                <tr>
-                    <td class="our_row header">Status</td>
-                    <td class="our_row"><xsl:value-of select="./er:status"/></td>
-                    <td class="our_row header">Occurrence</td>
-                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                        <xsl:with-param name="friendly-name" select="./er:occurrence/@xlink:href"/>
-                        <xsl:with-param name="real-url" select="./er:occurrence/@xlink:href"/>
-                    </xsl:call-template></td>
-
-
-                </tr>
-
-                <xsl:for-each select="./er:relatedActivity/er:MiningActivity">
-                    <!-- Related Mining Activity -->
-                    <xsl:variable name="rel-mine-id" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-                    <xsl:choose>
-                        <xsl:when test="position()=1">
-                         <tr>
-                            <td class="our_row header">&#160;</td>
-                            <td class="our_row col_header">Start Date - End Date</td>
-                            <td class="our_row header">&#160;</td>
-                            <td class="our_row" colspan="2">&#160;</td>
-                        </tr>
-                        <tr>
-                            <td class="our_row header">Related Mining Activity</td>
-                            <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
-                            <td class="our_row header">Mining Activity Id:</td>
-                            <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                                    <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
-                                    <xsl:with-param name="real-url" select="$rel-mine-id"/>
-                                </xsl:call-template></td>
-                        </tr>
-                        </xsl:when>
-                        <xsl:otherwise>
-                        <tr>
-                            <td class="header">&#160;</td>
-                            <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
-                            <td class="our_row header">Mining Activity Id:</td>
-                            <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                                    <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
-                                    <xsl:with-param name="real-url" select="$rel-mine-id"/>
-                                </xsl:call-template></td>
-                        </tr>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                    <!-- Related Mine -->
-                    <!--<xsl:for-each select="./er:associatedMine">
-                        <xsl:variable name="rel-mine-id" select="@xlink:href"/>
-                        <xsl:choose>
-                            <xsl:when test="position()=1">
-                            <tr>
-                                <td class="our_row header">Related Mine</td>
-                                <td class="our_row">&#160;</td>
-                                <td class="our_row header">Mine Id:</td>
-                                <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                                        <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
-                                        <xsl:with-param name="real-url" select="$rel-mine-id"/>
-                                    </xsl:call-template></td>
-                            </tr>
-                            </xsl:when>
-                            <xsl:otherwise>
-                            <tr>
-                                <td>&#160;</td>
-                                <td>&#160;</td>
-                                <td class="our_row header">Mine Id:</td>
-                                <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                                        <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
-                                        <xsl:with-param name="real-url" select="$rel-mine-id"/>
-                                    </xsl:call-template></td>
-                            </tr>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </xsl:for-each>-->
-                </xsl:for-each>
-            </tbody>
-        </table>
-    </xsl:template>
-
-
-    <!-- TEMPLATE FOR TRANSLATING Commodity -->
-    <!-- =============================================================== -->
-    <xsl:template match="er:Commodity">
-        <xsl:variable name="commodity_id" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-        <xsl:variable name="commodity_name" select="./er:commodityName"/>
-        <table>
-            <tbody>
-                <tr>
-                    <td class="caption" colspan="2" rowspan="1">EarthResourceML - Commodity</td>
-                    <td>&#160;</td>
-                    <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
-                            <xsl:with-param name="real-url" select="$commodity_id"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <!-- Commodity -->
-                <tr>
-                    <td class="our_row header">Commodity</td>
-                    <td class="our_row">
-                    
-                        <xsl:choose>
-                            <xsl:when test="contains($commodity_name, '/')">                   
-                                <xsl:call-template name="make-popup-url">
-                                    <xsl:with-param name="friendly-name" select="substring-after($commodity_name,'classifier/cgi/commodity/')"/>
-                                    <xsl:with-param name="real-url" select="$commodity_name"/>                                                                 
-                                </xsl:call-template>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:call-template name="make-popup-url">
-                                    <xsl:with-param name="friendly-name" select="$commodity_name"/>
-                                    <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring-after($commodity_name, 'urn:cgi:classifier:GA:commodity:'))"/>                                                                 
-                                </xsl:call-template>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                                                        
-                    </td>
-                    <td class="our_row header">Commodity Id:</td>
-                    <td class="our_row" colspan="1">
-                        <xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="$commodity_id"/>
-                            <xsl:with-param name="real-url" select="$commodity_id"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="our_row header">Local Name*</td>
-                    <td class="our_row"><xsl:value-of select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
-                    <td class="our_row header">Local Group*</td>
-                    <td class="our_row" colspan="1"><xsl:value-of select="./er:commodityGroup[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
-                </tr>
-                <tr>
-                    <td class="our_row header">Importance</td>
-                    <td class="our_row" ><xsl:value-of select="./er:commodityImportance"/></td>
-                    <td class="our_row header">Rank:</td>
-                    <td class="our_row" colspan="1"><xsl:value-of select="./er:commodityRank"/></td>
-                </tr>
-        <xsl:for-each select="./er:source">
-            <xsl:choose>
-                <xsl:when test="position()=1">
-                <tr>
-                    <td class="our_row header">Associated Earth Resources</td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row header">Earth Resource Id:</td>
-                    <td class="our_row" colspan="1">
-                        <xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="@xlink:href"/>
-                            <xsl:with-param name="real-url" select="@xlink:href"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                </xsl:when>
-                <xsl:otherwise>
-                <tr>
-                    <td>&#160;</td>
-                    <td>&#160;</td>
-                    <td class="our_row header">Earth Resource Id:</td>
-                    <td class="our_row" colspan="1">
-                        <xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="@xlink:href"/>
-                            <xsl:with-param name="real-url" select="@xlink:href"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:for-each>
-            </tbody>
-        </table>
-    </xsl:template>
-
-
-    <!-- TEMPLATE FOR TRANSLATING Mineral Occurrence -->
-    <!-- =============================================================== -->
-    <xsl:template match="er:MineralOccurrence">
-        <xsl:variable name="minocc_id">
-            <xsl:value-of select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-        </xsl:variable>
-        <table>
-            <tbody>
-                <tr>
-                    <td class="caption" colspan="2" rowspan="1">EarthResourceML - MineralOccurrence</td>
-                    <td>&#160;</td>
-                    <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
-                            <xsl:with-param name="real-url" select="$minocc_id"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <!-- Type -->
-                <tr>
-                    <td class="our_row header">Type</td>
-                    <td class="our_row"><xsl:value-of select="er:type"/></td>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="2">
-                        <xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="$minocc_id"/>
-                            <xsl:with-param name="real-url" select="$minocc_id"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <!-- Mineral Occurrence Name -->
-        <xsl:for-each select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]">
-            <xsl:choose>
-                <xsl:when test="position()=1">
-                <tr>
-                    <td class="our_row header">Mineral Occurrence Name</td>
-                    <td class="our_row"><xsl:value-of select="."/></td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row">&#160;</td>
-                </tr>
-                </xsl:when>
-                <xsl:otherwise>
-                <tr>
-                    <td>&#160;</td>
-                    <td><xsl:value-of select="."/></td>
-                    <td>&#160;</td>
-                    <td>&#160;</td>
-                    <td>&#160;</td>
-                </tr>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:for-each>
-                <!-- Description -->
-        <xsl:if test="gml:description">
-                <tr>
-                    <td class="our_row header" rowspan="1">Description</td>
-                    <td class="our_row" rowspan="2" colspan="4"><xsl:value-of select="./gml:description"/></td>
-                </tr>
-                <tr></tr><!-- VT: workaround to fix a spacing bug in the output-->
-        </xsl:if>
-                <!-- Commodity -->
-        <xsl:for-each select="./er:commodityDescription">
-            <xsl:variable name="comm_description">
-                <xsl:value-of select="@xlink:href"/>
-            </xsl:variable>
-            <xsl:variable name="comm_name">
-                <xsl:value-of select="./er:Commodity/er:commodityName"/>
-            </xsl:variable>
-            <xsl:variable name="comm_url">
-                <xsl:value-of select="./er:Commodity/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-            </xsl:variable>
-            <xsl:choose>
-                <xsl:when test="position()=1">
-                <tr>
-                    <td class="our_row header">Commodity</td>
-                    <td class="our_row"><xsl:call-template name="make-popup-url">
-                        <xsl:with-param name="friendly-name" select="$comm_name"/>
-                        <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring-after($comm_name, 'urn:cgi:classifier:GA:commodity:'))"/>                        
-                    </xsl:call-template></td>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="2">
-                        <xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="$comm_url"/>
-                            <xsl:with-param name="real-url" select="$comm_url"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                </xsl:when>
-                <xsl:otherwise>
-                <tr>
-                    <td>&#160;</td>
-                    <td class="our_row"><xsl:call-template name="make-popup-url">
-                        <xsl:with-param name="friendly-name" select="$comm_name"/>
-                        <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring($comm_name, string-length($comm_name) - 1))"/>
-                    </xsl:call-template></td>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="2">
-                        <xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="$comm_url"/>
-                            <xsl:with-param name="real-url" select="$comm_url"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                </xsl:otherwise>
-            </xsl:choose>
-        </xsl:for-each>
-                <!-- Observation Method -->
-                <tr>
-                    <td class="our_row header">Observation Method</td>
-                    <td class="our_row"><xsl:value-of select="./gsml:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td class="our_row header">Purpose:</td>
-                    <td class="our_row" colspan="2"><xsl:value-of select="./gsml:purpose"/></td>
-                </tr>
-                 <!-- Dimension -->
-       <xsl:if test="./er:dimension">
-                <tr>
-                    <td class="our_row header">Dimension</td>
-                    <td class="our_row col_header">Area</td>
-                    <td class="our_row col_header">Depth</td>
-                    <td class="our_row col_header">Length</td>
-                    <td class="our_row col_header">Width</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:area/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:area/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:depth/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:depth/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:length/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:length/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td><xsl:value-of select="./er:dimension/er:EarthResourceDimension/er:width/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:dimension/er:EarthResourceDimension/er:width/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                </tr>
-       </xsl:if>
-                <!-- Appearance -->
-       <xsl:if test="./er:form | ./er:expression | ./er:shape">
-                <tr>
-                    <td class="our_row header">Appearance</td>
-                    <td class="our_row col_header">Form</td>
-                    <td class="our_row col_header">Expression</td>
-                    <td class="our_row col_header">Shape</td>
-                    <td class="our_row col_header">&#160;</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:form/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td><xsl:value-of select="./er:expression/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td><xsl:value-of select="./er:shape/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td></td>
-                </tr>
-       </xsl:if>
-                <!-- Linear Orientation -->
-       <xsl:if test="./er:linearOrientation">
-                <tr>
-                    <td class="our_row header">Linear Orientation</td>
-                    <td class="our_row col_header">Plunge</td>
-                    <td class="our_row col_header">Trend</td>
-                    <td class="our_row col_header">&#160;</td>
-                    <td class="our_row col_header">&#160;</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:linearOrientation/gsml:CGI_LinearOrientation/gsml:plungeValue"/></td>
-                    <td><xsl:value-of select="./er:linearOrientation/gsml:CGI_LinearOrientation/gsml:trend"/></td>
-                    <td></td>
-                    <td></td>
-                </tr>
-       </xsl:if>
-                <!-- Planar Orientation -->
-       <xsl:if test="./er:planarOrientation">
-                <tr>
-                    <td class="our_row header">Planar Orientation</td>
-                    <td class="our_row col_header">Convention</td>
-                    <td class="our_row col_header">Azimuth</td>
-                    <td class="our_row col_header">Dip</td>
-                    <td class="our_row col_header">&#160;</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:planarOrientation/gsml:CGI_PlanarOrientation/gsml:convention"/></td>
-                    <td><xsl:value-of select="./er:planarOrientation/gsml:CGI_PlanarOrientation/gsml:azimuth/gsml:CGI_NumericValue/gsml:principalValue"/></td>
-                    <td><xsl:value-of select="./er:planarOrientation/gsml:CGI_PlanarOrientation/gsml:dip/gsml:CGI_NumericValue/gsml:principalValue"/></td>
-                    <td></td>
-                </tr>
-       </xsl:if>
-                <!-- Classification -->
-       <xsl:if test="./er:classification">
-                <tr>
-                    <td class="our_row header">Classification</td>
-                    <td class="our_row col_header">Deposit Group</td>
-                    <td class="our_row col_header">&#160;</td>
-                    <td class="our_row col_header">Deposit Type</td>
-                    <td class="our_row col_header">&#160;</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:classification/er:MineralDepositModel/er:mineralDepositGroup"/></td>
-                    <td></td>
-                    <td><xsl:value-of select="./er:classification/er:MineralDepositModel/er:mineralDepositType"/></td>
-                    <td></td>
-                </tr>
-       </xsl:if>
-                <!-- Supergene Modification -->
-       <xsl:if test="./er:supergeneModification">
-                <tr>
-                    <td class="our_row header">Supergene Modification</td>
-                    <td class="col_header">Lithology</td>
-                    <td class="col_header">Supergene Type</td>
-                    <td class="col_header">Depth</td>
-                    <td class="col_header"></td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td></td>
-                    <!-- <td><xsl:value-of select="./er:supergeneModification/er:SupergeneProcesses/er:material/gsml:lithology"/></td> -->
-                    <td><xsl:value-of select="./er:supergeneModification/er:SupergeneProcesses/er:type/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td><xsl:value-of select="./er:supergeneModification/er:SupergeneProcesses/er:depth/gsml:CGI_Numeric/gsml:CGI_NumericValue/gsml:principalValue"/></td>
-                    <td></td>
-                </tr>
-       </xsl:if>
-                <!-- Composition
-                Note: there are more than one type of thing in here. -->
-       <xsl:if test="./er:composition">
-           <xsl:for-each select="./er:composition">
-                <tr>
-                    <td class="our_row header">Composition</td>
-                 <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title">
-                    <td class="our_row col_header">Lithology</td>
-                </xsl:if>
-                 <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title">
-                    <td class="our_row col_header">Mineral Name</td>
-                </xsl:if>
-
-                    <td class="our_row col_header">Role</td>
-                    <td class="our_row col_header">Proportion</td>
-                    <td class="our_row col_header"></td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title">
-                        <td><xsl:value-of select="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title"/></td>
-                    </xsl:if>
-                     <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title">
-                        <td><xsl:value-of select="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title"/></td>
-                    </xsl:if>
-                    <td><xsl:value-of select="./er:EarthResourceMaterial/er:earthResourceMaterialRole"/></td>
-                    <td><xsl:value-of select="./er:EarthResourceMaterial/er:proportion/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:call-template name="convert-escaped-percentage">
-                            <xsl:with-param name="value" select="substring-after(./er:composition/er:EarthResourceMaterial/er:proportion/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                        </xsl:call-template>
-                    </td>
-                    <td></td>
-                </tr>
-           </xsl:for-each>
-       </xsl:if>
-                <!-- Geological History -->
-       <xsl:if test="./gsml:preferredAge/gsml:GeologicEvent">
-                <tr>
-                    <td class="our_row header">Geological History</td>
-                    <td class="our_row col_header">Age</td>
-                    <td class="our_row col_header">Process</td>
-                    <td class="our_row col_header">Environment</td>
-                    <td class="our_row col_header"></td>
-                </tr>
-            <xsl:for-each select="./gsml:preferredAge/gsml:GeologicEvent">
-                <tr>
-                    <td></td>
-                    <td>
-                    <xsl:choose>
-                        <xsl:when test="./gsml:eventAge/gsml:CGI_TermValue/gsml:value">
-                            <xsl:value-of select="./gsml:eventAge/gsml:CGI_TermValue/gsml:value"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="./gsml:eventAge/gsml:CGI_NumericValue/gsml:principalValue"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                    </td>
-                    <td><xsl:value-of select="./gsml:eventProcess/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td><xsl:value-of select="./gsml:eventEnvironment/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td></td>
-                </tr>
-            </xsl:for-each>
-       </xsl:if>
-                <!-- Reserves -->
-        <xsl:for-each select="./er:oreAmount/er:Reserve">
-                <tr>
-                    <td class="our_row header">Reserves</td>
-                    <td class="our_row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td class="our_row"><xsl:value-of select="./er:category"/></td>
-                    <td class="our_row header">Date:</td>
-                    <td class="our_row"><xsl:value-of select="./er:date"/></td>
-                </tr>
-            <xsl:for-each select="./er:measureDetails">
-                <xsl:variable name="comm_description" select="substring-after(./er:CommodityMeasure/er:commodityOfInterest/@xlink:href,'#')"></xsl:variable>
-                <xsl:variable name="comm_org_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"></xsl:variable>
-                <xsl:variable name="comm_std_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/er:commodityName[@codeSpace='urn:cgi:classifierScheme:GA:commodity']"></xsl:variable>
-                <xsl:variable name="comm_url" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"></xsl:variable>
-                <tr>
-                    <td class="col_header" >Commodity:</td>
-                    <td class="our_row">
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="$comm_std_name"/>
-                            <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring($comm_std_name, string-length($comm_std_name) - 1))"/>
-                        </xsl:call-template>
-                    </td>
-                    <td class="our_row header">Commodity Id:</td>
-                        <td class="our_row" colspan="2">
-                            <xsl:call-template name="make-wfspopup-url">
-                                <xsl:with-param name="friendly-name" select="$comm_description"/>
-                                <xsl:with-param name="real-url" select="$comm_description"/>
-                            </xsl:call-template>
-                        </td>
-                    </tr>
-                <tr>
-                    <td></td>
-                    <td class="our_row col_header">Commodity Amount</td>
-                    <td class="our_row col_header">Cut-off Grade</td>
-                    <td class="our_row col_header">Grade</td>
-                    <td class="our_row col_header">Importance</td>
-                </tr>
-                <xsl:variable name="cut_off_grade_uom">
-                    <xsl:choose>
-                        <xsl:when test="contains(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
-                <xsl:variable name="grade_uom">
-                    <xsl:choose>
-                        <xsl:when test="contains(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:choose>
-                            <xsl:when test="contains(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                <xsl:value-of select="substring-after(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:call-template name="convert-escaped-percentage">
-                            <xsl:with-param name="value" select="$cut_off_grade_uom"/>
-                        </xsl:call-template>
-                    </td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:call-template name="convert-escaped-percentage">
-                            <xsl:with-param name="value" select="$grade_uom"/>
-                        </xsl:call-template>
-                    </td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityOfInterest/er:commodityImportance"/></td>
-                </tr>
-            </xsl:for-each>
-        </xsl:for-each>
-                <!-- Resources -->
-        <xsl:for-each select="./er:oreAmount/er:Resource">
-                <tr>
-                    <td class="our_row header">Resources</td>
-                    <td class="our_row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td class="our_row"><xsl:value-of select="./er:category"/></td>
-                    <td class="our_row header">Date:</td>
-                    <td class="our_row"><xsl:value-of select="./er:date"/></td>
-                </tr>
-            <xsl:for-each select="./er:measureDetails">
-                <xsl:variable name="comm_description" select="substring-after(./er:CommodityMeasure/er:commodityOfInterest/@xlink:href,'#')"></xsl:variable>
-                <xsl:variable name="comm_org_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"></xsl:variable>
-                <xsl:variable name="comm_std_name" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/er:commodityName[@codeSpace='urn:cgi:classifierScheme:GA:commodity']"></xsl:variable>
-                <xsl:variable name="comm_url" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"></xsl:variable>
-                    <tr>
-                        <td class="col_header" >Commodity:</td>
-                        <td class="our_row">
-                            <xsl:call-template name="make-popup-url">
-                                <xsl:with-param name="friendly-name" select="$comm_std_name"/>
-                                <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring($comm_std_name, string-length($comm_std_name) - 1))"/>
-                            </xsl:call-template>
-                        </td>
-                        <td class="our_row header">Id:</td>
-                        <td class="our_row" colspan="2">
-                            <xsl:call-template name="make-wfspopup-url">
-                                <xsl:with-param name="friendly-name" select="$comm_url"/>
-                                <xsl:with-param name="real-url" select="$comm_url"/>
-                            </xsl:call-template>
-                        </td>
-                    </tr>
-                <xsl:variable name="cut_off_grade_uom">
-                    <xsl:choose>
-                        <xsl:when test="contains(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
-                <xsl:variable name="grade_uom">
-                    <xsl:choose>
-                        <xsl:when test="contains(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                            <xsl:value-of select="substring-after(./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                        </xsl:when>
-                        <xsl:otherwise>
-                            <xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:variable>
-                <tr>
-                    <td></td>
-                    <td class="our_row col_header">Commodity Amount</td>
-                    <td class="our_row col_header">Cut-off Grade</td>
-                    <td class="our_row col_header">Grade</td>
-                    <td class="our_row col_header">Importance</td>
-                </tr>
-                <tr>
-                    <td></td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:choose>
-                            <xsl:when test="contains(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
-                                <xsl:value-of select="substring-after(./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
-                            </xsl:when>
-                            <xsl:otherwise>
-                                <xsl:value-of select="./er:CommodityMeasure/er:commodityAmount/gsml:CGI_NumericValue/gsml:principalValue/@uom"/>
-                            </xsl:otherwise>
-                        </xsl:choose>
-                    </td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:cutOffGrade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:call-template name="convert-escaped-percentage">
-                            <xsl:with-param name="value" select="$cut_off_grade_uom"/>
-                        </xsl:call-template>
-                    </td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:grade/gsml:CGI_NumericValue/gsml:principalValue"/><xsl:value-of select="' '"/>
-                        <xsl:call-template name="convert-escaped-percentage">
-                            <xsl:with-param name="value" select="$grade_uom"/>
-                        </xsl:call-template>
-                    </td>
-                    <td><xsl:value-of select="./er:CommodityMeasure/er:commodityOfInterest/er:commodityImportance"/></td>
-                </tr>
-            </xsl:for-each>
-        </xsl:for-each>
-                <!-- Associated Mining Activity -->
-       <xsl:if test="./er:resourceExtraction">
-                <tr>
-                    <td class="our_row header">Associated Mining Activity</td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="2">
-                        <a href="wfsFeaturePopup.do?url={./er:resourceExtraction/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:resourceExtraction/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:resourceExtraction/@xlink:href,'=')"/></a>
-                    </td>
-                </tr>
-       </xsl:if>
-                <!-- Parent Earth Resources -->
-       <xsl:if test="./er:parent">
-                <tr>
-                    <td class="our_row header">Parent Earth Resources</td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="2">
-                        <a href="wfsFeaturePopup.do?url={./er:parent/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:parent/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:parent/@xlink:href,'=')"/></a>
-                    </td>
-                </tr>
-       </xsl:if>
-                <!-- Child Earth Resources -->
-       <xsl:if test="./er:child">
-                <tr>
-                    <td class="our_row header">Child Earth Resources</td>
-                    <td class="our_row">&#160;</td>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="2">
-                        <a href="wfsFeaturePopup.do?url={./er:child/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:child/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:child/@xlink:href,'=')"/></a>
-                    </td>
-                </tr>
-       </xsl:if>
-            </tbody>
-        </table>
-    </xsl:template>
-
-
-
-    <!-- TEMPLATE FOR TRANSLATING MiningFeatureOccurrence -->
-    <!-- =============================================================== -->
-    <xsl:template match="er:MiningFeatureOccurrence">
-        <xsl:variable name="mfoID" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
-
-        <table>
-            <colgroup span="1" width="15%"/>
-            <colgroup span="1" width="25%"/>
-            <colgroup span="2" width="15%"/>
-            <colgroup span="1" width="35%"/>
-            <tbody>
-                <tr>
-                    <td class="caption" colspan="3" rowspan="1">EarthResourceML - MiningFeatureOccurrence</td>
-                    <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
-                            <xsl:with-param name="real-url" select="$mfoID"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-
-                <!-- MiningFeatureOccurrence Type -->
-                <tr>
-                    <td class="our_row header">Mining Feature Occurrence Description:</td>
-                    <td class="our_row"><xsl:value-of select="./gml:description"/></td>
-                    <td class="our_row header">Mining Feature Occurrence Id:</td>
-                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
-                            <xsl:with-param name="friendly-name" select="$mfoID"/>
-                            <xsl:with-param name="real-url" select="$mfoID"/>
-                        </xsl:call-template></td>
-                </tr>
-                <!-- Observation Method -->
-                <tr>
-                    <td class="our_row header" colspan="2">Observation Method:</td>
-                    <td class="our_row" colspan="2"><xsl:value-of select="./er:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td class="our_row" colspan="1">&#160;</td>
-                </tr>
-                <!-- Positional Accuracy -->
-                <tr>
-                    <td class="our_row header" colspan="2">Positional Accuracy:</td>
-                    <td class="our_row" colspan="2"><xsl:value-of select="./er:positionalAccuracy/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td class="our_row" colspan="1">&#160;</td>
-                </tr>
-            </tbody>
-        </table>&#160;
-
-        <xsl:for-each select="./er:specification/er:Mine">
-            <p></p>
-            <table>
-                <tbody>
-                    <xsl:apply-templates select=". | er:Mine"/>
-                </tbody>
-            </table>&#160;
-        </xsl:for-each>
-
-        <xsl:for-each select="./er:specification/er:Mine/er:relatedActivity/er:MiningActivity">
-        <p></p>
-            <table>
-                <tbody>
-                    <xsl:apply-templates select=". | er:MiningActivity"/>
-                </tbody>
-            </table>&#160;
-        </xsl:for-each>
-    </xsl:template>
-
-    <!-- TEMPLATE FOR TRANSLATING Yilgarn Geochemistry -->
-    <!-- =============================================================== -->
-    <xsl:template match="gsml:GeologicUnit">
-        <xsl:variable name="guID" select="@gml:id"/>
-        <xsl:variable name="mappedFeatureObsMethod" select="./gsml:occurrence/gsml:MappedFeature/gsml:observationMethod/gsml:CGI_TermValue/gsml:value[@codeSpace='www.ietf.org/rfc/rfc1738']"/>
-        <xsl:variable name="observationMethod" select="./gsml:observationMethod/gsml:CGI_TermValue/gsml:value[@codeSpace='www.ietf.org/rfc/rfc1738']"/>
-
-        <table>
-            <colgroup span="1" width="15%"/>
-            <colgroup span="1" width="35%"/>
-            <colgroup span="2" width="20%"/>
-            <colgroup span="1" width="20%"/>
-            <tbody>
-                <tr>
-                    <td class="caption" colspan="3" rowspan="1">GeoSciML - Yilgarn Laterite Geologic Unit</td>
-                    <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="'XML'"/>
-                            <xsl:with-param name="real-url" select="concat($serviceURL,'?SERVICE=WFS&amp;REQUEST=GetFeature&amp;VERSION=1.1.0&amp;typeName=gsml:GeologicUnit&amp;featureId=',$guID)"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-                <tr>
-                    <td class="our_row header">Id:</td>
-                    <td class="our_row" colspan="4"><xsl:value-of select="$guID"/></td>
-                </tr>
-                <xsl:for-each select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc3406')]">
-                    <xsl:choose>
-                        <xsl:when test="position()=1">
-                        <tr>
-                            <td class="our_row header">Name:</td>
-                            <td class="our_row"><xsl:value-of select="."/></td>
-                            <td class="our_row">&#160;</td>
-                            <td class="our_row">&#160;</td>
-                            <td class="our_row">&#160;</td>
-                        </tr>
-                        </xsl:when>
-                        <xsl:otherwise>
-                        <tr>
-                            <td>&#160;</td>
-                            <td><xsl:value-of select="."/></td>
-                            <td>&#160;</td>
-                            <td>&#160;</td>
-                            <td>&#160;</td>
-                        </tr>
-                        </xsl:otherwise>
-                    </xsl:choose>
-                </xsl:for-each>
-                <tr>
-                    <td class="our_row header">Observation Method:</td>
-                    <td class="our_row">
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="$observationMethod"/>
-                            <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookupCGI,$observationMethod)"/>
-                        </xsl:call-template>
-                    </td>
-                    <td class="our_row header">Mapped Feature Id:</td>
-                    <td class="our_row" colspan="2"><xsl:value-of select="./gsml:occurrence/gsml:MappedFeature/@gml:id"/></td>
-                </tr>
-                <tr>
-                    <td class="our_row header">Mapped Feature Observation Method:</td>
-                    <td class="our_row" colspan="4">
-                        <xsl:call-template name="make-popup-url">
-                            <xsl:with-param name="friendly-name" select="$mappedFeatureObsMethod"/>
-                            <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookupCGI,$mappedFeatureObsMethod)"/>
-                        </xsl:call-template>
-                    </td>
-                </tr>
-
-            </tbody>
-        </table>
-    </xsl:template>
-
-
-
-    <!-- ================================================================= -->
+        <!-- ================================================================= -->
     <!--    FUNCTION TO GET STRING AFTER LAST OCCURRENCE OF A SUBSTR       -->
     <!--    PARAM: input - string to search within                         -->
     <!--    PARAM: substr - last occurrence of str that we searching for   -->
@@ -1234,5 +188,423 @@
         <xsl:param name="real-url"/>
         <a href="wfsFeaturePopup.do?url={$real-url}" onclick="var w=window.open('{$portalBaseURL}/wfsFeaturePopup.do?url={$real-url}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=820');w.focus();return false;"><xsl:value-of select="$friendly-name"/></a>
     </xsl:template>
-
-</xsl:stylesheet>
+    
+    <!-- Adapted from "functx:camel-case-to-words" -->
+    <xsl:template name="formatLabel">
+        <xsl:param name="arg"/>
+         <!-- separate camel case into words, capitalise first letter of the words -->
+        <xsl:value-of select="concat(upper-case(substring($arg,1,1)),
+             replace(substring($arg,2),'(\p{Lu})',
+                        concat(' ', '$1')))"/>
+    </xsl:template>
+    <!-- Adapted from functx:substring-before-if-contains and camel-case-to-words -->
+    <xsl:template name="formatURILabel">
+        <xsl:param name="arg"/>
+        <xsl:variable name="label" select="concat(upper-case(substring($arg,1,1)),
+             replace(substring($arg,2),'(\p{Lu})',
+                        concat(' ', '$1')))"/>
+        <!-- Strip the URI suffix -->
+        <xsl:value-of select="substring-before($label, '_uri')"/>
+    </xsl:template>    
+    <xsl:template name="formatSimpleFeatures">
+        <xsl:param name="wfsUriList"/>
+        <xsl:for-each select="./*">
+            <xsl:choose>
+                 <xsl:when test="contains($wfsUriList, local-name(.))">
+                     <xsl:choose>
+                         <xsl:when test="contains(name(.), '_uri')">
+                             <tr>
+                                 <td class="our_row header">
+                                     <xsl:call-template name="formatURILabel">
+                                         <xsl:with-param name="arg" select="local-name(.)"/>
+                                     </xsl:call-template>
+                                 </td>
+                                 <td class="our_row" colspan="2">
+                                     <xsl:call-template name="make-wfspopup-url">
+                                         <xsl:with-param name="friendly-name" select="."/>
+                                         <xsl:with-param name="real-url" select="."/>
+                                     </xsl:call-template>
+                                 </td>
+                             </tr>
+                         </xsl:when>
+                         <xsl:otherwise>
+                             <tr>
+                                 <td class="our_row header">
+                                     <xsl:call-template name="formatLabel">
+                                         <xsl:with-param name="arg" select="local-name(.)"/>
+                                     </xsl:call-template>
+                                 </td>
+                                 <td class="our_row" colspan="2">
+                                     <xsl:call-template name="make-wfspopup-url">
+                                         <xsl:with-param name="friendly-name" select="."/>
+                                         <xsl:with-param name="real-url" select="."/>
+                                    </xsl:call-template>
+                                </td>
+                             </tr>
+                         </xsl:otherwise>
+                     </xsl:choose>                            
+                 </xsl:when>
+                 <xsl:otherwise> 
+                     <xsl:choose>
+                         <xsl:when test="contains(name(.), '_uri')">
+                             <tr>
+                                 <td class="our_row header">
+                                     <xsl:call-template name="formatURILabel">
+                                         <xsl:with-param name="arg" select="local-name(.)"/>
+                                     </xsl:call-template>
+                                 </td>
+                                 <td class="our_row" colspan="2">
+                                     <xsl:call-template name="make-popup-url">
+                                         <xsl:with-param name="friendly-name" select="."/>
+                                         <xsl:with-param name="real-url" select="."/>
+                                     </xsl:call-template>
+                                 </td>
+                             </tr>
+                         </xsl:when>
+                         <xsl:otherwise>                                
+                             <tr>
+                                 <td class="our_row header">
+                                     <xsl:call-template name="formatLabel">
+                                         <xsl:with-param name="arg" select="local-name(.)"/>
+                                     </xsl:call-template>
+                                 </td>
+                                 <td class="our_row"><xsl:value-of select="."/></td>
+                             </tr>
+                         </xsl:otherwise>
+                     </xsl:choose>
+                 </xsl:otherwise>
+             </xsl:choose>
+         </xsl:for-each>
+     </xsl:template>
+        <!-- Mineral Occurrence View -->
+    <!-- =============================================================== -->
+    <xsl:template match="mo:MinOccView">        
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">Mineral Occurrence Portrayal View</td>
+                </tr>
+                <xsl:call-template name="formatSimpleFeatures">
+                    <xsl:with-param name="wfsUriList" select="concat('earthResourceSpecification_uri ', 'identifier')" />
+                </xsl:call-template>                
+            </tbody>
+        </table>
+    </xsl:template>
+    
+    <!-- Mineral Tenement -->
+    <!-- =============================================================== -->
+    <xsl:template match="mt:MineralTenement">        
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">Mineral Tenement</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'MineralTenementML'"/>
+                            <xsl:with-param name="real-url" select="./*:identifier"/>
+                        </xsl:call-template>
+                    </td> 
+                </tr>
+                <xsl:call-template name="formatSimpleFeatures">
+                    <xsl:with-param name="wfsUriList" select="'identifier'" />
+                </xsl:call-template>                
+            </tbody>
+        </table>
+    </xsl:template>
+    
+    <!-- Borehole and BoreholeView -->
+    <!-- =============================================================== -->
+    <xsl:template match="gsmlp:BoreholeView">        
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">Borehole Portrayal View</td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Identifier:</td>
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="./gsmlp:identifier"/>
+                            <xsl:with-param name="real-url" select="./gsmlp:identifier"/>
+                        </xsl:call-template>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Name:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:name"/>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Drilling Method:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:drillingMethod"/>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Operator:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:operator"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Driller:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:driller"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Drill Start Date:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:drillStartDate"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Drill End Date:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:drillEndDate"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Start Point:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:startPoint"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Inclination Type:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:inclinationType"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Borehole Material Custodian:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:boreholeCustodianMaterial"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Borehole Length:</td>
+                    <td class="our_row">
+                        <xsl:if test="./gsmlp:boreholeLength_m">                            
+                            <xsl:value-of select="concat(./gsmlp:boreholeLength_m, ' (m)')"/>
+                        </xsl:if>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Elevation SRS:</td>
+                    <td class="our_row">
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="./gsmlp:elevation_srs"/>
+                            <xsl:with-param name="real-url" select="./gsmlp:elevation_srs"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Metadata:</td>
+                    <td class="our_row">
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="./gsmlp:metadata_uri"/>
+                            <xsl:with-param name="real-url" select="./gsmlp:metadata_uri"/>
+                        </xsl:call-template>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Shape:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:shape"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">NVCL Collection:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:nvclCollection"/>
+                    </td>
+                </tr>
+                <tr>
+                    <td class="our_row header">Project:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./gsmlp:project"/>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </xsl:template>
+    <xsl:template match="gsml:Borehole">        
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">Borehole</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'GeoSciML'"/>
+                            <xsl:with-param name="real-url" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+                        </xsl:call-template>
+                    </td> 
+                </tr>
+                <tr>
+                    <td class="our_row header">Name:</td>
+                    <td class="our_row" colspan="2">
+                        <xsl:call-template name="make-wfspopup-url">
+                            <xsl:with-param name="friendly-name" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+                            <xsl:with-param name="real-url" select="./gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"/>
+                        </xsl:call-template>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Local Name:</td>
+                    <td class="our_row"><xsl:value-of select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Sampled Feature:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./sa:sampledFeature/@xlink:title"/>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Shape:</td>
+                    <td class="our_row">
+                        <xsl:value-of select="./sa:shape"/>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Collar Location:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:collarLocation/gsml:BoreholeCollar/gsml:location"/></td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Collar Elevation:</td>
+                    <td class="our_row">
+                        <xsl:if test="./gsml:collarLocation/gsml:BoreholeCollar/gsml:elevation">                            
+                            <xsl:value-of select="concat(./gsml:collarLocation/gsml:BoreholeCollar/gsml:elevation, ' (m)')"/>
+                        </xsl:if>
+                    </td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Driller:</td>  
+                    <td class="our_row"><xsl:value-of select="./gsml:indexData/gsml:BoreholeDetails/gsml:driller/@xlink:title"/></td>
+                 </tr>
+                 <tr>          
+                    <td class="our_row header">Date of Drilling:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:indexData/gsml:BoreholeDetails/gsml:dateOfDrilling"/></td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Drilling Method:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:indexData/gsml:BoreholeDetails/gsml:drillingMethod"/></td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Start Point:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:indexData/gsml:BoreholeDetails/gsml:startPoint"/></td>
+                 </tr>
+                 <tr>
+                    <td class="our_row header">Inclination Type:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:indexData/gsml:BoreholeDetails/gsml:inclinationType"/></td>                    
+                 </tr>
+                 <tr>
+                     <td class="our_row header">Cored Interval (Upper Corner):</td>
+                     <td class="our_row">
+                        <xsl:if test="./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:upperCorner">                            
+                            <xsl:value-of select="concat(./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:upperCorner, ' m')"/>
+                        </xsl:if>
+                     </td>
+                 </tr>
+                 <tr>
+                     <td class="our_row header">Cored Interval (Lower Corner):</td>
+                     <td class="our_row">
+                        <xsl:if test="./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:lowerCorner">                            
+                            <xsl:value-of select="concat(./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:lowerCorner, ' m')"/>
+                        </xsl:if>
+                     </td>
+                 </tr>
+                 <tr>   
+                    <td class="our_row header">Core Custodian:</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:indexData/gsml:BoreholeDetails/gsml:coreCustodian/@xlink:title"/></td>
+                 </tr>  
+            </tbody>
+        </table>
+    </xsl:template>
+         
+    <!--  Earth ResourceML Lite -->
+    <!-- =============================================================== -->
+    <xsl:template match="*:MineralOccurrenceView[starts-with(namespace-uri(), $erl)]">
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML Lite - MineralOccurrenceView</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML Lite'"/>
+                            <xsl:with-param name="real-url" select="./*:identifier"/>
+                        </xsl:call-template>
+                    </td> 
+                </tr>                  
+                <xsl:call-template name="formatSimpleFeatures">
+                    <xsl:with-param name="wfsUriList" select="concat('mine_uri ', 'specification_uri ', 'identifier')" />
+                </xsl:call-template>
+            </tbody>
+        </table>
+    </xsl:template>
+    <xsl:template match="*:MineView[starts-with(namespace-uri(), $erl)]">
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML Lite - MineralOccurrenceView</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML Lite'"/>
+                            <xsl:with-param name="real-url" select="./*:identifier"/>
+                        </xsl:call-template>
+                    </td> 
+                </tr>                  
+                <xsl:call-template name="formatSimpleFeatures">
+                    <xsl:with-param name="wfsUriList" select="concat('specification_uri ', 'identifier')" />
+                </xsl:call-template>
+            </tbody>
+        </table>
+    </xsl:template>
+    <xsl:template match="*:CommodityResourceView[starts-with(namespace-uri(), $erl)]">
+        <table>
+            <colgroup span="1" width="15%"/>
+            <colgroup span="1" width="25%"/>
+            <colgroup span="2" width="15%"/>
+            <colgroup span="1" width="35%"/>
+            <tbody>
+                <tr>
+                    <td class="caption" colspan="3" rowspan="1">EarthResourceML Lite - MineralOccurrenceView</td>
+                    <td colspan="2" ALIGN="right"><b>View As: </b>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML Lite'"/>
+                            <xsl:with-param name="real-url" select="./*:identifier"/>
+                        </xsl:call-template>
+                    </td> 
+                </tr>                  
+                <xsl:call-template name="formatSimpleFeatures">
+                    <xsl:with-param name="wfsUriList" select="concat('mineralOccurrence_uri ', 'mine_uri ', 'specification_uri ', 'identifier')" />
+                </xsl:call-template>
+            </tbody>
+        </table>
+    </xsl:template>
+ </xsl:stylesheet>

--- a/src/main/resources/org/auscope/portal/core/xslt/WfsToHtml.xsl
+++ b/src/main/resources/org/auscope/portal/core/xslt/WfsToHtml.xsl
@@ -11,10 +11,11 @@
                 exclude-result-prefixes="er gml wfs fo gsml xlink">
     <xsl:output method="html" indent="yes"/>
 
-    <!-- External Parameters -->
+    <!-- External Parameters -->    
     <xsl:param name="serviceURL"/>
     <xsl:param name="vocabserviceURL"/>
     <xsl:param name="vocabservice-reponame"/>
+    <xsl:param name="portalBaseURL"/>
     <xsl:variable name="vocab-hard-coded-lookup" select="concat('http://services.auscope.org/sissvoc/commodity-vocab/resource.rdf?uri=http://resource.auscope.org/classifier/GA/commodity/', '')"/>
     <xsl:variable name="vocab-hard-coded-lookupCGI" select="concat('http://services-test.auscope.org/SISSVoc/getConceptByURI?CGI/', '')"/>
 
@@ -58,13 +59,14 @@
                     td.caption {
                         font-weight: bold;
                         font-size:medium;
-                        color: #FF6600;
+                        color: #4f94cd;
                     }
                     td.header {
                         font-weight: bold;
                         color: #15428B;
                     }
-                    td.row {
+                    /* rename row to our_row so bootstrap row styles doesn't interfere!*/
+                    td.our_row {
                         border-top: 1px solid #4682B4;
                     }
                     td.col {
@@ -82,9 +84,6 @@
                 <meta http-equiv="content-type" content="text/html; charset=utf-8" />
             </head>
             <body>
-                <div>
-                    <img alt="" src="img/img-auscope-banner.gif" style="border: 0px solid;" />
-                </div>
                 <!-- we apply the template on both featuremember and featuremembers as both are valid response.
                      GeoServer provides the option of encoding the different result via its setting
                      http://docs.geoserver.org/latest/en/user/data/app-schema/wfs-service-settings.html
@@ -133,36 +132,36 @@
                 </tr>
                 <!-- Mining Activity Type -->
                 <tr>
-                    <td class="row header">Mining Activity Type</td>
-                    <td class="row"><xsl:value-of select="./er:activityType"/></td>
-                    <td class="row header">MiningActivity Id:</td>
-                    <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                    <td class="our_row header">Mining Activity Type</td>
+                    <td class="our_row"><xsl:value-of select="./er:activityType"/></td>
+                    <td class="our_row header">MiningActivity Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                         <xsl:with-param name="friendly-name" select="$miningActivityID"/>
                         <xsl:with-param name="real-url" select="$miningActivityID"/>
                     </xsl:call-template></td>
                 </tr>
                 <!-- Start Date -->
                 <tr>
-                    <td class="row header">Start Date:</td>
-                    <td class="row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/></td>
-                    <td class="row header">End Date:</td>
-                    <td class="row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
-                    <td class="row">&#160;</td>
+                    <td class="our_row header">Start Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/></td>
+                    <td class="our_row header">End Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
+                    <td class="our_row">&#160;</td>
                 </tr>
                 <!-- Associated Mine Name -->
                 <tr>
-                    <td class="row header">Associated Mine</td>
-                    <td class="row"></td>
-                    <td class="row header">Associated Mine Id:</td>
-                    <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                    <td class="our_row header">Associated Mine</td>
+                    <td class="our_row"></td>
+                    <td class="our_row header">Associated Mine Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                         <xsl:with-param name="friendly-name" select="./er:associatedMine/@xlink:href"/>
                         <xsl:with-param name="real-url" select="./er:associatedMine/@xlink:href"/>
                     </xsl:call-template></td>
                 </tr>
                 <!-- Amount of Ore Processed -->
                 <tr>
-                    <td class="row header">Amount of Ore Processed</td>
-                    <td class="row"><xsl:value-of select="./er:oreProcessed"/><xsl:value-of select="' '"/>
+                    <td class="our_row header">Amount of Ore Processed</td>
+                    <td class="our_row"><xsl:value-of select="./er:oreProcessed"/><xsl:value-of select="' '"/>
                         <xsl:choose>
                             <xsl:when test="contains(./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
                                 <xsl:value-of select="substring-after(./er:oreProcessed/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
@@ -172,7 +171,7 @@
                             </xsl:otherwise>
                         </xsl:choose>
                     </td>
-                    <td class="row" colspan="3">&#160;</td>
+                    <td class="our_row" colspan="3">&#160;</td>
                 </tr>
                 <!-- Commodity -->
                <xsl:for-each select="./er:producedMaterial/er:Product/er:sourceCommodity">
@@ -198,10 +197,10 @@
                             </xsl:variable>
 
                             <tr>
-                                <td class="row header">Commodity</td>
-                                <td class="row"><xsl:value-of select="$commodityName"/></td>
-                                <td class="row header">Commodity Id:</td>
-                                <td class="row" colspan="2">
+                                <td class="our_row header">Commodity</td>
+                                <td class="our_row"><xsl:value-of select="$commodityName"/></td>
+                                <td class="our_row header">Commodity Id:</td>
+                                <td class="our_row" colspan="2">
                                     <xsl:choose>
                                         <xsl:when test="starts-with($commodityID, 'http://')">
                                             <a href="wfsFeaturePopup.do?url={$commodityID}" onclick="var w=window.open('wfsFeaturePopup.do?url={$commodityID}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="$commodityID"/></a>
@@ -222,11 +221,11 @@
                     <xsl:choose>
                         <xsl:when test="position()=1">
                         <tr>
-                            <td class="row">&#160;</td>
-                            <td class="row">&#160;</td>
-                            <td class="row col_header">Production Amount</td>
-                            <td class="row col_header">Recovery %</td>
-                            <td class="row col_header">Grade</td>
+                            <td class="our_row">&#160;</td>
+                            <td class="our_row">&#160;</td>
+                            <td class="our_row col_header">Production Amount</td>
+                            <td class="our_row col_header">Recovery %</td>
+                            <td class="our_row col_header">Grade</td>
                         </tr>
                         <tr>
                             <td class="header">Product Name</td>
@@ -257,8 +256,8 @@
                         <xsl:otherwise>
                         <tr>
                             <td>&#160;</td>
-                            <td class="row"><xsl:value-of select="./er:Product/er:productName"/></td>
-                            <td class="row"><xsl:value-of select="./er:Product/er:production"/><xsl:value-of select="' '"/>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:productName"/></td>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:production"/><xsl:value-of select="' '"/>
                             <xsl:choose>
                                 <xsl:when test="contains(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
                                     <xsl:value-of select="substring-after(./er:Product/er:production/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
@@ -268,8 +267,8 @@
                                 </xsl:otherwise>
                             </xsl:choose>
                             </td>
-                            <td class="row"><xsl:value-of select="./er:Product/er:recovery"/></td>
-                            <td class="row"><xsl:value-of select="./er:Product/er:grade"/><xsl:value-of select="' '"/>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:recovery"/></td>
+                            <td class="our_row"><xsl:value-of select="./er:Product/er:grade"/><xsl:value-of select="' '"/>
                             <xsl:choose>
                                 <xsl:when test="contains(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')">
                                     <xsl:value-of select="substring-after(./er:Product/er:grade/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/>
@@ -286,11 +285,11 @@
                 <!-- Raw Material -->
                 <xsl:if test="./er:composition">
                     <tr>
-                        <td class="row header">Raw Material</td>
-                        <td class="row col_header">Lithology</td>
-                        <td class="row col_header">Role</td>
-                        <td class="row col_header">Proportion</td>
-                        <td class="row col_header">&#160;</td>
+                        <td class="our_row header">Raw Material</td>
+                        <td class="our_row col_header">Lithology</td>
+                        <td class="our_row col_header">Role</td>
+                        <td class="our_row col_header">Proportion</td>
+                        <td class="our_row col_header">&#160;</td>
                     </tr>
                     <tr>
                         <td>&#160;</td>
@@ -302,10 +301,10 @@
                 </xsl:if>
                 <!-- Associated Earth Resources -->
                 <tr>
-                    <td class="row header">Associated Earth Resources</td>
-                    <td class="row">&#160;</td>
-                    <td class="row header">Earth Resource Id:</td>
-                    <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                    <td class="our_row header">Associated Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Earth Resource Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                         <xsl:with-param name="friendly-name" select="./er:deposit/@xlink:href"/>
                         <xsl:with-param name="real-url" select="./er:deposit/@xlink:href"/>
                     </xsl:call-template></td>
@@ -337,10 +336,10 @@
                 </tr>
                 <!-- Mine Name -->
                 <tr>
-                    <td class="row header">Mine Name</td>
-                    <td class="row"><xsl:value-of select="$minePrefName"/></td>
-                    <td class="row header">Mine Id:</td>
-                    <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                    <td class="our_row header">Mine Name</td>
+                    <td class="our_row"><xsl:value-of select="$minePrefName"/></td>
+                    <td class="our_row header">Mine Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="$mineID"/>
                             <xsl:with-param name="real-url" select="$mineID"/>
                         </xsl:call-template></td>
@@ -351,9 +350,9 @@
                     <xsl:choose>
                         <xsl:when test="position()=1">
                         <tr>
-                            <td class="row header">Alternative Mine Name</td>
-                            <td class="row"><xsl:value-of select="$currentOtherName"/></td>
-                            <td class="row" colspan="3">&#160;</td>
+                            <td class="our_row header">Alternative Mine Name</td>
+                            <td class="our_row"><xsl:value-of select="$currentOtherName"/></td>
+                            <td class="our_row" colspan="3">&#160;</td>
                         </tr>
                         </xsl:when>
                         <xsl:otherwise>
@@ -367,10 +366,10 @@
                 </xsl:for-each>
                 <!-- Status -->
                 <tr>
-                    <td class="row header">Status</td>
-                    <td class="row"><xsl:value-of select="./er:status"/></td>
-                    <td class="row header">Occurence</td>
-                    <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                    <td class="our_row header">Status</td>
+                    <td class="our_row"><xsl:value-of select="./er:status"/></td>
+                    <td class="our_row header">Occurrence</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                         <xsl:with-param name="friendly-name" select="./er:occurrence/@xlink:href"/>
                         <xsl:with-param name="real-url" select="./er:occurrence/@xlink:href"/>
                     </xsl:call-template></td>
@@ -384,16 +383,16 @@
                     <xsl:choose>
                         <xsl:when test="position()=1">
                          <tr>
-                            <td class="row header">&#160;</td>
-                            <td class="row col_header">Start Date - End Date</td>
-                            <td class="row header">&#160;</td>
-                            <td class="row" colspan="2">&#160;</td>
+                            <td class="our_row header">&#160;</td>
+                            <td class="our_row col_header">Start Date - End Date</td>
+                            <td class="our_row header">&#160;</td>
+                            <td class="our_row" colspan="2">&#160;</td>
                         </tr>
                         <tr>
-                            <td class="row header">Related Mining Activity</td>
-                            <td class="row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
-                            <td class="row header">Mining Activity Id:</td>
-                            <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <td class="our_row header">Related Mining Activity</td>
+                            <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
+                            <td class="our_row header">Mining Activity Id:</td>
+                            <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                                     <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
                                     <xsl:with-param name="real-url" select="$rel-mine-id"/>
                                 </xsl:call-template></td>
@@ -402,9 +401,9 @@
                         <xsl:otherwise>
                         <tr>
                             <td class="header">&#160;</td>
-                            <td class="row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
-                            <td class="row header">Mining Activity Id:</td>
-                            <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                            <td class="our_row"><xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:begin"/> - <xsl:value-of select="./er:activityDuration/gml:TimePeriod/gml:end"/></td>
+                            <td class="our_row header">Mining Activity Id:</td>
+                            <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                                     <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
                                     <xsl:with-param name="real-url" select="$rel-mine-id"/>
                                 </xsl:call-template></td>
@@ -417,10 +416,10 @@
                         <xsl:choose>
                             <xsl:when test="position()=1">
                             <tr>
-                                <td class="row header">Related Mine</td>
-                                <td class="row">&#160;</td>
-                                <td class="row header">Mine Id:</td>
-                                <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                                <td class="our_row header">Related Mine</td>
+                                <td class="our_row">&#160;</td>
+                                <td class="our_row header">Mine Id:</td>
+                                <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                                         <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
                                         <xsl:with-param name="real-url" select="$rel-mine-id"/>
                                     </xsl:call-template></td>
@@ -430,8 +429,8 @@
                             <tr>
                                 <td>&#160;</td>
                                 <td>&#160;</td>
-                                <td class="row header">Mine Id:</td>
-                                <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                                <td class="our_row header">Mine Id:</td>
+                                <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                                         <xsl:with-param name="friendly-name" select="$rel-mine-id"/>
                                         <xsl:with-param name="real-url" select="$rel-mine-id"/>
                                     </xsl:call-template></td>
@@ -456,13 +455,16 @@
                     <td class="caption" colspan="2" rowspan="1">EarthResourceML - Commodity</td>
                     <td>&#160;</td>
                     <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <a href="{$serviceURL}" onclick="var w=window.open('{$serviceURL}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=820');w.focus();return false;">EarthResourceML</a>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$commodity_id"/>
+                        </xsl:call-template>
                     </td>
                 </tr>
                 <!-- Commodity -->
                 <tr>
-                    <td class="row header">Commodity</td>
-                    <td class="row">
+                    <td class="our_row header">Commodity</td>
+                    <td class="our_row">
                     
                         <xsl:choose>
                             <xsl:when test="contains($commodity_name, '/')">                   
@@ -480,8 +482,8 @@
                         </xsl:choose>
                                                         
                     </td>
-                    <td class="row header">Commodity Id:</td>
-                    <td class="row" colspan="1">
+                    <td class="our_row header">Commodity Id:</td>
+                    <td class="our_row" colspan="1">
                         <xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="$commodity_id"/>
                             <xsl:with-param name="real-url" select="$commodity_id"/>
@@ -489,25 +491,25 @@
                     </td>
                 </tr>
                 <tr>
-                    <td class="row header">Local Name*</td>
-                    <td class="row"><xsl:value-of select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
-                    <td class="row header">Local Group*</td>
-                    <td class="row" colspan="1"><xsl:value-of select="./er:commodityGroup[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
+                    <td class="our_row header">Local Name*</td>
+                    <td class="our_row"><xsl:value-of select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
+                    <td class="our_row header">Local Group*</td>
+                    <td class="our_row" colspan="1"><xsl:value-of select="./er:commodityGroup[not(@codeSpace='http://www.ietf.org/rfc/rfc2616')]"/></td>
                 </tr>
                 <tr>
-                    <td class="row header">Importance</td>
-                    <td class="row" ><xsl:value-of select="./er:commodityImportance"/></td>
-                    <td class="row header">Rank:</td>
-                    <td class="row" colspan="1"><xsl:value-of select="./er:commodityRank"/></td>
+                    <td class="our_row header">Importance</td>
+                    <td class="our_row" ><xsl:value-of select="./er:commodityImportance"/></td>
+                    <td class="our_row header">Rank:</td>
+                    <td class="our_row" colspan="1"><xsl:value-of select="./er:commodityRank"/></td>
                 </tr>
         <xsl:for-each select="./er:source">
             <xsl:choose>
                 <xsl:when test="position()=1">
                 <tr>
-                    <td class="row header">Associated Earth Resources</td>
-                    <td class="row">&#160;</td>
-                    <td class="row header">Earth Resource Id:</td>
-                    <td class="row" colspan="1">
+                    <td class="our_row header">Associated Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Earth Resource Id:</td>
+                    <td class="our_row" colspan="1">
                         <xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="@xlink:href"/>
                             <xsl:with-param name="real-url" select="@xlink:href"/>
@@ -519,8 +521,8 @@
                 <tr>
                     <td>&#160;</td>
                     <td>&#160;</td>
-                    <td class="row header">Earth Resource Id:</td>
-                    <td class="row" colspan="1">
+                    <td class="our_row header">Earth Resource Id:</td>
+                    <td class="our_row" colspan="1">
                         <xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="@xlink:href"/>
                             <xsl:with-param name="real-url" select="@xlink:href"/>
@@ -547,15 +549,18 @@
                     <td class="caption" colspan="2" rowspan="1">EarthResourceML - MineralOccurrence</td>
                     <td>&#160;</td>
                     <td colspan="2" ALIGN="right"><b>View As: </b>
-                        <a href="{$serviceURL}" onclick="var w=window.open('{$serviceURL}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=820');w.focus();return false;">EarthResourceML</a>
+                        <xsl:call-template name="make-popup-url">
+                            <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
+                            <xsl:with-param name="real-url" select="$minocc_id"/>
+                        </xsl:call-template>
                     </td>
                 </tr>
                 <!-- Type -->
                 <tr>
-                    <td class="row header">Type</td>
-                    <td class="row"><xsl:value-of select="er:type"/></td>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="2">
+                    <td class="our_row header">Type</td>
+                    <td class="our_row"><xsl:value-of select="er:type"/></td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
                         <xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="$minocc_id"/>
                             <xsl:with-param name="real-url" select="$minocc_id"/>
@@ -567,11 +572,11 @@
             <xsl:choose>
                 <xsl:when test="position()=1">
                 <tr>
-                    <td class="row header">Mineral Occurrence Name</td>
-                    <td class="row"><xsl:value-of select="."/></td>
-                    <td class="row">&#160;</td>
-                    <td class="row">&#160;</td>
-                    <td class="row">&#160;</td>
+                    <td class="our_row header">Mineral Occurrence Name</td>
+                    <td class="our_row"><xsl:value-of select="."/></td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row">&#160;</td>
                 </tr>
                 </xsl:when>
                 <xsl:otherwise>
@@ -588,8 +593,8 @@
                 <!-- Description -->
         <xsl:if test="gml:description">
                 <tr>
-                    <td class="row header" rowspan="1">Description</td>
-                    <td class="row" rowspan="2" colspan="4"><xsl:value-of select="./gml:description"/></td>
+                    <td class="our_row header" rowspan="1">Description</td>
+                    <td class="our_row" rowspan="2" colspan="4"><xsl:value-of select="./gml:description"/></td>
                 </tr>
                 <tr></tr><!-- VT: workaround to fix a spacing bug in the output-->
         </xsl:if>
@@ -607,13 +612,13 @@
             <xsl:choose>
                 <xsl:when test="position()=1">
                 <tr>
-                    <td class="row header">Commodity</td>
-                    <td class="row"><xsl:call-template name="make-popup-url">
+                    <td class="our_row header">Commodity</td>
+                    <td class="our_row"><xsl:call-template name="make-popup-url">
                         <xsl:with-param name="friendly-name" select="$comm_name"/>
                         <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring-after($comm_name, 'urn:cgi:classifier:GA:commodity:'))"/>                        
                     </xsl:call-template></td>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="2">
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
                         <xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="$comm_url"/>
                             <xsl:with-param name="real-url" select="$comm_url"/>
@@ -624,12 +629,12 @@
                 <xsl:otherwise>
                 <tr>
                     <td>&#160;</td>
-                    <td class="row"><xsl:call-template name="make-popup-url">
+                    <td class="our_row"><xsl:call-template name="make-popup-url">
                         <xsl:with-param name="friendly-name" select="$comm_name"/>
                         <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring($comm_name, string-length($comm_name) - 1))"/>
                     </xsl:call-template></td>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="2">
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
                         <xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="$comm_url"/>
                             <xsl:with-param name="real-url" select="$comm_url"/>
@@ -641,19 +646,19 @@
         </xsl:for-each>
                 <!-- Observation Method -->
                 <tr>
-                    <td class="row header">Observation Method</td>
-                    <td class="row"><xsl:value-of select="./gsml:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td class="row header">Purpose:</td>
-                    <td class="row" colspan="2"><xsl:value-of select="./gsml:purpose"/></td>
+                    <td class="our_row header">Observation Method</td>
+                    <td class="our_row"><xsl:value-of select="./gsml:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td class="our_row header">Purpose:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./gsml:purpose"/></td>
                 </tr>
                  <!-- Dimension -->
        <xsl:if test="./er:dimension">
                 <tr>
-                    <td class="row header">Dimension</td>
-                    <td class="row col_header">Area</td>
-                    <td class="row col_header">Depth</td>
-                    <td class="row col_header">Length</td>
-                    <td class="row col_header">Width</td>
+                    <td class="our_row header">Dimension</td>
+                    <td class="our_row col_header">Area</td>
+                    <td class="our_row col_header">Depth</td>
+                    <td class="our_row col_header">Length</td>
+                    <td class="our_row col_header">Width</td>
                 </tr>
                 <tr>
                     <td></td>
@@ -666,11 +671,11 @@
                 <!-- Appearance -->
        <xsl:if test="./er:form | ./er:expression | ./er:shape">
                 <tr>
-                    <td class="row header">Appearance</td>
-                    <td class="row col_header">Form</td>
-                    <td class="row col_header">Expression</td>
-                    <td class="row col_header">Shape</td>
-                    <td class="row col_header">&#160;</td>
+                    <td class="our_row header">Appearance</td>
+                    <td class="our_row col_header">Form</td>
+                    <td class="our_row col_header">Expression</td>
+                    <td class="our_row col_header">Shape</td>
+                    <td class="our_row col_header">&#160;</td>
                 </tr>
                 <tr>
                     <td></td>
@@ -683,11 +688,11 @@
                 <!-- Linear Orientation -->
        <xsl:if test="./er:linearOrientation">
                 <tr>
-                    <td class="row header">Linear Orientation</td>
-                    <td class="row col_header">Plunge</td>
-                    <td class="row col_header">Trend</td>
-                    <td class="row col_header">&#160;</td>
-                    <td class="row col_header">&#160;</td>
+                    <td class="our_row header">Linear Orientation</td>
+                    <td class="our_row col_header">Plunge</td>
+                    <td class="our_row col_header">Trend</td>
+                    <td class="our_row col_header">&#160;</td>
+                    <td class="our_row col_header">&#160;</td>
                 </tr>
                 <tr>
                     <td></td>
@@ -700,11 +705,11 @@
                 <!-- Planar Orientation -->
        <xsl:if test="./er:planarOrientation">
                 <tr>
-                    <td class="row header">Planar Orientation</td>
-                    <td class="row col_header">Convention</td>
-                    <td class="row col_header">Azimuth</td>
-                    <td class="row col_header">Dip</td>
-                    <td class="row col_header">&#160;</td>
+                    <td class="our_row header">Planar Orientation</td>
+                    <td class="our_row col_header">Convention</td>
+                    <td class="our_row col_header">Azimuth</td>
+                    <td class="our_row col_header">Dip</td>
+                    <td class="our_row col_header">&#160;</td>
                 </tr>
                 <tr>
                     <td></td>
@@ -717,11 +722,11 @@
                 <!-- Classification -->
        <xsl:if test="./er:classification">
                 <tr>
-                    <td class="row header">Classification</td>
-                    <td class="row col_header">Deposit Group</td>
-                    <td class="row col_header">&#160;</td>
-                    <td class="row col_header">Deposit Type</td>
-                    <td class="row col_header">&#160;</td>
+                    <td class="our_row header">Classification</td>
+                    <td class="our_row col_header">Deposit Group</td>
+                    <td class="our_row col_header">&#160;</td>
+                    <td class="our_row col_header">Deposit Type</td>
+                    <td class="our_row col_header">&#160;</td>
                 </tr>
                 <tr>
                     <td></td>
@@ -734,7 +739,7 @@
                 <!-- Supergene Modification -->
        <xsl:if test="./er:supergeneModification">
                 <tr>
-                    <td class="row header">Supergene Modification</td>
+                    <td class="our_row header">Supergene Modification</td>
                     <td class="col_header">Lithology</td>
                     <td class="col_header">Supergene Type</td>
                     <td class="col_header">Depth</td>
@@ -754,17 +759,17 @@
        <xsl:if test="./er:composition">
            <xsl:for-each select="./er:composition">
                 <tr>
-                    <td class="row header">Composition</td>
+                    <td class="our_row header">Composition</td>
                  <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:RockMaterial/gsml:lithology/@xlink:title">
-                    <td class="row col_header">Lithology</td>
+                    <td class="our_row col_header">Lithology</td>
                 </xsl:if>
                  <xsl:if test="./er:EarthResourceMaterial/er:material/gsml:Mineral/gsml:mineralName/@xlink:title">
-                    <td class="row col_header">Mineral Name</td>
+                    <td class="our_row col_header">Mineral Name</td>
                 </xsl:if>
 
-                    <td class="row col_header">Role</td>
-                    <td class="row col_header">Proportion</td>
-                    <td class="row col_header"></td>
+                    <td class="our_row col_header">Role</td>
+                    <td class="our_row col_header">Proportion</td>
+                    <td class="our_row col_header"></td>
                 </tr>
                 <tr>
                     <td></td>
@@ -787,11 +792,11 @@
                 <!-- Geological History -->
        <xsl:if test="./gsml:preferredAge/gsml:GeologicEvent">
                 <tr>
-                    <td class="row header">Geological History</td>
-                    <td class="row col_header">Age</td>
-                    <td class="row col_header">Process</td>
-                    <td class="row col_header">Environment</td>
-                    <td class="row col_header"></td>
+                    <td class="our_row header">Geological History</td>
+                    <td class="our_row col_header">Age</td>
+                    <td class="our_row col_header">Process</td>
+                    <td class="our_row col_header">Environment</td>
+                    <td class="our_row col_header"></td>
                 </tr>
             <xsl:for-each select="./gsml:preferredAge/gsml:GeologicEvent">
                 <tr>
@@ -815,11 +820,11 @@
                 <!-- Reserves -->
         <xsl:for-each select="./er:oreAmount/er:Reserve">
                 <tr>
-                    <td class="row header">Reserves</td>
-                    <td class="row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td class="row"><xsl:value-of select="./er:category"/></td>
-                    <td class="row header">Date:</td>
-                    <td class="row"><xsl:value-of select="./er:date"/></td>
+                    <td class="our_row header">Reserves</td>
+                    <td class="our_row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td class="our_row"><xsl:value-of select="./er:category"/></td>
+                    <td class="our_row header">Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:date"/></td>
                 </tr>
             <xsl:for-each select="./er:measureDetails">
                 <xsl:variable name="comm_description" select="substring-after(./er:CommodityMeasure/er:commodityOfInterest/@xlink:href,'#')"></xsl:variable>
@@ -828,14 +833,14 @@
                 <xsl:variable name="comm_url" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"></xsl:variable>
                 <tr>
                     <td class="col_header" >Commodity:</td>
-                    <td class="row">
+                    <td class="our_row">
                         <xsl:call-template name="make-popup-url">
                             <xsl:with-param name="friendly-name" select="$comm_std_name"/>
                             <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring($comm_std_name, string-length($comm_std_name) - 1))"/>
                         </xsl:call-template>
                     </td>
-                    <td class="row header">Commodity Id:</td>
-                        <td class="row" colspan="2">
+                    <td class="our_row header">Commodity Id:</td>
+                        <td class="our_row" colspan="2">
                             <xsl:call-template name="make-wfspopup-url">
                                 <xsl:with-param name="friendly-name" select="$comm_description"/>
                                 <xsl:with-param name="real-url" select="$comm_description"/>
@@ -844,10 +849,10 @@
                     </tr>
                 <tr>
                     <td></td>
-                    <td class="row col_header">Commodity Amount</td>
-                    <td class="row col_header">Cut-off Grade</td>
-                    <td class="row col_header">Grade</td>
-                    <td class="row col_header">Importance</td>
+                    <td class="our_row col_header">Commodity Amount</td>
+                    <td class="our_row col_header">Cut-off Grade</td>
+                    <td class="our_row col_header">Grade</td>
+                    <td class="our_row col_header">Importance</td>
                 </tr>
                 <xsl:variable name="cut_off_grade_uom">
                     <xsl:choose>
@@ -898,11 +903,11 @@
                 <!-- Resources -->
         <xsl:for-each select="./er:oreAmount/er:Resource">
                 <tr>
-                    <td class="row header">Resources</td>
-                    <td class="row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
-                    <td class="row"><xsl:value-of select="./er:category"/></td>
-                    <td class="row header">Date:</td>
-                    <td class="row"><xsl:value-of select="./er:date"/></td>
+                    <td class="our_row header">Resources</td>
+                    <td class="our_row"><xsl:value-of select="./er:ore"/><xsl:value-of select="' '"/><xsl:value-of select="substring-after(./er:ore/gsml:CGI_NumericValue/gsml:principalValue/@uom,'::')"/></td>
+                    <td class="our_row"><xsl:value-of select="./er:category"/></td>
+                    <td class="our_row header">Date:</td>
+                    <td class="our_row"><xsl:value-of select="./er:date"/></td>
                 </tr>
             <xsl:for-each select="./er:measureDetails">
                 <xsl:variable name="comm_description" select="substring-after(./er:CommodityMeasure/er:commodityOfInterest/@xlink:href,'#')"></xsl:variable>
@@ -911,14 +916,14 @@
                 <xsl:variable name="comm_url" select="../../../er:commodityDescription/er:Commodity[@gml:id=concat($comm_description,'')]/gml:name[@codeSpace='http://www.ietf.org/rfc/rfc2616']"></xsl:variable>
                     <tr>
                         <td class="col_header" >Commodity:</td>
-                        <td class="row">
+                        <td class="our_row">
                             <xsl:call-template name="make-popup-url">
                                 <xsl:with-param name="friendly-name" select="$comm_std_name"/>
                                 <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookup,substring($comm_std_name, string-length($comm_std_name) - 1))"/>
                             </xsl:call-template>
                         </td>
-                        <td class="row header">Id:</td>
-                        <td class="row" colspan="2">
+                        <td class="our_row header">Id:</td>
+                        <td class="our_row" colspan="2">
                             <xsl:call-template name="make-wfspopup-url">
                                 <xsl:with-param name="friendly-name" select="$comm_url"/>
                                 <xsl:with-param name="real-url" select="$comm_url"/>
@@ -947,10 +952,10 @@
                 </xsl:variable>
                 <tr>
                     <td></td>
-                    <td class="row col_header">Commodity Amount</td>
-                    <td class="row col_header">Cut-off Grade</td>
-                    <td class="row col_header">Grade</td>
-                    <td class="row col_header">Importance</td>
+                    <td class="our_row col_header">Commodity Amount</td>
+                    <td class="our_row col_header">Cut-off Grade</td>
+                    <td class="our_row col_header">Grade</td>
+                    <td class="our_row col_header">Importance</td>
                 </tr>
                 <tr>
                     <td></td>
@@ -981,10 +986,10 @@
                 <!-- Associated Mining Activity -->
        <xsl:if test="./er:resourceExtraction">
                 <tr>
-                    <td class="row header">Associated Mining Activity</td>
-                    <td class="row">&#160;</td>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="2">
+                    <td class="our_row header">Associated Mining Activity</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
                         <a href="wfsFeaturePopup.do?url={./er:resourceExtraction/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:resourceExtraction/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:resourceExtraction/@xlink:href,'=')"/></a>
                     </td>
                 </tr>
@@ -992,10 +997,10 @@
                 <!-- Parent Earth Resources -->
        <xsl:if test="./er:parent">
                 <tr>
-                    <td class="row header">Parent Earth Resources</td>
-                    <td class="row">&#160;</td>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="2">
+                    <td class="our_row header">Parent Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
                         <a href="wfsFeaturePopup.do?url={./er:parent/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:parent/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:parent/@xlink:href,'=')"/></a>
                     </td>
                 </tr>
@@ -1003,10 +1008,10 @@
                 <!-- Child Earth Resources -->
        <xsl:if test="./er:child">
                 <tr>
-                    <td class="row header">Child Earth Resources</td>
-                    <td class="row">&#160;</td>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="2">
+                    <td class="our_row header">Child Earth Resources</td>
+                    <td class="our_row">&#160;</td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="2">
                         <a href="wfsFeaturePopup.do?url={./er:child/@xlink:href}" onclick="var w=window.open('wfsFeaturePopup.do?url={./er:child/@xlink:href}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=850');w.focus();return false;"><xsl:value-of select="substring-after(./er:child/@xlink:href,'=')"/></a>
                     </td>
                 </tr>
@@ -1033,32 +1038,32 @@
                     <td colspan="2" ALIGN="right"><b>View As: </b>
                         <xsl:call-template name="make-popup-url">
                             <xsl:with-param name="friendly-name" select="'EarthResourceML'"/>
-                            <xsl:with-param name="real-url" select="$serviceURL"/>
+                            <xsl:with-param name="real-url" select="$mfoID"/>
                         </xsl:call-template>
                     </td>
                 </tr>
 
                 <!-- MiningFeatureOccurrence Type -->
                 <tr>
-                    <td class="row header">Mining Feature Occurrence Description:</td>
-                    <td class="row"><xsl:value-of select="./gml:description"/></td>
-                    <td class="row header">Mining Feature Occurrence Id:</td>
-                    <td class="row" colspan="2"><xsl:call-template name="make-wfspopup-url">
+                    <td class="our_row header">Mining Feature Occurrence Description:</td>
+                    <td class="our_row"><xsl:value-of select="./gml:description"/></td>
+                    <td class="our_row header">Mining Feature Occurrence Id:</td>
+                    <td class="our_row" colspan="2"><xsl:call-template name="make-wfspopup-url">
                             <xsl:with-param name="friendly-name" select="$mfoID"/>
                             <xsl:with-param name="real-url" select="$mfoID"/>
                         </xsl:call-template></td>
                 </tr>
                 <!-- Observation Method -->
                 <tr>
-                    <td class="row header" colspan="2">Observation Method:</td>
-                    <td class="row" colspan="2"><xsl:value-of select="./er:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td class="row" colspan="1">&#160;</td>
+                    <td class="our_row header" colspan="2">Observation Method:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./er:observationMethod/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td class="our_row" colspan="1">&#160;</td>
                 </tr>
                 <!-- Positional Accuracy -->
                 <tr>
-                    <td class="row header" colspan="2">Positional Accuracy:</td>
-                    <td class="row" colspan="2"><xsl:value-of select="./er:positionalAccuracy/gsml:CGI_TermValue/gsml:value"/></td>
-                    <td class="row" colspan="1">&#160;</td>
+                    <td class="our_row header" colspan="2">Positional Accuracy:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./er:positionalAccuracy/gsml:CGI_TermValue/gsml:value"/></td>
+                    <td class="our_row" colspan="1">&#160;</td>
                 </tr>
             </tbody>
         </table>&#160;
@@ -1105,18 +1110,18 @@
                     </td>
                 </tr>
                 <tr>
-                    <td class="row header">Id:</td>
-                    <td class="row" colspan="4"><xsl:value-of select="$guID"/></td>
+                    <td class="our_row header">Id:</td>
+                    <td class="our_row" colspan="4"><xsl:value-of select="$guID"/></td>
                 </tr>
                 <xsl:for-each select="./gml:name[not(@codeSpace='http://www.ietf.org/rfc/rfc3406')]">
                     <xsl:choose>
                         <xsl:when test="position()=1">
                         <tr>
-                            <td class="row header">Name:</td>
-                            <td class="row"><xsl:value-of select="."/></td>
-                            <td class="row">&#160;</td>
-                            <td class="row">&#160;</td>
-                            <td class="row">&#160;</td>
+                            <td class="our_row header">Name:</td>
+                            <td class="our_row"><xsl:value-of select="."/></td>
+                            <td class="our_row">&#160;</td>
+                            <td class="our_row">&#160;</td>
+                            <td class="our_row">&#160;</td>
                         </tr>
                         </xsl:when>
                         <xsl:otherwise>
@@ -1131,19 +1136,19 @@
                     </xsl:choose>
                 </xsl:for-each>
                 <tr>
-                    <td class="row header">Observation Method:</td>
-                    <td class="row">
+                    <td class="our_row header">Observation Method:</td>
+                    <td class="our_row">
                         <xsl:call-template name="make-popup-url">
                             <xsl:with-param name="friendly-name" select="$observationMethod"/>
                             <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookupCGI,$observationMethod)"/>
                         </xsl:call-template>
                     </td>
-                    <td class="row header">Mapped Feature Id:</td>
-                    <td class="row" colspan="2"><xsl:value-of select="./gsml:occurrence/gsml:MappedFeature/@gml:id"/></td>
+                    <td class="our_row header">Mapped Feature Id:</td>
+                    <td class="our_row" colspan="2"><xsl:value-of select="./gsml:occurrence/gsml:MappedFeature/@gml:id"/></td>
                 </tr>
                 <tr>
-                    <td class="row header">Mapped Feature Observation Method:</td>
-                    <td class="row" colspan="4">
+                    <td class="our_row header">Mapped Feature Observation Method:</td>
+                    <td class="our_row" colspan="4">
                         <xsl:call-template name="make-popup-url">
                             <xsl:with-param name="friendly-name" select="$mappedFeatureObsMethod"/>
                             <xsl:with-param name="real-url" select="concat($vocab-hard-coded-lookupCGI,$mappedFeatureObsMethod)"/>
@@ -1227,7 +1232,7 @@
     <xsl:template name="make-wfspopup-url">
         <xsl:param name="friendly-name"/>
         <xsl:param name="real-url"/>
-        <a href="wfsFeaturePopup.do?url={$real-url}" onclick="var w=window.open('wfsFeaturePopup.do?url={$real-url}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=820');w.focus();return false;"><xsl:value-of select="$friendly-name"/></a>
+        <a href="wfsFeaturePopup.do?url={$real-url}" onclick="var w=window.open('{$portalBaseURL}/wfsFeaturePopup.do?url={$real-url}','AboutWin','toolbar=no, menubar=no,location=no,resizable=yes,scrollbars=yes,statusbar=no,height=450,width=820');w.focus();return false;"><xsl:value-of select="$friendly-name"/></a>
     </xsl:template>
 
 </xsl:stylesheet>

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestWfsController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestWfsController.java
@@ -7,13 +7,14 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.auscope.portal.core.server.controllers.WFSController;
 import org.auscope.portal.core.services.PortalServiceException;
+import org.auscope.portal.core.services.WFSGml32Service;
+import org.auscope.portal.core.services.WFSService;
 import org.auscope.portal.core.services.methodmakers.filter.SimplePropertyFilter;
 import org.auscope.portal.core.services.responses.wfs.WFSCountResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSTransformedResponse;
 import org.auscope.portal.core.test.ByteBufferedServletOutputStream;
 import org.auscope.portal.core.test.PortalTestClass;
-import org.auscope.portal.core.services.WFSService;
 import org.jmock.Expectations;
 import org.junit.Assert;
 import org.junit.Before;
@@ -38,11 +39,13 @@ public class TestWfsController extends PortalTestClass {
 
     private WFSService mockWfsService = context.mock(WFSService.class);
 
+    private WFSGml32Service mockWfs32Service = context.mock(WFSGml32Service.class);
+
     private HttpServletResponse mockResponse = context.mock(HttpServletResponse.class);
 
     @Before
     public void setUp() {
-        wfsController = new WFSController(mockWfsService);
+        wfsController = new WFSController(mockWfsService, mockWfs32Service);
     }
 
     /**

--- a/src/test/java/org/auscope/portal/core/services/TestWFSService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestWFSService.java
@@ -9,6 +9,7 @@ import org.auscope.portal.core.server.http.HttpClientInputStream;
 import org.auscope.portal.core.server.http.HttpServiceCaller;
 import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker;
 import org.auscope.portal.core.services.methodmakers.WFSGetFeatureMethodMaker.ResultType;
+import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.auscope.portal.core.services.responses.ows.OWSException;
 import org.auscope.portal.core.services.responses.wfs.WFSCountResponse;
 import org.auscope.portal.core.services.responses.wfs.WFSResponse;
@@ -270,7 +271,7 @@ public class TestWFSService extends PortalTestClass {
                 oneOf(mockMethodMaker).makeGetMethod(serviceUrl, typeName, featureId, BaseWFSService.DEFAULT_SRS, null);
                 will(returnValue(mockMethod));
 
-                oneOf(mockGmlToHtml).convert(responseString, serviceUrl);
+                oneOf(mockGmlToHtml).convert(with(any(String.class)), with(any(ErmlNamespaceContext.class)));
                 will(returnValue(responseHtml));
 
             }
@@ -349,13 +350,12 @@ public class TestWFSService extends PortalTestClass {
                 .loadResourceAsString("org/auscope/portal/core/test/responses/wfs/EmptyWFSResponse.xml");
         final String responseKml = "<kml:response/>"; //we aren't testing the validity of this
         final String serviceUrl = "http://service/wfs?request=GetFeature";
-
         context.checking(new Expectations() {
             {
                 oneOf(mockServiceCaller).getMethodResponseAsString(with(any(HttpGet.class)));
                 will(returnValue(responseString));
 
-                oneOf(mockGmlToHtml).convert(responseString, serviceUrl);
+                oneOf(mockGmlToHtml).convert(with(any(String.class)), with(any(ErmlNamespaceContext.class)));
                 will(returnValue(responseKml));
 
             }

--- a/src/test/java/org/auscope/portal/core/services/TestWMSService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestWMSService.java
@@ -21,6 +21,7 @@ import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord_1_1_
 import org.auscope.portal.core.services.responses.wms.GetCapabilitiesWMSLayerRecord;
 import org.auscope.portal.core.test.PortalTestClass;
 import org.auscope.portal.core.util.ResourceUtil;
+import org.auscope.portal.core.xslt.GmlToHtml;
 import org.jmock.Expectations;
 import org.junit.Assert;
 import org.junit.Before;
@@ -47,7 +48,7 @@ public class TestWMSService extends PortalTestClass {
         mockMethodMaker = context.mock(WMSMethodMaker.class);
         mockMethod = context.mock(HttpRequestBase.class);
         methodMaker.add(mockMethodMaker);
-        service = new WMSService(mockServiceCaller, methodMaker);
+        service = new WMSService(mockServiceCaller, methodMaker, new GmlToHtml());
     }
 
     /**

--- a/src/test/java/org/auscope/portal/core/services/TestWMSService.java
+++ b/src/test/java/org/auscope/portal/core/services/TestWMSService.java
@@ -21,7 +21,6 @@ import org.auscope.portal.core.services.responses.wms.GetCapabilitiesRecord_1_1_
 import org.auscope.portal.core.services.responses.wms.GetCapabilitiesWMSLayerRecord;
 import org.auscope.portal.core.test.PortalTestClass;
 import org.auscope.portal.core.util.ResourceUtil;
-import org.auscope.portal.core.xslt.GmlToHtml;
 import org.jmock.Expectations;
 import org.junit.Assert;
 import org.junit.Before;
@@ -48,7 +47,7 @@ public class TestWMSService extends PortalTestClass {
         mockMethodMaker = context.mock(WMSMethodMaker.class);
         mockMethod = context.mock(HttpRequestBase.class);
         methodMaker.add(mockMethodMaker);
-        service = new WMSService(mockServiceCaller, methodMaker, new GmlToHtml());
+        service = new WMSService(mockServiceCaller, methodMaker);
     }
 
     /**

--- a/src/test/java/org/auscope/portal/core/xslt/TestGmlToHtml.java
+++ b/src/test/java/org/auscope/portal/core/xslt/TestGmlToHtml.java
@@ -1,5 +1,6 @@
 package org.auscope.portal.core.xslt;
 
+import org.auscope.portal.core.services.namespaces.ErmlNamespaceContext;
 import org.auscope.portal.core.test.PortalTestClass;
 import org.auscope.portal.core.util.ResourceUtil;
 import org.junit.Assert;
@@ -23,7 +24,7 @@ public class TestGmlToHtml extends PortalTestClass {
         final String wfs = ResourceUtil.loadResourceAsString("org/auscope/portal/core/erml/mine/mineGetFeatureResponse.xml");
         final String serviceUrl = "http://example.org/wfs";
 
-        final String response = gmlToHtml.convert(wfs, serviceUrl);
+        final String response = gmlToHtml.convert(wfs, new ErmlNamespaceContext());
         Assert.assertNotNull(response);
         Assert.assertFalse(response.isEmpty());
     }

--- a/src/test/java/org/auscope/portal/core/xslt/TestGmlToHtml.java
+++ b/src/test/java/org/auscope/portal/core/xslt/TestGmlToHtml.java
@@ -6,6 +6,9 @@ import org.auscope.portal.core.util.ResourceUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class TestGmlToHtml extends PortalTestClass {
 
@@ -14,6 +17,9 @@ public class TestGmlToHtml extends PortalTestClass {
     @Before
     public void setup() {
         this.gmlToHtml = new GmlToHtml();
+        // Give it some request context for GmlToHtml convert()
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
     }
 
     /**
@@ -22,7 +28,6 @@ public class TestGmlToHtml extends PortalTestClass {
     @Test
     public void testNoErrors() throws Exception {
         final String wfs = ResourceUtil.loadResourceAsString("org/auscope/portal/core/erml/mine/mineGetFeatureResponse.xml");
-        final String serviceUrl = "http://example.org/wfs";
 
         final String response = gmlToHtml.convert(wfs, new ErmlNamespaceContext());
         Assert.assertNotNull(response);


### PR DESCRIPTION
Basically, I split wfsToHtml.xsl into 3 files: 
-ER1.xsl to handle the old ERML 1.1
-ER2.xsl to handle ERML 2.0 because the structure is different
-wfsToHtml.xsl handles everything else (ERLite, borehole,  boreholeview, tenement, minoccview)

In the controller part, I just search for ER namespace and pass it on to GmlToHtml so it can pass it on to the xslt (to determine which xsl to use). Only matters for ER types, because the structure is complex and different. Flat ones such as ERLite and boreholeview only has difference in attribute labels, and they don't need to be mapped specifically (I just iterate through them). 

Changes in PortalXSLTTransformer enables it to pass on parameters between xsl files (or was it for including multiple xslt files.. I don't remember but I had to change the order). 

Also refactored WFSService so WFSGml32Service is a separate class (was ugly).
