### PR TITLE
AUS-3464: Borehole HTML assumes elevation and cored interval in meters

### DIFF
--- a/src/main/resources/org/auscope/portal/core/xslt/WfsToHtml.xsl
+++ b/src/main/resources/org/auscope/portal/core/xslt/WfsToHtml.xsl
@@ -491,7 +491,8 @@
                     <td class="our_row header">Collar Elevation:</td>
                     <td class="our_row">
                         <xsl:if test="./gsml:collarLocation/gsml:BoreholeCollar/gsml:elevation">                            
-                            <xsl:value-of select="concat(./gsml:collarLocation/gsml:BoreholeCollar/gsml:elevation, ' (m)')"/>
+                            <xsl:value-of select="concat(./gsml:collarLocation/gsml:BoreholeCollar/gsml:elevation, ' ',
+                                 ./gsml:collarLocation/gsml:BoreholeCollar/gsml:elevation/@uomLabels)"/>
                         </xsl:if>
                     </td>
                  </tr>
@@ -519,7 +520,8 @@
                      <td class="our_row header">Cored Interval (Upper Corner):</td>
                      <td class="our_row">
                         <xsl:if test="./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:upperCorner">                            
-                            <xsl:value-of select="concat(./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:upperCorner, ' m')"/>
+                            <xsl:value-of select="concat(./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:upperCorner, 
+                                ' ', ./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/@uomLabels)"/>
                         </xsl:if>
                      </td>
                  </tr>
@@ -527,7 +529,8 @@
                      <td class="our_row header">Cored Interval (Lower Corner):</td>
                      <td class="our_row">
                         <xsl:if test="./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:lowerCorner">                            
-                            <xsl:value-of select="concat(./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:lowerCorner, ' m')"/>
+                            <xsl:value-of select="concat(./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/gml:lowerCorner,
+                                ' ', ./gsml:indexData/gsml:BoreholeDetails/gsml:coredInterval/gml:Envelope/@uomLabels)"/>
                         </xsl:if>
                      </td>
                  </tr>


### PR DESCRIPTION
Changed so it picks it up from uomLabels. To test locally:
1. Add Boreholes -> MSCL data to map.
- Click on a feature and bring up a pop up.
- Click on the identifier link on top. It should bring up another pop up.
- In the second pop up, check that "elevation", "cored interval (upper corner)", "cored interval (lower corner)" doesn't have "m" or any metrics in the end. This may seem wrong, but it is correct according to the data (it's not specified in the XML). 
i.e. http://meiproc.earthsci.unimelb.edu.au/geoserver/wfs?service=WFS&version=1.1.0&request=GetFeature&typeName=gsml:Borehole&featureid=100 uomLabels aren't specified in the relevant nodes. 

2. Add Boreholes -> National virtual core library to map.
- Click on a feature in WA and bring up a pop up.
- Click on the identifier link on top. It should bring up another pop up.
-  The same fields as above should display uomLabels according to the data (a mix of 'unknown' and 'm'). 