### PR TITLE
WMS proxy accepts version < 1.3 SRS parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ target/
 /bin/
 *.iml
 .temp-*
+.factorypath


### PR DESCRIPTION
Allow our getWMSMapViaProxy.do endpoint to accept WMS version < 1.3.0 requests using the SRS parameter.

Test by displaying the Geological Provinces layer, which is hosted on a version 1.1.1 WMS. Note that this will currently only work on Chrome due to an unrelated rendering bug in Firefox/Safari.