### PR TITLE
Upgrade JClouds, no longer need shaded version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -396,7 +396,7 @@
         <dependency>
             <groupId>org.apache.jclouds</groupId>
             <artifactId>jclouds-all</artifactId>
-            <version>2.1.2-SHADED</version>
+            <version>2.3.0</version>
             <exclusions>
               <exclusion>
                 <groupId>javax.annotation</groupId>

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudComputeServiceNectar.java
@@ -1,6 +1,6 @@
 package org.auscope.portal.core.services.cloud;
 
-import static com.shaded.google.common.base.Predicates.not;
+import static com.google.common.base.Predicates.not;
 import static org.jclouds.compute.predicates.NodePredicates.RUNNING;
 import static org.jclouds.compute.predicates.NodePredicates.TERMINATED;
 import static org.jclouds.compute.predicates.NodePredicates.inGroup;
@@ -39,8 +39,8 @@ import org.openstack4j.api.OSClient;
 import org.openstack4j.model.common.Identifier;
 import org.openstack4j.openstack.OSFactory;
 
-import com.shaded.google.common.base.Predicate;
-import com.shaded.google.common.base.Predicates;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
 
 
 /**

--- a/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
+++ b/src/main/java/org/auscope/portal/core/services/cloud/CloudStorageServiceJClouds.java
@@ -35,9 +35,9 @@ import org.jclouds.sts.STSApi;
 import org.jclouds.sts.domain.UserAndSessionCredentials;
 import org.jclouds.sts.options.AssumeRoleOptions;
 
-import com.shaded.google.common.base.Supplier;
-import com.shaded.google.common.base.Suppliers;
-import com.shaded.google.common.io.Files;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.io.Files;
 
 
 /**

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudComputeService.java
@@ -20,7 +20,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.shaded.google.common.base.Predicate;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableSet;
 
 public class TestCloudComputeService extends PortalTestClass {

--- a/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
+++ b/src/test/java/org/auscope/portal/core/services/cloud/TestCloudStorageService.java
@@ -34,7 +34,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.shaded.google.common.io.ByteSource;
+import com.google.common.io.ByteSource;
 
 
 public class TestCloudStorageService extends PortalTestClass {


### PR DESCRIPTION
Very simple changes, JClouds upgraded to latest version and all corresponding imports updated.