### PR TITLE
AUS-3705 Empty CSV Downloads

### DIFF
--- a/src/main/java/org/auscope/portal/core/server/controllers/DownloadController.java
+++ b/src/main/java/org/auscope/portal/core/server/controllers/DownloadController.java
@@ -42,7 +42,10 @@ import com.google.common.io.Files;
 
 @Controller
 public class DownloadController extends BasePortalController {
+	
     private final Log logger = LogFactory.getLog(getClass());
+    // Minimum number of lines we expect a download to be (header file plus at least one data row)
+    private final static Integer MINIMUM_NUMBER_OF_LINES = 2;
     private HttpServiceCaller serviceCaller;
     private ServiceConfiguration serviceConfiguration;
 
@@ -181,7 +184,7 @@ public class DownloadController extends BasePortalController {
             ZipOutputStream zout = new ZipOutputStream(response.getOutputStream());
             //VT: threadpool is closed within downloadAll();
             ArrayList<DownloadResponse> gmlDownloads = downloadManager.downloadAll();
-            FileIOUtil.writeResponseToZip(gmlDownloads, zout,outputFormat);
+            FileIOUtil.writeResponseToZip(gmlDownloads, zout,outputFormat, MINIMUM_NUMBER_OF_LINES);
             zout.finish();
             zout.flush();
             zout.close();
@@ -193,7 +196,7 @@ public class DownloadController extends BasePortalController {
             ZipOutputStream zout = new ZipOutputStream(response.getOutputStream());
             //VT: threadpool is closed within downloadAll();
             ArrayList<DownloadResponse> gmlDownloads = downloadManager.downloadAll();
-            FileIOUtil.writeResponseToZip(gmlDownloads, zout);
+            FileIOUtil.writeResponseToZip(gmlDownloads, zout, MINIMUM_NUMBER_OF_LINES);
             zout.finish();
             zout.flush();
             zout.close();

--- a/src/main/java/org/auscope/portal/core/server/http/download/DownloadTracker.java
+++ b/src/main/java/org/auscope/portal/core/server/http/download/DownloadTracker.java
@@ -27,6 +27,8 @@ import org.auscope.portal.core.util.FileIOUtil;
  */
 public class DownloadTracker {
     protected final Log logger = LogFactory.getLog(getClass());
+    // Minimum number of lines we expect a download to be (header file plus at least one data row)
+    private final static Integer MINIMUM_NUMBER_OF_LINES = 2;
     private String email;
     public String getEmail() {
         return email;
@@ -238,7 +240,7 @@ public class DownloadTracker {
             try (FileOutputStream fos = new FileOutputStream(file);
                  ZipOutputStream zout = new ZipOutputStream(fos)) {
                 ArrayList<DownloadResponse> gmlDownloads = sdm.downloadAll();
-                FileIOUtil.writeResponseToZip(gmlDownloads, zout, this.extensionOverride);
+                FileIOUtil.writeResponseToZip(gmlDownloads, zout, this.extensionOverride, MINIMUM_NUMBER_OF_LINES);
                 zout.finish();
                 zout.flush();
                 zout.close();

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestBasePortalController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestBasePortalController.java
@@ -25,7 +25,7 @@ import org.springframework.web.servlet.ModelAndView;
  *
  */
 public class TestBasePortalController extends PortalTestClass {
-
+	
     private class BasePortalControllerImpl extends BasePortalController {
         // empty
     }
@@ -136,7 +136,7 @@ public class TestBasePortalController extends PortalTestClass {
         ZipOutputStream zout = new ZipOutputStream(outputStream);
 
         //Write our data out
-        FileIOUtil.writeResponseToZip(Arrays.asList(dr1, dr2), zout, false);
+        FileIOUtil.writeResponseToZip(Arrays.asList(dr1, dr2), zout, false, null);
         zout.finish();
         zout.close();
         outputStream.close();

--- a/src/test/java/org/auscope/portal/core/server/controllers/TestDownloadController.java
+++ b/src/test/java/org/auscope/portal/core/server/controllers/TestDownloadController.java
@@ -76,14 +76,16 @@ public class TestDownloadController extends PortalTestClass {
     }
 
     /**
-     * Test that this function makes all of the approriate calls, and see if it returns gml given some dummy data
+     * Test that this function makes all of the appropriate calls, and see if it returns gml given some dummy data
      */
     @Test
     public void testDownloadGMLAsZip() throws Exception {
         final String[] serviceUrls = {"http://localhost:8088/AuScope-Portal/doBoreholeFilter.do?&serviceUrl=http://nvclwebservices.vm.csiro.au:80/geoserverBH/wfs"};
         final String outputFormat = "gml";
-        final String dummyGml = "<someGmlHere/>";
-        final String dummyJSONResponse = "{\"data\":{\"gml\":\"" + dummyGml + "\"},\"success\":true}";
+        // We need to pass in dummy GML with an escaped newline to parse as JSON, but return value won't be escaped  
+        final String dummyGmlWithEscapedLineBreak = "<someGmlHere/>\\n<someMoreGmlHere/>";
+        final String dummyGmlReturned = "<someGmlHere/>\n<someMoreGmlHere/>";
+        final String dummyJSONResponse = "{\"data\":{\"gml\":\"" + dummyGmlWithEscapedLineBreak + "\"},\"success\":true}";
         final MyServletOutputStream servletOutputStream = new MyServletOutputStream(dummyJSONResponse.length());
         final InputStream dummyJSONResponseIS = new ByteArrayInputStream(dummyJSONResponse.getBytes());
 
@@ -116,18 +118,19 @@ public class TestDownloadController extends PortalTestClass {
         Assert.assertNotNull(ze);
         Assert.assertTrue(ze.getName().endsWith(".xml"));
 
-        byte[] uncompressedData = new byte[dummyGml.getBytes().length];
+        byte[] uncompressedData = new byte[dummyGmlReturned.getBytes().length];
         int dataRead = in.read(uncompressedData);
 
-        Assert.assertEquals(dummyGml.getBytes().length, dataRead);
-        Assert.assertArrayEquals(dummyGml.getBytes(), uncompressedData);
+        // 
+        Assert.assertEquals(dummyGmlReturned.getBytes().length, dataRead);
+        Assert.assertArrayEquals(dummyGmlReturned.getBytes(), uncompressedData);
 
         in.close();
 
     }
 
     /**
-     * Test that this function makes all of the approriate calls, and see if it returns gml given some dummy data
+     * Test that this function makes all of the appropriate calls, and see if it returns gml given some dummy data
      *
      * This dummy data is missing the data element but contains a msg property (This added in response to JIRA AUS-1575)
      */
@@ -201,7 +204,7 @@ public class TestDownloadController extends PortalTestClass {
         final String[] serviceUrls = {
                 "http://localhost:8088/AuScope-Portal/doBoreholeFilter.do?&serviceUrl=http://nvclwebservices.vm.csiro.au:80/geoserverBH/wfs",
                 "http://localhost:8088/AuScope-Portal/doBoreholeFilter.do?&serviceUrl=http://www.mrt.tas.gov.au:80/web-services/wfs"};
-        final String dummyGml = "<someGmlHere/>";
+        final String dummyGml = "<someGmlHere/>\\n<someMoreGmlHere/>";
         final String dummyJSONResponse = "{\"data\":{\"gml\":\""
                 + dummyGml + "\"},\"success\":true}";
         final MyServletOutputStream servletOutputStream = new MyServletOutputStream(dummyJSONResponse.length());


### PR DESCRIPTION
Exclude creating CSV files for services that do not intersect the specified download bounds by only writing files that contain a minimum of 2 lines (header plus at least one data row).